### PR TITLE
PPR API adjust the default recycle connections timeout: still connect…

### DIFF
--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -95,13 +95,13 @@ class _Config():  # pylint: disable=too-few-public-methods
     DB_MIN_POOL_SIZE = os.getenv('DATABASE_MIN_POOL_SIZE', '5')
     DB_MAX_POOL_SIZE = os.getenv('DATABASE_MAX_POOL_SIZE', '5')
     DB_CONN_WAIT_TIMEOUT = os.getenv('DATABASE_CONN_WAIT_TIMEOUT', '5')
-    DB_CONN_TIMEOUT = os.getenv('DATABASE_CONN_TIMEOUT', '3600')
+    DB_CONN_TIMEOUT = os.getenv('DATABASE_CONN_TIMEOUT', '900')
 
     SQLALCHEMY_ENGINE_OPTIONS = {
         'pool_pre_ping': True,
         'pool_size': int(DB_MIN_POOL_SIZE),
         'max_overflow': (int(DB_MAX_POOL_SIZE) - int(DB_MIN_POOL_SIZE)),
-        # 'pool_recycle': int(DB_CONN_TIMEOUT),
+        'pool_recycle': int(DB_CONN_TIMEOUT),
         'pool_timeout': int(DB_CONN_WAIT_TIMEOUT)
     }
 


### PR DESCRIPTION
…ion lost contact and end-of-file on communication channel errors.

Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity###

*PPR API adjust the default recycle connections timeout: still connection lost contact and end-of-file on communication channel errors.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
