### PR TITLE
PPR API Use service account token for payment refunds

### DIFF
--- a/oracle-db/scripts/create_views_ddl.sql
+++ b/oracle-db/scripts/create_views_ddl.sql
@@ -9,7 +9,7 @@ SELECT r.registration_type_cd,
   FROM registration r, financing_statement fs, registration r2
  WHERE r2.financing_id = r.financing_id
    AND r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -37,7 +37,7 @@ SELECT r.registration_type_cd,
        sc.srch_vin
   FROM registration r, financing_statement fs, serial_collateral sc
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -67,7 +67,7 @@ SELECT r.registration_type_cd,
        sc.srch_vin
   FROM registration r, financing_statement fs, serial_collateral sc
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -96,7 +96,7 @@ SELECT r.registration_type_cd,
        sc.srch_vin
   FROM registration r, financing_statement fs, serial_collateral sc
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id

--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -99,7 +99,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_ENGINE_OPTIONS = {
         'pool_pre_ping': True,
-        'echo_pool': 'debug',
+        # 'echo_pool': 'debug',
         'pool_size': int(DB_MIN_POOL_SIZE),
         'max_overflow': (int(DB_MAX_POOL_SIZE) - int(DB_MIN_POOL_SIZE)),
         'pool_recycle': int(DB_CONN_TIMEOUT),
@@ -134,6 +134,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     JWT_OIDC_AUDIENCE = os.getenv('JWT_OIDC_AUDIENCE')
     JWT_OIDC_CLIENT_SECRET = os.getenv('JWT_OIDC_CLIENT_SECRET')
     JWT_OIDC_CACHING_ENABLED = os.getenv('JWT_OIDC_CACHING_ENABLED')
+    JWT_OIDC_TOKEN_URL = os.getenv('JWT_OIDC_TOKEN_URL')
     try:
         JWT_OIDC_JWKS_CACHE_TIMEOUT = int(os.getenv('JWT_OIDC_JWKS_CACHE_TIMEOUT'))
         if not JWT_OIDC_JWKS_CACHE_TIMEOUT:
@@ -150,12 +151,9 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     # service accounts
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL')
-    ACCOUNT_SVC_ENTITY_URL = os.getenv('ACCOUNT_SVC_ENTITY_URL')
-    ACCOUNT_SVC_AFFILIATE_URL = os.getenv('ACCOUNT_SVC_AFFILIATE_URL')
     ACCOUNT_SVC_CLIENT_ID = os.getenv('ACCOUNT_SVC_CLIENT_ID')
     ACCOUNT_SVC_CLIENT_SECRET = os.getenv('ACCOUNT_SVC_CLIENT_SECRET')
-    ACCOUNT_SVC_TIMEOUT = os.getenv('ACCOUNT_SVC_TIMEOUT')
-
+    # ACCOUNT_SVC_TIMEOUT = os.g
     TESTING = False
     DEBUG = False
 

--- a/ppr-api/src/ppr_api/models/financing_statement.py
+++ b/ppr-api/src/ppr_api/models/financing_statement.py
@@ -292,7 +292,7 @@ class FinancingStatement(db.Model):  # pylint: disable=too-many-instance-attribu
                                                   FinancingStatement.state_type_cd).\
                                 filter(FinancingStatement.financing_id == Registration.financing_id,
                                        Registration.account_id == account_id,
-                                       Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN'])).\
+                                       Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN', 'CROWNLIEN'])).\
                                 order_by(FinancingStatement.financing_id).all()
             else:
                 days_ago = model_utils.now_ts_offset(10, False)
@@ -302,7 +302,7 @@ class FinancingStatement(db.Model):  # pylint: disable=too-many-instance-attribu
                                                   FinancingStatement.state_type_cd).\
                                 filter(FinancingStatement.financing_id == Registration.financing_id,
                                        Registration.account_id == account_id,
-                                       Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN']),
+                                       Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN', 'CROWNLIEN']),
                                        Registration.registration_ts > days_ago).\
                                 order_by(FinancingStatement.financing_id).all()
 
@@ -356,7 +356,8 @@ class FinancingStatement(db.Model):  # pylint: disable=too-many-instance-attribu
             statement = db.session.query(FinancingStatement).\
                         filter(FinancingStatement.financing_id == Registration.financing_id,
                                Registration.registration_num == registration_num,
-                               Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN'])).one_or_none()
+                               Registration.registration_type_cl.in_(['PPSALIEN', 'MISCLIEN', 'CROWNLIEN'])).\
+                               one_or_none()
 
         if not statement:
             raise BusinessException(

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -41,7 +41,7 @@ SELECT r.registration_type_cd,r.registration_ts AS base_registration_ts,
         fs.expire_date,fs.state_type_cd,sc.serial_id AS vehicle_id, sc.mhr_number
   FROM registration r, financing_statement fs, serial_collateral sc 
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id 
@@ -61,7 +61,7 @@ SELECT r.registration_type_cd,r.registration_ts AS base_registration_ts,
   FROM registration r, financing_statement fs, registration r2
  WHERE r2.financing_id = r.financing_id
    AND r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -98,7 +98,7 @@ SELECT r.registration_type_cd,r.registration_ts AS base_registration_ts,
        fs.expire_date,fs.state_type_cd,p.party_id
   FROM registration r, financing_statement fs, party p
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -126,7 +126,7 @@ SELECT r.registration_type_cd,r.registration_ts AS base_registration_ts,
        fs.expire_date,fs.state_type_cd
   FROM registration r, financing_statement fs, party p
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -146,7 +146,7 @@ BUSINESS_NAME_TOTAL_COUNT = """
 SELECT COUNT(r.registration_id)
   FROM registration r, financing_statement fs, party p
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -168,7 +168,7 @@ INDIVIDUAL_NAME_TOTAL_COUNT = """
 SELECT COUNT(r.registration_id)
   FROM registration r, financing_statement fs, party p
  WHERE r.financing_id = fs.financing_id
-   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
    AND r.base_reg_number IS NULL
    AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
    AND NOT EXISTS (SELECT r3.registration_id
@@ -186,7 +186,7 @@ SERIAL_SEARCH_COUNT_BASE = """
 SELECT COUNT(r.registration_id)
   FROM registration r, financing_statement fs, serial_collateral sc
   WHERE r.financing_id = fs.financing_id
-    AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN')
+    AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
     AND r.base_reg_number IS NULL
     AND (fs.expire_date IS NULL OR fs.expire_date > ((SYSTIMESTAMP AT TIME ZONE 'UTC') - 30))
     AND NOT EXISTS (SELECT r3.registration_id

--- a/ppr-api/src/ppr_api/resources/drafts.py
+++ b/ppr-api/src/ppr_api/resources/drafts.py
@@ -19,7 +19,6 @@ from http import HTTPStatus
 
 from flask import request, jsonify
 from flask_restx import Namespace, Resource, cors
-from registry_schemas import utils as schema_utils
 
 from ppr_api.utils.auth import jwt
 from ppr_api.utils.util import cors_preflight
@@ -27,9 +26,8 @@ from ppr_api.exceptions import BusinessException
 from ppr_api.services.authz import is_staff, authorized
 from ppr_api.models import Draft
 
-from .utils import get_account_id, account_required_response, validation_error_response, \
-                   business_exception_response, default_exception_response
-from .utils import unauthorized_error_response, path_param_error_response
+from .utils import get_account_id, account_required_response, business_exception_response, \
+                   default_exception_response, unauthorized_error_response, path_param_error_response
 
 
 API = Namespace('drafts', description='Endpoints for maintaining draft statements.')
@@ -85,10 +83,10 @@ class DraftResource(Resource):
                 return unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)
-            # Validate schema.
-            valid_format, errors = schema_utils.validate(request_json, 'draft', 'ppr')
-            if not valid_format:
-                return validation_error_response(errors, VAL_ERROR)
+            # Disable schema validation: draft may be partial/incomplele.
+            # valid_format, errors = schema_utils.validate(request_json, 'draft', 'ppr')
+            # if not valid_format:
+            #   return validation_error_response(errors, VAL_ERROR)
 
             # Save new draft statement: BusinessException raised if failure.
             draft = Draft.create_from_json(request_json, account_id)
@@ -154,10 +152,10 @@ class MaintainDraftResource(Resource):
                 return unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)
-            # Validate schema.
-            valid_format, errors = schema_utils.validate(request_json, 'draft', 'ppr')
-            if not valid_format:
-                return validation_error_response(errors, VAL_ERROR)
+            # Disable schema validation: draft may be partial/incomplele.
+            # valid_format, errors = schema_utils.validate(request_json, 'draft', 'ppr')
+            # if not valid_format:
+            #   return validation_error_response(errors, VAL_ERROR)
 
             # Save draft statement update: BusinessException raised if failure.
             draft = Draft.update(request_json, document_id)

--- a/ppr-api/tests/unit/api/test_drafts.py
+++ b/ppr-api/tests/unit/api/test_drafts.py
@@ -32,8 +32,8 @@ SAMPLE_JSON_CHANGE = copy.deepcopy(DRAFT_CHANGE_STATEMENT)
 SAMPLE_JSON_AMENDMENT = copy.deepcopy(DRAFT_AMENDMENT_STATEMENT)
 
 
-def test_draft_create_invalid_type_400(session, client, jwt):
-    """Assert that create draft  with an invalid type returns a 400 error."""
+def test_draft_create_invalid_type(session, client, jwt):
+    """Assert that create draft  with an invalid type returns a 404 error."""
     # setup
     json_data = copy.deepcopy(SAMPLE_JSON_FINANCING)
     json_data['type'] = 'INVALID_TYPE'
@@ -44,7 +44,7 @@ def test_draft_create_invalid_type_400(session, client, jwt):
                      headers=create_header_account(jwt, [PPR_ROLE]),
                      content_type='application/json')
     # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 def test_draft_create_valid_financing_201(session, client, jwt):
@@ -146,8 +146,8 @@ def test_draft_invalid_get_statement_404(session, client, jwt):
     assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_draft_update_invalid_type_400(session, client, jwt):
-    """Assert that an update draft financing statement request with an invalid type returns a 400 error."""
+def test_draft_update_invalid_type_404(session, client, jwt):
+    """Assert that an update draft financing statement request with an invalid type returns a 404."""
     # setup
     json_data = copy.deepcopy(SAMPLE_JSON_FINANCING)
     json_data['financingStatement']['type'] = 'XA'
@@ -158,7 +158,7 @@ def test_draft_update_invalid_type_400(session, client, jwt):
                     headers=create_header_account(jwt, [PPR_ROLE]),
                     content_type='application/json')
     # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
+    assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_draft_update_valid_financing_200(session, client, jwt):

--- a/ppr-api/tests/unit/services/test_payment.py
+++ b/ppr-api/tests/unit/services/test_payment.py
@@ -178,3 +178,17 @@ def test_payment_apikey(client, jwt):
         assert pay_data
         assert pay_data['invoiceId']
         assert pay_data['receipt']
+
+
+def test_sa_get_token(client, jwt):
+    """Assert that an OIDC get token request with valid SA credentials works as expected."""
+    # setup
+    token = helper_create_jwt(jwt, [PPR_ROLE])
+    pay_client = SBCPaymentClient(jwt=token, account_id='PS12345')
+
+    # test
+    jwt = pay_client.get_sa_token()
+
+    # check
+    assert jwt
+    assert len(jwt) > 0


### PR DESCRIPTION

Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#7340

*Description of changes:*
7340 pay-api refund use service account token to submit refund requests
Disable schema validation for drafts to allow incomplete saves.
Turn off debug db connection logging.
Include CROWNLIEN registration class in financing statement queries.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
