### PR TITLE
API create registration improve address, party code validation.

### DIFF
--- a/ppr-api/migrations/versions/ca3675d682cc_initial_migration.py
+++ b/ppr-api/migrations/versions/ca3675d682cc_initial_migration.py
@@ -437,19 +437,19 @@ def upgrade():
       LANGUAGE plpgsql
       AS
       $$
-      -- Debtor individual name matching comparison is between party.last_name_key and a key generated from lastname, and
-      -- between party.first_name_key and a key generated from the firstname parameter.
-      -- For matching, a last name key may have 2 names separated by a space character.
-      -- For matching, a first name key may have 3 names separated by a space character.
-      -- In all cases, first name matching is a cartesian cross product on either exact name or nickname.
-      -- Cases from Oracle PL/SQL:
-      -- 1. Match last name by keys on algorithm and first name by either algorithm, name, or nickname.
-      -- 2. Match last name by exact match on party.last_name_key second name and lastname first name; first name by either name or nickname.  
-      -- 3. Match last name by exact match on party.last_name_key first name and lastname second name; first name by either name or nickname.  
-      -- 4. Match last name by exact match on party.last_name_key second name and lastname second name; first name by either name or nickname.
-      -- As any of 2, 3 and 4 is a hit they are collapsed to the same condition below.
-      -- Performance should improve if split names are stored as separate columns in the party table and indexed or stored in a separate table.
-      DECLARE
+        -- Debtor individual name matching comparison is between party.last_name_key and a key generated from lastname, and
+        -- between party.first_name_key and a key generated from the firstname parameter.
+        -- For matching, a last name key may have 2 names separated by a space character.
+        -- For matching, a first name key may have 3 names separated by a space character.
+        -- In all cases, first name matching is a cartesian cross product on either exact name or nickname.
+        -- Cases from Oracle PL/SQL:
+        -- 1. Match last name by keys on algorithm and first name by either algorithm, name, or nickname.
+        -- 2. Match last name by exact match on party.last_name_key second name and lastname first name; first name by either name or nickname.  
+        -- 3. Match last name by exact match on party.last_name_key first name and lastname second name; first name by either name or nickname.  
+        -- 4. Match last name by exact match on party.last_name_key second name and lastname second name; first name by either name or nickname.
+        -- As any of 2, 3 and 4 is a hit they are collapsed to the same condition below.
+        -- Performance should improve if split names are stored as separate columns in the party table and indexed or stored in a separate table.
+        DECLARE
           v_ids  integer ARRAY;
           v_lastname_key VARCHAR(50);
           v_last1 VARCHAR(50);
@@ -458,7 +458,7 @@ def upgrade():
           v_first1 VARCHAR(50);
           v_first2 VARCHAR(50);
           v_first3 VARCHAR(50);
-      BEGIN
+        BEGIN
           v_lastname_key := searchkey_last_name(lastname);
           v_last1 = split_part(v_lastname_key, ' ', 1);
           v_last2 = split_part(v_lastname_key, ' ', 2);  -- May be null
@@ -466,24 +466,37 @@ def upgrade():
           v_first1 = split_part(v_firstname_key, ' ', 1);
           v_first2 = split_part(v_firstname_key, ' ', 2);  -- May be null
           v_first3 = split_part(v_firstname_key, ' ', 3);  -- May be null
+
+          IF (LENGTH(v_last2) < 1) THEN
+            v_last2 := null;
+          END IF;
+          IF (LENGTH(v_first2) < 1) THEN
+            v_first2 := null;
+          END IF;
+          IF (LENGTH(v_first3) < 1) THEN
+            v_first3 := null;
+          END IF;
           
           -- Replace where clause: Oracle uses UTL_MATCH.JARO_WINKLER_SIMILARITY
           SELECT array_agg(id)
-          INTO v_ids
-          FROM parties p
+            INTO v_ids
+            FROM parties p
           WHERE registration_id_end IS NULL AND
-              party_type = 'DI' AND
-              ((levenshtein(p.last_name_key, v_lastname_key) <= 2 AND 
+                party_type = 'DI' AND
+                (
+                  (levenshtein(p.last_name_key, v_lastname_key) <= 2 AND 
                   (levenshtein(p.first_name_key, v_firstname_key) <= 2 OR
-                  searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
-                  searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)) OR
-              -- This looks like a full party table scan
-              (searchkey_name_match(p.last_name_key, v_last1, v_last2, null) > 0 AND 
+                    searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
+                    searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)
+                  ) OR
+                  -- This looks like a full parties table scan: commenting out reduces the query by about 3 seconds.
+                  (searchkey_name_match(p.last_name_key, v_last1, v_last2, null) > 0 AND 
                   (searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
-                  searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)));
-
+                    searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)
+                  )
+                );
           RETURN v_ids;
-      END
+        END
       ; 
       $$;
       """
@@ -5266,19 +5279,19 @@ def downgrade():
       LANGUAGE plpgsql
       AS
       $$
-      -- Debtor individual name matching comparison is between party.last_name_key and a key generated from lastname, and
-      -- between party.first_name_key and a key generated from the firstname parameter.
-      -- For matching, a last name key may have 2 names separated by a space character.
-      -- For matching, a first name key may have 3 names separated by a space character.
-      -- In all cases, first name matching is a cartesian cross product on either exact name or nickname.
-      -- Cases from Oracle PL/SQL:
-      -- 1. Match last name by keys on algorithm and first name by either algorithm, name, or nickname.
-      -- 2. Match last name by exact match on party.last_name_key second name and lastname first name; first name by either name or nickname.  
-      -- 3. Match last name by exact match on party.last_name_key first name and lastname second name; first name by either name or nickname.  
-      -- 4. Match last name by exact match on party.last_name_key second name and lastname second name; first name by either name or nickname.
-      -- As any of 2, 3 and 4 is a hit they are collapsed to the same condition below.
-      -- Performance should improve if split names are stored as separate columns in the party table and indexed or stored in a separate table.
-      DECLARE
+        -- Debtor individual name matching comparison is between party.last_name_key and a key generated from lastname, and
+        -- between party.first_name_key and a key generated from the firstname parameter.
+        -- For matching, a last name key may have 2 names separated by a space character.
+        -- For matching, a first name key may have 3 names separated by a space character.
+        -- In all cases, first name matching is a cartesian cross product on either exact name or nickname.
+        -- Cases from Oracle PL/SQL:
+        -- 1. Match last name by keys on algorithm and first name by either algorithm, name, or nickname.
+        -- 2. Match last name by exact match on party.last_name_key second name and lastname first name; first name by either name or nickname.  
+        -- 3. Match last name by exact match on party.last_name_key first name and lastname second name; first name by either name or nickname.  
+        -- 4. Match last name by exact match on party.last_name_key second name and lastname second name; first name by either name or nickname.
+        -- As any of 2, 3 and 4 is a hit they are collapsed to the same condition below.
+        -- Performance should improve if split names are stored as separate columns in the party table and indexed or stored in a separate table.
+        DECLARE
           v_ids  integer ARRAY;
           v_lastname_key VARCHAR(50);
           v_last1 VARCHAR(50);
@@ -5287,7 +5300,7 @@ def downgrade():
           v_first1 VARCHAR(50);
           v_first2 VARCHAR(50);
           v_first3 VARCHAR(50);
-      BEGIN
+        BEGIN
           v_lastname_key := searchkey_last_name(lastname);
           v_last1 = split_part(v_lastname_key, ' ', 1);
           v_last2 = split_part(v_lastname_key, ' ', 2);  -- May be null
@@ -5295,24 +5308,37 @@ def downgrade():
           v_first1 = split_part(v_firstname_key, ' ', 1);
           v_first2 = split_part(v_firstname_key, ' ', 2);  -- May be null
           v_first3 = split_part(v_firstname_key, ' ', 3);  -- May be null
+
+          IF (LENGTH(v_last2) < 1) THEN
+            v_last2 := null;
+          END IF;
+          IF (LENGTH(v_first2) < 1) THEN
+            v_first2 := null;
+          END IF;
+          IF (LENGTH(v_first3) < 1) THEN
+            v_first3 := null;
+          END IF;
           
           -- Replace where clause: Oracle uses UTL_MATCH.JARO_WINKLER_SIMILARITY
           SELECT array_agg(id)
-          INTO v_ids
-          FROM parties p
+            INTO v_ids
+            FROM parties p
           WHERE registration_id_end IS NULL AND
-              party_type = 'DI' AND
-              ((levenshtein(p.last_name_key, v_lastname_key) <= 2 AND 
+                party_type = 'DI' AND
+                (
+                  (levenshtein(p.last_name_key, v_lastname_key) <= 2 AND 
                   (levenshtein(p.first_name_key, v_firstname_key) <= 2 OR
-                  searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
-                  searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)) OR
-              -- This looks like a full party table scan
-              (searchkey_name_match(p.last_name_key, v_last1, v_last2, null) > 0 AND 
+                    searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
+                    searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)
+                  ) OR
+                  -- This looks like a full parties table scan: commenting out reduces the query by about 3 seconds.
+                  (searchkey_name_match(p.last_name_key, v_last1, v_last2, null) > 0 AND 
                   (searchkey_name_match(p.first_name_key, v_first1, v_first2, v_first3) > 0 OR
-                  searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)));
-
+                    searchkey_nickname_match(p.first_name_key, v_first1, v_first2, v_first3) > 0)
+                  )
+                );
           RETURN v_ids;
-      END
+        END
       ; 
       $$;
       """

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -57,9 +57,9 @@ STATE_ACTIVE = 'ACT'
 STATE_EXPIRED = 'HEX'
 
 # Financing statement, registraiton constants
-LIFE_INFINITE = -99
+LIFE_INFINITE = 99
 REPAIRER_LIEN_DAYS = 180
-REPAIRER_LIEN_YEARS = 1
+REPAIRER_LIEN_YEARS = 0
 
 # Mapping from API draft type to DB registration class
 DRAFT_TYPE_TO_REG_CLASS = {

--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -31,6 +31,7 @@ from ppr_api.services.payment.exceptions import SBCPaymentException
 from ppr_api.services.payment.payment import Payment, TransactionTypes
 from ppr_api.utils.auth import jwt
 from ppr_api.utils.util import cors_preflight
+from ppr_api.utils.validators import party_validator, registration_validator
 
 
 API = Namespace('financing-statements', description='Endpoints for maintaining financing statements and updates.')
@@ -103,8 +104,9 @@ class FinancingResource(Resource):
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
             valid_format, errors = schema_utils.validate(request_json, 'financingStatement', 'ppr')
-            if not valid_format:
-                return resource_utils.validation_error_response(errors, VAL_ERROR)
+            extra_validation_msg = validate_financing(request_json)
+            if not valid_format or extra_validation_msg != '':
+                return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
 
             # Set up the financing statement registration, pay, and save the data.
             statement = pay_and_save_financing(request_json, account_id)
@@ -192,8 +194,9 @@ class AmendmentResource(Resource):
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
             valid_format, errors = schema_utils.validate(request_json, 'amendmentStatement', 'ppr')
-            if not valid_format:
-                return resource_utils.validation_error_response(errors, VAL_ERROR_AMEND)
+            extra_validation_msg = validate_registration(request_json)
+            if not valid_format or extra_validation_msg != '':
+                return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
 
             # payload base registration number must match path registration number
             if registration_num != request_json['baseRegistrationNumber']:
@@ -208,6 +211,9 @@ class AmendmentResource(Resource):
             # Verify base debtor (bypassed for staff)
             if not statement.validate_base_debtor(request_json['baseDebtor'], is_staff(jwt)):
                 return resource_utils.base_debtor_invalid_response()
+
+            # Verify delete party and collateral ID's
+            validate_delete_ids(request_json, statement)
 
             # Set up the registration, pay, and save the data.
             registration = pay_and_save(request_json,
@@ -260,8 +266,9 @@ class ChangeResource(Resource):
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
             valid_format, errors = schema_utils.validate(request_json, 'changeStatement', 'ppr')
-            if not valid_format:
-                return resource_utils.validation_error_response(errors, VAL_ERROR_CHANGE)
+            extra_validation_msg = validate_registration(request_json)
+            if not valid_format or extra_validation_msg != '':
+                return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
 
             # payload base registration number must match path registration number
             if registration_num != request_json['baseRegistrationNumber']:
@@ -276,6 +283,9 @@ class ChangeResource(Resource):
             # Verify base debtor (bypassed for staff)
             if not statement.validate_base_debtor(request_json['baseDebtor'], is_staff(jwt)):
                 return resource_utils.base_debtor_invalid_response()
+
+            # Verify delete party and collateral ID's
+            validate_delete_ids(request_json, statement)
 
             # Set up the registration, pay, and save the data.
             registration = pay_and_save(request_json,
@@ -325,8 +335,9 @@ class RenewalResource(Resource):
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
             valid_format, errors = schema_utils.validate(request_json, 'renewalStatement', 'ppr')
-            if not valid_format:
-                return resource_utils.validation_error_response(errors, VAL_ERROR_RENEWAL)
+            extra_validation_msg = validate_financing(request_json)
+            if not valid_format or extra_validation_msg != '':
+                return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
 
             # payload base registration number must match path registration number
             if registration_num != request_json['baseRegistrationNumber']:
@@ -390,8 +401,9 @@ class DischargeResource(Resource):
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
             valid_format, errors = schema_utils.validate(request_json, 'dischargeStatement', 'ppr')
-            if not valid_format:
-                return resource_utils.validation_error_response(errors, VAL_ERROR_DISCHARGE)
+            extra_validation_msg = validate_financing(request_json)
+            if not valid_format or extra_validation_msg != '':
+                return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
 
             # payload base registration number must match path registration number
             if registration_num != request_json['baseRegistrationNumber']:
@@ -530,3 +542,29 @@ def get_payment_details(registration):
         'value': registration.base_registration_num
     }
     return details
+
+
+def validate_financing(json_data):
+    """Perform non-schema extra validation on a financing statement."""
+    error_msg = party_validator.validate_financing_parties(json_data)
+
+    return error_msg
+
+
+def validate_registration(json_data):
+    """Perform non-schema extra validation on a non-financing registrations."""
+    error_msg = party_validator.validate_registration_parties(json_data)
+    error_msg += registration_validator.validate_collateral_ids(json_data)
+
+    return error_msg
+
+
+def validate_delete_ids(json_data, financing_statement):
+    """Perform non-schema extra validation on a change amendment delete party, collateral ID's."""
+    error_msg = party_validator.validate_party_ids(json_data, financing_statement)
+    error_msg += registration_validator.validate_collateral_ids(json_data, financing_statement)
+    if error_msg != '':
+        raise BusinessException(
+            error=error_msg,
+            status_code=HTTPStatus.BAD_REQUEST
+        )

--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -24,8 +24,9 @@ ACCOUNT_REQUIRED = 'Account-Id header required.'
 def serialize(errors):
     """Serialize errors."""
     error_message = []
-    for error in errors:
-        error_message.append('Schema validation: ' + error.message + '.')
+    if errors:
+        for error in errors:
+            error_message.append('Schema validation: ' + error.message + '.')
     return error_message
 
 
@@ -50,10 +51,12 @@ def account_required_response():
     return jsonify({'message': ACCOUNT_REQUIRED}), HTTPStatus.BAD_REQUEST
 
 
-def validation_error_response(errors, cause):
+def validation_error_response(errors, cause, additional_msg: str = None):
     """Build a schema validation error response."""
-    return jsonify({'message': cause, 'detail': serialize(errors)}), HTTPStatus.BAD_REQUEST
-#    return {'cause': cause, 'message': schema_utils.serialize(errors)}, HTTPStatus.BAD_REQUEST
+    details = serialize(errors)
+    if additional_msg:
+        details.append('Additional validation: ' + additional_msg)
+    return jsonify({'message': cause, 'detail': details}), HTTPStatus.BAD_REQUEST
 
 
 def business_exception_response(exception):

--- a/ppr-api/src/ppr_api/utils/validators/__init__.py
+++ b/ppr-api/src/ppr_api/utils/validators/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds request non-schema data validation functions and helpers."""

--- a/ppr-api/src/ppr_api/utils/validators/party_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/party_validator.py
@@ -1,0 +1,190 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds party validation for rules not covered by the schema.
+
+Validation includes verifying party codes and address region and country codes.
+"""
+import pycountry
+
+from ppr_api.models import Party
+from ppr_api.models import utils as model_utils
+
+
+REGISTERING_CODE_MSG = 'No registering party client party found for code {}. '
+SECURED_CODE_MSG = 'No secured party client party found for code {}. '
+DELETE_MISSING_ID_SECURED = 'Required partyId missing in delete Secured Parties. '
+DELETE_MISSING_ID_DEBTOR = 'Required partyId missing in delete Debtors. '
+INVALID_PARTY_ID_SECURED = 'Invalid partyId {} in delete Secured Parties. '
+INVALID_PARTY_ID_DEBTOR = 'Invalid partyId {} in delete Debtors. '
+INVALID_COUNTRY_REGISTERING = 'Registering Party country {} is invalid. '
+INVALID_REGION_REGISTERING = 'Registering Party region {} is invalid. '
+INVALID_COUNTRY_SECURED = 'Secured Party country {} is invalid. '
+INVALID_REGION_SECURED = 'Secured Party region {} is invalid. '
+INVALID_COUNTRY_DEBTOR = 'Debtor country {} is invalid. '
+INVALID_REGION_DEBTOR = 'Debtor region {} is invalid. '
+
+
+def validate_financing_parties(json_data):
+    """Verify party data for all parties in json_data representing a financing statement."""
+    error_msg = validate_party_codes(json_data)
+    error_msg += validate_party_addresses(json_data)
+    return error_msg
+
+
+def validate_registration_parties(json_data, financing_statement=None):
+    """Verify party data for all parties in json_data representing a registration."""
+    error_msg = validate_party_codes(json_data)
+    error_msg += validate_party_addresses(json_data)
+    error_msg += validate_party_ids(json_data, financing_statement)
+
+    return error_msg
+
+
+def validate_party_codes(json_data):
+    """Verify party codes exist in the database for all parties in json_data."""
+    error_msg = ''
+    code = None
+
+    if 'registeringParty' in json_data and 'code' in json_data['registeringParty']:
+        code = json_data['registeringParty']['code']
+        if not Party.verify_party_code(code):
+            error_msg += REGISTERING_CODE_MSG.format(code)
+
+    if 'securedParties' in json_data:
+        for party in json_data['securedParties']:
+            if 'code' in party:
+                code = party['code']
+                if not Party.verify_party_code(code):
+                    error_msg += SECURED_CODE_MSG.format(code)
+
+    if 'addSecuredParties' in json_data:
+        for party in json_data['addSecuredParties']:
+            if 'code' in party:
+                code = party['code']
+                if not Party.verify_party_code(code):
+                    error_msg += SECURED_CODE_MSG.format(code)
+
+    return error_msg
+
+
+def validate_party_addresses(json_data):
+    """Verify all party address country and region values in json_data."""
+    error_msg = ''
+
+    if 'registeringParty' in json_data and 'address' in json_data['registeringParty']:
+        error_msg += validate_address(json_data['registeringParty'],
+                                      INVALID_COUNTRY_REGISTERING,
+                                      INVALID_REGION_REGISTERING)
+
+    if 'securedParties' in json_data:
+        for party in json_data['securedParties']:
+            error_msg += validate_address(party,
+                                          INVALID_COUNTRY_SECURED,
+                                          INVALID_REGION_SECURED)
+
+    if 'addSecuredParties' in json_data:
+        for party in json_data['addSecuredParties']:
+            error_msg += validate_address(party,
+                                          INVALID_COUNTRY_SECURED,
+                                          INVALID_REGION_SECURED)
+
+    if 'debtors' in json_data:
+        for party in json_data['debtors']:
+            error_msg += validate_address(party,
+                                          INVALID_COUNTRY_DEBTOR,
+                                          INVALID_REGION_DEBTOR)
+
+    if 'addDebtors' in json_data:
+        for party in json_data['addDebtors']:
+            error_msg += validate_address(party,
+                                          INVALID_COUNTRY_DEBTOR,
+                                          INVALID_REGION_DEBTOR)
+
+    return error_msg
+
+
+def validate_address(json_party, country_message: str, region_message: str):
+    """Verify the address country and region values in json_address."""
+    if not json_party or 'address' not in json_party:
+        return ''
+
+    error_msg = ''
+    json_address = json_party['address']
+    if 'country' in json_address:
+        json_country = json_address['country'].strip().upper()
+        country = None
+        if len(json_country) == 2:
+            country = pycountry.countries.get(alpha_2=json_country)
+        elif len(json_country) == 3:
+            country = pycountry.countries.get(alpha_3=json_country)
+        else:
+            country = pycountry.countries.search_fuzzy(json_address['country'].strip())
+        if not country:
+            error_msg += country_message.format(json_address['country'])
+        if 'region' in json_address:  # Validate region.
+            region_code = None
+            if len(json_address['region'].strip()) == 2:
+                country_prefix = country.alpha_2 + '-' if country else 'CA-'
+                # test_code = country_prefix + json_address['region'].strip().upper()
+                region_code = pycountry.subdivisions.get(code=(country_prefix + json_address['region'].strip().upper()))
+            if not region_code:
+                error_msg += region_message.format(json_address['region'])
+
+    return error_msg
+
+
+def validate_party_ids(json_data, financing_statement=None):
+    """Verify party ID's. when removing secured parties and debtors."""
+    error_msg = ''
+
+    if 'deleteSecuredParties' in json_data:
+        for party in json_data['deleteSecuredParties']:
+            if 'partyId' not in party:
+                error_msg += DELETE_MISSING_ID_SECURED
+            elif financing_statement and financing_statement.parties:
+                existing = find_party_by_id(party['partyId'],
+                                            model_utils.PARTY_SECURED,
+                                            financing_statement.parties)
+                if not existing:
+                    error_msg += INVALID_PARTY_ID_SECURED.format(str(party['partyId']))
+
+    if 'deleteDebtors' in json_data:
+        for party in json_data['deleteDebtors']:
+            if 'partyId' not in party:
+                error_msg += DELETE_MISSING_ID_DEBTOR
+            elif financing_statement and financing_statement.parties:
+                existing = find_party_by_id(party['partyId'],
+                                            model_utils.PARTY_DEBTOR_BUS,
+                                            financing_statement.parties)
+                if not existing:
+                    error_msg += INVALID_PARTY_ID_DEBTOR.format(str(party['partyId']))
+
+    return error_msg
+
+
+def find_party_by_id(party_id: int, party_type: str, parties):
+    """Search existing list of party objects for a matching party id and type."""
+    party = None
+
+    if party_id and party_type and parties:
+        for eval_party in parties:
+            if eval_party.id == party_id and party_type == eval_party.party_type and \
+                    not eval_party.registration_id_end:
+                party = eval_party
+            elif eval_party.id == party_id and party_type == model_utils.PARTY_DEBTOR_BUS and \
+                    eval_party.party_type == model_utils.PARTY_DEBTOR_IND and \
+                    not eval_party.registration_id_end:
+                party = eval_party
+
+    return party

--- a/ppr-api/src/ppr_api/utils/validators/registration_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/registration_validator.py
@@ -1,0 +1,73 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds non-party registration validation for rules not covered by the schema.
+
+Validation includes verifying delete collateral ID's and timestamps.
+"""
+
+
+DELETE_MISSING_ID_VEHICLE = 'Required vehicleId missing in delete Vehicle Collateral.\n'
+DELETE_MISSING_ID_GENERAL = 'Required collateralId missing in delete General Collateral.\n'
+DELETE_INVALID_ID_VEHICLE = 'Invalid vehicleId {} in delete Vehicle Collateral.\n'
+DELETE_INVALID_ID_GENERAL = 'Invalid collateralId {} in delete General Collateral.\n'
+
+
+def validate_collateral_ids(json_data, financing_statement=None):
+    """Check amendment, change registration delete collateral ID's are valid."""
+    error_msg = ''
+    # Check delete vehicle ID's
+    if 'deleteVehicleCollateral' in json_data:
+        for collateral in json_data['deleteVehicleCollateral']:
+            if 'vehicleId' not in collateral:
+                error_msg += DELETE_MISSING_ID_VEHICLE
+            elif financing_statement:
+                collateral_id = collateral['vehicleId']
+                existing = find_vehicle_collateral_by_id(collateral_id, financing_statement.vehicle_collateral)
+                if not existing:
+                    error_msg += DELETE_INVALID_ID_VEHICLE.format(str(collateral_id))
+
+    # Check delete general collateral ID's
+    if 'deleteGeneralCollateral' in json_data:
+        for collateral in json_data['deleteGeneralCollateral']:
+            if 'collateralId' not in collateral:
+                error_msg += DELETE_MISSING_ID_GENERAL
+            elif financing_statement:
+                collateral_id = collateral['collateralId']
+                existing = find_general_collateral_by_id(collateral_id, financing_statement.general_collateral)
+                if not existing:
+                    error_msg += DELETE_INVALID_ID_GENERAL.format(str(collateral_id))
+
+    return error_msg
+
+
+def find_vehicle_collateral_by_id(vehicle_id: int, vehicle_collateral):
+    """Search existing list of vehicle_collateral objects for a matching vehicle id."""
+    collateral = None
+
+    if vehicle_id and vehicle_collateral:
+        for v_collateral in vehicle_collateral:
+            if v_collateral.id == vehicle_id and not v_collateral.registration_id_end:
+                collateral = v_collateral
+    return collateral
+
+
+def find_general_collateral_by_id(collateral_id: int, general_collateral):
+    """Search existing list of general_collateral objects for a matching collateral id."""
+    collateral = None
+
+    if collateral_id and general_collateral:
+        for g_collateral in general_collateral:
+            if g_collateral.id == collateral_id and not g_collateral.registration_id_end:
+                collateral = g_collateral
+    return collateral

--- a/ppr-api/tests/unit/api/test_amendment.py
+++ b/ppr-api/tests/unit/api/test_amendment.py
@@ -19,57 +19,262 @@ Test-Suite to ensure that the /financing-statement/registrationNum/amendments en
 import copy
 from http import HTTPStatus
 
+import pytest
 from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT, FINANCING_STATEMENT
 
-from ppr_api.services.authz import STAFF_ROLE, COLIN_ROLE, PPR_ROLE
-from tests.unit.services.utils import create_header_account, create_header
+from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE
+from tests.unit.services.utils import create_header, create_header_account
 
 
 # prep sample post amendment statement data
 SAMPLE_JSON = copy.deepcopy(AMENDMENT_STATEMENT)
+STATEMENT_VALID = {
+  'baseRegistrationNumber': 'TEST0001',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 2 DEBTOR'
+  },
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+INVALID_REG_NUM = {
+  'baseRegistrationNumber': 'TESTXXX1',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 2 DEBTOR'
+  },
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+MISSING_BASE_DEBTOR = {
+  'baseRegistrationNumber': 'TEST0001',
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+INVALID_BASE_DEBTOR = {
+  'baseRegistrationNumber': 'TEST0001',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 3 DEBTOR'
+  },
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+INVALID_HISTORICAL = {
+  'baseRegistrationNumber': 'TEST0003',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 2 DEBTOR'
+  },
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+INVALID_CODE = {
+  'baseRegistrationNumber': 'TEST0001',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 2 DEBTOR'
+  },
+  'registeringParty': {
+      'code': '300000000'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
+INVALID_ADDRESS = {
+  'baseRegistrationNumber': 'TEST0001',
+  'baseDebtor': {
+      'businessName': 'TEST BUS 2 DEBTOR'
+  },
+  'registeringParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'XX',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'description': 'Test amendment.',
+  'addSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ]
+}
 
 
-def test_amendment_invalid_type_400(session, client, jwt):
-    """Assert that create statement with an invalid type returns a 400 error."""
+# testdata pattern is ({description}, {test data}, {roles}, {status}, {has_account}, {reg_num})
+TEST_CREATE_DATA = [
+    ('Invalid registration number', INVALID_REG_NUM, [PPR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXXX1'),
+    ('Invalid missing base debtor', MISSING_BASE_DEBTOR, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid base debtor', INVALID_BASE_DEBTOR, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid historical', INVALID_HISTORICAL, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0003'),
+    ('Invalid party code extra validation', INVALID_CODE, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid party address extra validation', INVALID_ADDRESS, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Missing account', STATEMENT_VALID, [PPR_ROLE], HTTPStatus.BAD_REQUEST, False, 'TEST0001'),
+    ('Invalid role', STATEMENT_VALID, [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0001')
+]
+
+
+@pytest.mark.parametrize('desc,json_data,roles,status,has_account,reg_num', TEST_CREATE_DATA)
+def test_create_amendment(session, client, jwt, desc, json_data, roles, status, has_account, reg_num):
+    """Assert that a post amendment registration statement works as expected."""
+    headers = None
     # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['changeType'] = 'XX'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
 
     # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
+    response = client.post('/api/v1/financing-statements/' + reg_num + '/amendments',
+                           json=json_data,
+                           headers=headers,
+                           content_type='application/json')
+
     # check
-    print(rv.json)
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
+    # print('Response data:')
+    # print(response.json)
+    assert response.status_code == status
 
 
-def test_amendment_valid_co_201(session, client, jwt):
+def test_amendment_court_order_success(session, client, jwt):
     """Assert that a valid CO type amendment statement returns a 200 status."""
     # setup
-    statement = copy.deepcopy(FINANCING_STATEMENT)
-    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
-    statement['type'] = 'SA'
-    del statement['createDateTime']
-    del statement['baseRegistrationNumber']
-    del statement['payment']
-    del statement['lifeInfinite']
-    del statement['lienAmount']
-    del statement['surrenderDate']
-    del statement['documentId']
-
-    rv1 = client.post('/api/v1/financing-statements',
-                      json=statement,
-                      headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                      content_type='application/json')
+    rv1 = create_financing_test(session, client, jwt)
     assert rv1.status_code == HTTPStatus.CREATED
     assert rv1.json['baseRegistrationNumber']
     base_reg_num = rv1.json['baseRegistrationNumber']
@@ -105,24 +310,10 @@ def test_amendment_valid_co_201(session, client, jwt):
     assert rv.status_code == HTTPStatus.CREATED
 
 
-def test_amendment_valid_am_201(session, client, jwt):
+def test_amendment_success(session, client, jwt):
     """Assert that a valid AM type amendment statement returns a 200 status."""
     # setup
-    statement = copy.deepcopy(FINANCING_STATEMENT)
-    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
-    statement['type'] = 'SA'
-    del statement['createDateTime']
-    del statement['baseRegistrationNumber']
-    del statement['payment']
-    del statement['lifeInfinite']
-    del statement['lienAmount']
-    del statement['surrenderDate']
-    del statement['documentId']
-
-    rv1 = client.post('/api/v1/financing-statements',
-                      json=statement,
-                      headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                      content_type='application/json')
+    rv1 = create_financing_test(session, client, jwt)
     assert rv1.status_code == HTTPStatus.CREATED
     assert rv1.json['baseRegistrationNumber']
     base_reg_num = rv1.json['baseRegistrationNumber']
@@ -157,160 +348,20 @@ def test_amendment_valid_am_201(session, client, jwt):
     assert rv.status_code == HTTPStatus.CREATED
 
 
-def test_amendment_create_invalid_regnum_404(session, client, jwt):
-    """Assert that an amendment statement on an invalid registration number returns a 404 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['changeType'] = 'CO'
-    json_data['baseRegistrationNumber'] = 'X12345X'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
+def create_financing_test(session, client, jwt):
+    """Create a financing statement for testing."""
+    statement = copy.deepcopy(FINANCING_STATEMENT)
+    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
+    statement['type'] = 'SA'
+    del statement['createDateTime']
+    del statement['baseRegistrationNumber']
+    del statement['payment']
+    del statement['documentId']
+    del statement['lifeInfinite']
+    del statement['lienAmount']
+    del statement['surrenderDate']
 
-    # test
-    rv = client.post('/api/v1/financing-statements/X12345X/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.NOT_FOUND
-
-
-def test_amendment_nonstaff_missing_account_400(session, client, jwt):
-    """Assert that an amendment statement request with a non-staff jwt and no account ID returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['changeType'] = 'CO'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header(jwt, [COLIN_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_amendment_staff_missing_account_201(session, client, jwt):
-    """Assert that an amendment statement request with a staff jwt and no account ID returns a 200 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['changeType'] = 'CO'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-    del json_data['courtOrderInformation']
-    del json_data['removeTrustIndenture']
-    del json_data['addTrustIndenture']
-    del json_data['addSecuredParties']
-    del json_data['deleteSecuredParties']
-    del json_data['addDebtors']
-    del json_data['deleteDebtors']
-    del json_data['deleteGeneralCollateral']
-    del json_data['addGeneralCollateral']
-    del json_data['deleteVehicleCollateral']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.CREATED
-
-
-def test_amendment_nonstaff_unauthorized_404(session, client, jwt):
-    """Assert that an amendment statement request with a non-ppr role and account ID returns a 404 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['changeType'] = 'CO'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [COLIN_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.UNAUTHORIZED
-
-
-def test_amendment_invalid_missing_basedebtor_400(session, client, jwt):
-    """Assert that create statement with a missing base debtor returns a 400 error."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-    del json_data['baseDebtor']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_amendment_invalid_historical_400(session, client, jwt):
-    """Assert that an amendments statement on an already discharged registration returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0003'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0003/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_amendment_invalid_debtor_400(session, client, jwt):
-    """Assert that a amendment statement with an invalid base debtor name returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 3 DEBTOR'
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['payment']
-    del json_data['documentId']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/amendments',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
+    return client.post('/api/v1/financing-statements',
+                       json=statement,
+                       headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
+                       content_type='application/json')

--- a/ppr-api/tests/unit/api/test_renewal.py
+++ b/ppr-api/tests/unit/api/test_renewal.py
@@ -19,7 +19,8 @@ Test-Suite to ensure that the /financing-statement/registrationNum/renewals endp
 import copy
 from http import HTTPStatus
 
-from registry_schemas.example_data.ppr import FINANCING_STATEMENT, RENEWAL_STATEMENT
+import pytest
+from registry_schemas.example_data.ppr import FINANCING_STATEMENT
 
 from ppr_api.models import FinancingStatement, Registration
 from ppr_api.resources.financing_statements import get_payment_details
@@ -28,38 +29,200 @@ from tests.unit.services.utils import create_header, create_header_account
 
 
 # prep sample post renewal statement data
-SAMPLE_JSON = copy.deepcopy(RENEWAL_STATEMENT)
+STATEMENT_VALID = {
+    'baseRegistrationNumber': 'TEST0001',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 2 DEBTOR'
+    },
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+MISSING_BASE_DEBTOR = {
+    'baseRegistrationNumber': 'TEST0001',
+    'clientReferenceId': 'A-00000402',
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+INVALID_BASE_DEBTOR = {
+    'baseRegistrationNumber': 'TEST0001',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 3 DEBTOR'
+    },
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+INVALID_REG_NUM = {
+    'baseRegistrationNumber': 'TESTXXX1',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 2 DEBTOR'
+    },
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+INVALID_HISTORICAL = {
+    'baseRegistrationNumber': 'TEST0003',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 2 DEBTOR'
+    },
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+INVALID_CODE = {
+    'baseRegistrationNumber': 'TEST0001',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 2 DEBTOR'
+    },
+    'registeringParty': {
+        'code': '300000000'
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+INVALID_ADDRESS = {
+    'baseRegistrationNumber': 'TEST0001',
+    'clientReferenceId': 'A-00000402',
+    'baseDebtor': {
+        'businessName': 'TEST BUS 2 DEBTOR'
+    },
+    'registeringParty': {
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'XX',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        }
+    },
+    'expiryDate': '2025-02-21T23:59:59+00:00',
+    'payment': {
+        'receipt': '/pay/api/v1/payment-requests/2199700/receipts',
+        'invoiceId': '2199700'
+    }
+}
+
+# testdata pattern is ({description}, {test data}, {roles}, {status}, {has_account}, {reg_num})
+TEST_CREATE_DATA = [
+    ('Invalid registration number', INVALID_REG_NUM, [PPR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXXX1'),
+    ('Invalid missing base debtor', MISSING_BASE_DEBTOR, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid base debtor', INVALID_BASE_DEBTOR, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid historical', INVALID_HISTORICAL, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0003'),
+    ('Invalid party code extra validation', INVALID_CODE, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Invalid party address extra validation', INVALID_ADDRESS, [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0001'),
+    ('Missing account', STATEMENT_VALID, [PPR_ROLE], HTTPStatus.BAD_REQUEST, False, 'TEST0001'),
+    ('Invalid role', STATEMENT_VALID, [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0001')
+]
 
 
-def test_renewal_valid_201(session, client, jwt):
-    """Assert that a valid create statement returns a 200 status."""
+@pytest.mark.parametrize('desc,json_data,roles,status,has_account,reg_num', TEST_CREATE_DATA)
+def test_create_renewal(session, client, jwt, desc, json_data, roles, status, has_account, reg_num):
+    """Assert that a post renewal registration statement works as expected."""
+    headers = None
     # setup
-    statement = copy.deepcopy(FINANCING_STATEMENT)
-    statement['type'] = 'SA'
-    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
-    del statement['createDateTime']
-    del statement['baseRegistrationNumber']
-    del statement['payment']
-    del statement['documentId']
-    del statement['lifeInfinite']
-    del statement['lienAmount']
-    del statement['surrenderDate']
-    del statement['generalCollateral']
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
 
-    rv1 = client.post('/api/v1/financing-statements',
-                      json=statement,
-                      headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                      content_type='application/json')
+    # test
+    response = client.post('/api/v1/financing-statements/' + reg_num + '/renewals',
+                           json=json_data,
+                           headers=headers,
+                           content_type='application/json')
+
+    # check
+    assert response.status_code == status
+
+
+def test_renewal_sa_success(session, client, jwt):
+    """Assert that a valid create statement returns a 201 status."""
+    # setup
+    rv1 = create_financing_test(session, client, jwt, 'SA')
     assert rv1.status_code == HTTPStatus.CREATED
     assert rv1.json['baseRegistrationNumber']
     base_reg_num = rv1.json['baseRegistrationNumber']
 
-    json_data = copy.deepcopy(SAMPLE_JSON)
+    json_data = copy.deepcopy(STATEMENT_VALID)
     json_data['baseRegistrationNumber'] = base_reg_num
     json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
     del json_data['payment']
 
     # test
@@ -71,36 +234,18 @@ def test_renewal_valid_201(session, client, jwt):
     assert rv.status_code == HTTPStatus.CREATED
 
 
-def test_renewal_valid_rl_201(session, client, jwt):
+def test_renewal_rl_success(session, client, jwt):
     """Assert that a valid repairer's lien create statement returns a 200 status."""
     # setup
-    statement = copy.deepcopy(FINANCING_STATEMENT)
-    statement['type'] = 'RL'
-    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
-    del statement['createDateTime']
-    del statement['baseRegistrationNumber']
-    del statement['payment']
-    del statement['documentId']
-    del statement['lifeInfinite']
-    del statement['trustIndenture']
-    del statement['lifeYears']
-    del statement['generalCollateral']
-
-    rv1 = client.post('/api/v1/financing-statements',
-                      json=statement,
-                      headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                      content_type='application/json')
+    rv1 = create_financing_test(session, client, jwt, 'RL')
     assert rv1.status_code == HTTPStatus.CREATED
     assert rv1.json['baseRegistrationNumber']
     base_reg_num = rv1.json['baseRegistrationNumber']
 
-    json_data = copy.deepcopy(SAMPLE_JSON)
+    json_data = copy.deepcopy(STATEMENT_VALID)
     json_data['baseRegistrationNumber'] = base_reg_num
     json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
     del json_data['payment']
-    del json_data['expiryDate']
 
     # test
     rv = client.post('/api/v1/financing-statements/' + base_reg_num + '/renewals',
@@ -109,153 +254,12 @@ def test_renewal_valid_rl_201(session, client, jwt):
                      content_type='application/json')
     # check
     assert rv.status_code == HTTPStatus.CREATED
-
-
-def test_renewal_invalid_regnum_404(session, client, jwt):
-    """Assert that a renewal statement on an invalid registration number returns a 404 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'X12345X'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/X12345X/renewals',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    # print(rv.json)
-    assert rv.status_code == HTTPStatus.NOT_FOUND
-
-
-def test_renewal_nonstaff_missing_account_400(session, client, jwt):
-    """Assert that a renewal statement request with a non-staff jwt and no account ID returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/renewals',
-                     json=json_data,
-                     headers=create_header(jwt, [COLIN_ROLE]),
-                     content_type='application/json')
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_renewal_staff_missing_account_201(session, client, jwt):
-    """Assert that a renewal statement request with a staff jwt and no account ID returns a 200 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/renewals',
-                     json=json_data,
-                     headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
-                     content_type='application/json')
-    # check
-    assert rv.status_code == HTTPStatus.CREATED
-
-
-def test_renewal_nonstaff_unauthorized_401(session, client, jwt):
-    """Assert that a renewal statement request with a non-ppr role and account ID returns a 404 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['courtOrderInformation']
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/renewals',
-                     json=json_data,
-                     headers=create_header_account(jwt, [COLIN_ROLE]),
-                     content_type='application/json')
-    # check
-    assert rv.status_code == HTTPStatus.UNAUTHORIZED
-
-
-def test_renewal_invalid_missing_basedebtor_400(session, client, jwt):
-    """Assert that create statement with a missing base debtor returns a 400 error."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-    del json_data['baseDebtor']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/renewals',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_renewal_invalid_historical_400(session, client, jwt):
-    """Assert that a renewal statement on an already discharged registration returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0003'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0003/renewals',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
-
-
-def test_renewal_invalid_debtor_400(session, client, jwt):
-    """Assert that a renewal statement with an invalid base debtor name returns a 400 status."""
-    # setup
-    json_data = copy.deepcopy(SAMPLE_JSON)
-    json_data['baseRegistrationNumber'] = 'TEST0001'
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 3 DEBTOR'
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-
-    # test
-    rv = client.post('/api/v1/financing-statements/TEST0001/renewals',
-                     json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE]),
-                     content_type='application/json')
-
-    # check
-    assert rv.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_get_payment_details_registration(session, client, jwt):
     """Assert that a valid renewal request payment details setup works as expected."""
     # setup
-    json_data = copy.deepcopy(RENEWAL_STATEMENT)
+    json_data = copy.deepcopy(STATEMENT_VALID)
     registration_num = 'TEST0001'
     statement = FinancingStatement.find_by_registration_number(registration_num, False)
     registration = Registration.create_from_json(json_data,
@@ -270,3 +274,26 @@ def test_get_payment_details_registration(session, client, jwt):
     assert details
     assert details['label'] == 'Register a Renewal Statement for Base Registration:'
     assert details['value'] == 'TEST0001'
+
+
+def create_financing_test(session, client, jwt, type):
+    """Create a financing statement for testing."""
+    statement = copy.deepcopy(FINANCING_STATEMENT)
+    statement['debtors'][0]['businessName'] = 'TEST BUS 2 DEBTOR'
+    statement['type'] = type
+    del statement['createDateTime']
+    del statement['baseRegistrationNumber']
+    del statement['payment']
+    del statement['documentId']
+    del statement['lifeInfinite']
+    del statement['generalCollateral']
+    if type != 'RL':
+        del statement['lienAmount']
+        del statement['surrenderDate']
+    else:
+        del statement['trustIndenture']
+        del statement['lifeYears']
+    return client.post('/api/v1/financing-statements',
+                       json=statement,
+                       headers=create_header(jwt, [PPR_ROLE, STAFF_ROLE]),
+                       content_type='application/json')

--- a/ppr-api/tests/unit/models/test_financing_statement.py
+++ b/ppr-api/tests/unit/models/test_financing_statement.py
@@ -217,35 +217,6 @@ def test_validate_base_debtor(session):
     assert not valid
 
 
-def test_financing_client_code_invalid(session):
-    """Assert that the financing statement json with an invalid RP client code validates correctly."""
-    json_data = copy.deepcopy(FINANCING_STATEMENT)
-    del json_data['createDateTime']
-    del json_data['baseRegistrationNumber']
-    del json_data['payment']
-    del json_data['lifeInfinite']
-    del json_data['trustIndenture']
-    del json_data['generalCollateral']
-    del json_data['expiryDate']
-    del json_data['registeringParty']
-    del json_data['documentId']
-    party = {
-        'code': '900000000'
-    }
-    sp = {
-        'code': '900000001'
-    }
-    json_data['registeringParty'] = party
-    json_data['securedParties'].append(sp)
-    with pytest.raises(BusinessException) as bad_request_err:
-        FinancingStatement.create_from_json(json_data, 'PS12345')
-
-    # check
-    assert bad_request_err
-    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
-    print(bad_request_err.value.error)
-
-
 def test_current_json(session):
     """Assert that financing statement JSON contains expected current view elements."""
     result = FinancingStatement.find_by_id(200000000)

--- a/ppr-api/tests/unit/models/test_registration.py
+++ b/ppr-api/tests/unit/models/test_registration.py
@@ -16,16 +16,18 @@
 
 Test-Suite to ensure that the Registration Model is working as expected.
 """
-from http import HTTPStatus
 import copy
 
-import pytest
-from registry_schemas.example_data.ppr import DISCHARGE_STATEMENT
-from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT, RENEWAL_STATEMENT, CHANGE_STATEMENT
-from registry_schemas.example_data.ppr import DRAFT_AMENDMENT_STATEMENT, DRAFT_CHANGE_STATEMENT
-from ppr_api.models import Registration, FinancingStatement, Draft
+from registry_schemas.example_data.ppr import (
+    AMENDMENT_STATEMENT,
+    CHANGE_STATEMENT,
+    DISCHARGE_STATEMENT,
+    DRAFT_AMENDMENT_STATEMENT,
+    DRAFT_CHANGE_STATEMENT,
+    RENEWAL_STATEMENT,
+)
 
-from ppr_api.exceptions import BusinessException
+from ppr_api.models import Draft, FinancingStatement, Registration
 
 
 def test_find_by_id(session):
@@ -480,125 +482,3 @@ def test_save_change_from_draft(session):
     result = registration.json
     assert result
 #    assert 'documentId' in result
-
-
-def test_renewal_client_code_invalid(session):
-    """Assert that the renewal statement json with an invalid RP client code validates correctly."""
-    json_data = copy.deepcopy(RENEWAL_STATEMENT)
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-    del json_data['courtOrderInformation']
-    del json_data['registeringParty']
-    party = {
-        'code': '900000000'
-    }
-    json_data['registeringParty'] = party
-
-    financing_statement = FinancingStatement.find_by_financing_id(200000004)
-    assert financing_statement
-
-    with pytest.raises(BusinessException) as bad_request_err:
-        Registration.create_from_json(json_data,
-                                      'RS',
-                                      financing_statement,
-                                      'TEST0001',
-                                      'PS12345')
-
-    # check
-    assert bad_request_err
-    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
-    print(bad_request_err.value.error)
-
-
-def test_amendment_party_id_invalid(session):
-    """Assert that the amendment statement json with an invalid SP delete party ID validates correctly."""
-    registration = Registration.find_by_id(200000008)
-    assert registration
-
-    json_data = registration.json
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['addGeneralCollateral']
-    del json_data['addVehicleCollateral']
-    del json_data['deleteGeneralCollateral']
-    del json_data['deleteVehicleCollateral']
-    del json_data['addDebtors']
-    del json_data['addSecuredParties']
-    json_data['deleteSecuredParties'][0]['partyId'] = 300000000
-    json_data['deleteDebtors'][0]['partyId'] = 300000001
-
-    financing_statement = FinancingStatement.find_by_financing_id(200000000)
-    with pytest.raises(BusinessException) as bad_request_err:
-        Registration.create_from_json(json_data,
-                                      'AMENDMENT',
-                                      financing_statement,
-                                      'TEST0005',
-                                      'PS12345')
-
-    # check
-    assert bad_request_err
-    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
-    print(bad_request_err.value.error)
-
-
-def test_amendment_vehicle_id_invalid(session):
-    """Assert that the amendment statement json with an invalid delete vehicle collateral ID validates correctly."""
-    registration = Registration.find_by_id(200000008)
-    assert registration
-
-    json_data = registration.json
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['addGeneralCollateral']
-    del json_data['addVehicleCollateral']
-    del json_data['deleteGeneralCollateral']
-    del json_data['addDebtors']
-    del json_data['addSecuredParties']
-    del json_data['deleteDebtors']
-    del json_data['deleteSecuredParties']
-    json_data['deleteVehicleCollateral'][0]['vehicleId'] = 300000000
-
-    financing_statement = FinancingStatement.find_by_financing_id(200000000)
-    with pytest.raises(BusinessException) as bad_request_err:
-        Registration.create_from_json(json_data,
-                                      'AMENDMENT',
-                                      financing_statement,
-                                      'TEST0001',
-                                      'PS12345')
-
-    # check
-    assert bad_request_err
-    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
-    print(bad_request_err.value.error)
-
-
-def test_amendment_collateral_id_invalid(session):
-    """Assert that the amendment statement json with an invalid delete general collateral ID validates correctly."""
-    registration = Registration.find_by_id(200000008)
-    assert registration
-
-    json_data = registration.json
-    del json_data['createDateTime']
-    del json_data['amendmentRegistrationNumber']
-    del json_data['addGeneralCollateral']
-    del json_data['addVehicleCollateral']
-    del json_data['deleteVehicleCollateral']
-    del json_data['addDebtors']
-    del json_data['addSecuredParties']
-    del json_data['deleteDebtors']
-    del json_data['deleteSecuredParties']
-    json_data['deleteGeneralCollateral'][0]['collateralId'] = 300000000
-
-    financing_statement = FinancingStatement.find_by_financing_id(200000000)
-    with pytest.raises(BusinessException) as bad_request_err:
-        Registration.create_from_json(json_data,
-                                      'AMENDMENT',
-                                      financing_statement,
-                                      'TEST0001',
-                                      'PS12345')
-
-    # check
-    assert bad_request_err
-    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
-    print(bad_request_err.value.error)

--- a/ppr-api/tests/unit/utils/__init__.py
+++ b/ppr-api/tests/unit/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the api utils module."""

--- a/ppr-api/tests/unit/utils/test_party_validator.py
+++ b/ppr-api/tests/unit/utils/test_party_validator.py
@@ -1,0 +1,453 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Party validator tests."""
+import copy
+
+import pytest
+
+from ppr_api.models import FinancingStatement
+from ppr_api.utils.validators import party_validator as validator
+
+
+FINANCING_VALID = {
+    'type': 'SA',
+    'registeringParty': {
+        'code': '200000001',
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'securedParties': [
+        {
+            'businessName': 'BANK OF BRITISH COLUMBIA',
+            'address': {
+                'street': '3720 BEACON AVENUE',
+                'city': 'SIDNEY',
+                'region': 'BC',
+                'country': 'CA',
+                'postalCode': 'V7R 1R7'
+            },
+            'partyId': 1321095
+        },
+        {
+            'code': '200000000'
+        }
+    ],
+    'debtors': [
+        {
+            'businessName': 'Brown Window Cleaning Inc.',
+            'address': {
+                'street': '1234 Blanshard St',
+                'city': 'Victoria',
+                'region': 'BC',
+                'country': 'CA',
+                'postalCode': 'V8S 3J5'
+             },
+            'emailAddress': 'csmith@bwc.com',
+            'partyId': 1400094
+        }
+    ]
+}
+FINANCING_INVALID = {
+    'type': 'SA',
+    'registeringParty': {
+        'code': '300000001',
+        'businessName': 'ABC SEARCHING COMPANY',
+        'address': {
+            'street': '222 SUMMER STREET',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'country': 'XX',
+            'postalCode': 'V8W 2V8'
+        },
+        'emailAddress': 'bsmith@abc-search.com'
+    },
+    'securedParties': [
+        {
+            'businessName': 'BANK OF BRITISH COLUMBIA',
+            'address': {
+                'street': '3720 BEACON AVENUE',
+                'city': 'SIDNEY',
+                'region': 'BX',
+                'country': 'XX',
+                'postalCode': 'V7R 1R7'
+            },
+            'partyId': 1321095
+        },
+        {
+            'code': '300000000'
+        }
+    ],
+    'debtors': [
+        {
+            'businessName': 'Brown Window Cleaning Inc.',
+            'address': {
+                'street': '1234 Blanshard St',
+                'city': 'Victoria',
+                'region': 'BC',
+                'country': 'US',
+                'postalCode': 'V8S 3J5'
+             },
+            'emailAddress': 'csmith@bwc.com',
+            'partyId': 1400094
+        }
+    ]
+}
+
+AMENDMENT_VALID = {
+  'statementType': 'AMENDMENT_STATEMENT',
+  'baseDebtor': {
+      'businessName': 'DEBTOR 1 INC.'
+  },
+  'registeringParty': {
+      'code': '200000001',
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'deleteDebtors': [
+    {
+        'businessName': 'Brawn Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        },
+        'partyId': 1321961
+    }
+  ],
+  'addDebtors': [
+    {
+        'businessName': 'Brown Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        }
+    }
+  ],
+  'deleteSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3720 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      },
+      'partyId': 1321095
+    }
+  ],
+  'addSecuredParties': [
+    {
+      'code': '200000000',
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'deleteVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KNADM5A39E6904135',
+      'year': 2014,
+      'make': 'KIA',
+      'model': 'RIO',
+      'vehicleId': 974124
+    }
+  ],
+  'addVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KM8J3CA46JU622994',
+      'year': 2018,
+      'make': 'HYUNDAI',
+      'model': 'TUCSON'
+    }
+  ],
+  'deleteGeneralCollateral': [
+    {
+      'description': 'Fridges and stoves. Proceeds: Accts Receivable.',
+      'collateralId': 123435
+    }
+  ],
+  'addGeneralCollateral': [
+    {
+      'description': '1985 white Fender Stratocaster Guitar #1234'
+    }
+  ]
+}
+
+AMENDMENT_INVALID = {
+  'statementType': 'AMENDMENT_STATEMENT',
+  'baseDebtor': {
+      'businessName': 'DEBTOR 1 INC.'
+  },
+  'registeringParty': {
+      'code': '300000001',
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'XX',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'deleteDebtors': [
+    {
+        'businessName': 'Brawn Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        }
+    }
+  ],
+  'addDebtors': [
+    {
+        'businessName': 'Brown Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'US',
+            'postalCode': 'V8S 3J5'
+          }
+    }
+  ],
+  'deleteSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3720 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'addSecuredParties': [
+    {
+      'code': '300000000',
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BX',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'deleteVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KNADM5A39E6904135',
+      'year': 2014,
+      'make': 'KIA',
+      'model': 'RIO'
+    }
+  ],
+  'addVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KM8J3CA46JU622994',
+      'year': 2018,
+      'make': 'HYUNDAI',
+      'model': 'TUCSON'
+    }
+  ],
+  'deleteGeneralCollateral': [
+    {
+      'description': 'Fridges and stoves. Proceeds: Accts Receivable.'
+    }
+  ],
+  'addGeneralCollateral': [
+    {
+      'description': '1985 white Fender Stratocaster Guitar #1234'
+    }
+  ]
+}
+
+
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_CODE_FS_DATA = [
+    ('Valid party codes', FINANCING_VALID, True, None),
+    ('Invalid party codes', FINANCING_INVALID, False, validator.REGISTERING_CODE_MSG.format('300000001'))
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_ADDRESS_FS_DATA = [
+    ('Valid addresses', FINANCING_VALID, True, None),
+    ('Invalid registering address', FINANCING_INVALID, False, validator.INVALID_COUNTRY_REGISTERING.format('XX')),
+    ('Invalid secured address region', FINANCING_INVALID, False, validator.INVALID_REGION_SECURED.format('BX')),
+    ('Invalid secured address country', FINANCING_INVALID, False, validator.INVALID_COUNTRY_SECURED.format('XX')),
+    ('Invalid debtor address', FINANCING_INVALID, False, validator.INVALID_REGION_DEBTOR.format('BC'))
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_PARTIES_FS_DATA = [
+    ('Valid parties', FINANCING_VALID, True, None),
+    ('Invalid party code', FINANCING_INVALID, False, validator.SECURED_CODE_MSG.format('300000000')),
+    ('Invalid party address', FINANCING_INVALID, False, validator.INVALID_REGION_SECURED.format('BX'))
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_PARTY_IDS_AM_DATA = [
+    ('Valid party IDs', AMENDMENT_VALID, True, None),
+    ('Missing delete secured id', AMENDMENT_INVALID, False, validator.DELETE_MISSING_ID_SECURED),
+    ('Missing delete debtor id', AMENDMENT_INVALID, False, validator.DELETE_MISSING_ID_DEBTOR)
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_CODE_AM_DATA = [
+    ('Valid party codes', AMENDMENT_VALID, True, None),
+    ('Invalid party codes', AMENDMENT_INVALID, False, validator.SECURED_CODE_MSG.format('300000000'))
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_ADDRESS_AM_DATA = [
+    ('Valid addresses', AMENDMENT_VALID, True, None),
+    ('Invalid registering address', AMENDMENT_INVALID, False, validator.INVALID_COUNTRY_REGISTERING.format('XX')),
+    ('Invalid secured address', AMENDMENT_INVALID, False, validator.INVALID_REGION_SECURED.format('BX')),
+    ('Invalid debtor address', AMENDMENT_INVALID, False, validator.INVALID_REGION_DEBTOR.format('BC'))
+]
+# testdata pattern is ({description}, {financing statement data}, {valid}, {message contents})
+TEST_PARTIES_AM_DATA = [
+    ('Valid parties', AMENDMENT_VALID, True, None),
+    ('Invalid party code', AMENDMENT_INVALID, False, validator.SECURED_CODE_MSG.format('300000000')),
+    ('Invalid party address', AMENDMENT_INVALID, False, validator.INVALID_REGION_SECURED.format('BX')),
+    ('Missing delete debtor id', AMENDMENT_INVALID, False, validator.DELETE_MISSING_ID_DEBTOR)
+]
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_CODE_FS_DATA)
+def test_validate_party_codes(session, desc, json_data, valid, message_content):
+    """Assert that financing statement client party code validation works as expected."""
+    error_msg = validator.validate_party_codes(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_ADDRESS_FS_DATA)
+def test_validate_party_addresses(session, desc, json_data, valid, message_content):
+    """Assert that financing statement party address validation works as expected."""
+    error_msg = validator.validate_party_addresses(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_PARTIES_FS_DATA)
+def test_validate_financing_parties(session, desc, json_data, valid, message_content):
+    """Assert that financing statement party validation works as expected."""
+    error_msg = validator.validate_financing_parties(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_PARTY_IDS_AM_DATA)
+def test_validate_party_ids(session, desc, json_data, valid, message_content):
+    """Assert that registration delete party id provided validation works as expected."""
+    error_msg = validator.validate_party_ids(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_CODE_AM_DATA)
+def test_validate_party_codes_registration(session, desc, json_data, valid, message_content):
+    """Assert that registration statement client party code validation works as expected."""
+    error_msg = validator.validate_party_codes(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_ADDRESS_AM_DATA)
+def test_validate_party_addresses_registration(session, desc, json_data, valid, message_content):
+    """Assert that registration statement party address validation works as expected."""
+    error_msg = validator.validate_party_addresses(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_PARTIES_AM_DATA)
+def test_validate_registration_parties(session, desc, json_data, valid, message_content):
+    """Assert that registration statement party validation works as expected."""
+    error_msg = validator.validate_registration_parties(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+def test_actual_party_ids(session):
+    """Assert that delete party id validation works as expected on an existing financing statement."""
+    json_data = copy.deepcopy(AMENDMENT_VALID)
+    statement = FinancingStatement.find_by_registration_number('TEST0001', False)
+    # example registration party ID's are bogus
+    error_msg = validator.validate_party_ids(json_data, statement)
+    assert error_msg != ''
+    assert error_msg.find('Invalid partyId') != -1
+
+    for party in statement.parties:
+        if not party.registration_id_end and party.party_type == 'SP':
+            json_data['deleteSecuredParties'][0]['partyId'] = party.id
+        elif not party.registration_id_end and party.party_type in ('DB', 'DI'):
+            json_data['deleteDebtors'][0]['partyId'] = party.id
+    error_msg = validator.validate_party_ids(json_data, statement)
+    if error_msg != '':
+        print(error_msg)
+    assert error_msg == ''

--- a/ppr-api/tests/unit/utils/test_registration_validator.py
+++ b/ppr-api/tests/unit/utils/test_registration_validator.py
@@ -1,0 +1,256 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registration non-party validator tests."""
+import copy
+
+import pytest
+
+from ppr_api.models import FinancingStatement
+from ppr_api.utils.validators import registration_validator as validator
+
+
+AMENDMENT_VALID = {
+  'statementType': 'AMENDMENT_STATEMENT',
+  'baseDebtor': {
+      'businessName': 'DEBTOR 1 INC.'
+  },
+  'registeringParty': {
+      'code': '200000001',
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'deleteDebtors': [
+    {
+        'businessName': 'Brawn Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        },
+        'partyId': 1321961
+    }
+  ],
+  'addDebtors': [
+    {
+        'businessName': 'Brown Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        }
+    }
+  ],
+  'deleteSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3720 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      },
+      'partyId': 1321095
+    }
+  ],
+  'addSecuredParties': [
+    {
+      'code': '200000000',
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'deleteVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KNADM5A39E6904135',
+      'year': 2014,
+      'make': 'KIA',
+      'model': 'RIO',
+      'vehicleId': 974124
+    }
+  ],
+  'addVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KM8J3CA46JU622994',
+      'year': 2018,
+      'make': 'HYUNDAI',
+      'model': 'TUCSON'
+    }
+  ],
+  'deleteGeneralCollateral': [
+    {
+      'description': 'Fridges and stoves. Proceeds: Accts Receivable.',
+      'collateralId': 123435
+    }
+  ],
+  'addGeneralCollateral': [
+    {
+      'description': '1985 white Fender Stratocaster Guitar #1234'
+    }
+  ]
+}
+
+AMENDMENT_INVALID = {
+  'statementType': 'AMENDMENT_STATEMENT',
+  'baseDebtor': {
+      'businessName': 'DEBTOR 1 INC.'
+  },
+  'registeringParty': {
+      'code': '300000001',
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+          'street': '222 SUMMER STREET',
+          'city': 'VICTORIA',
+          'region': 'BC',
+          'country': 'XX',
+          'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com'
+  },
+  'changeType': 'AM',
+  'deleteDebtors': [
+    {
+        'businessName': 'Brawn Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'CA',
+            'postalCode': 'V8S 3J5'
+        }
+    }
+  ],
+  'addDebtors': [
+    {
+        'businessName': 'Brown Window Cleaning Inc.',
+        'address': {
+            'street': '1234 Blanshard St',
+            'city': 'Victoria',
+            'region': 'BC',
+            'country': 'US',
+            'postalCode': 'V8S 3J5'
+          }
+    }
+  ],
+  'deleteSecuredParties': [
+    {
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3720 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BC',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'addSecuredParties': [
+    {
+      'code': '300000000',
+      'businessName': 'BANK OF BRITISH COLUMBIA',
+      'address': {
+          'street': '3721 BEACON AVENUE',
+          'city': 'SIDNEY',
+          'region': 'BX',
+          'country': 'CA',
+          'postalCode': 'V7R 1R7'
+      }
+    }
+  ],
+  'deleteVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KNADM5A39E6904135',
+      'year': 2014,
+      'make': 'KIA',
+      'model': 'RIO'
+    }
+  ],
+  'addVehicleCollateral': [
+    {
+      'type': 'MV',
+      'serialNumber': 'KM8J3CA46JU622994',
+      'year': 2018,
+      'make': 'HYUNDAI',
+      'model': 'TUCSON'
+    }
+  ],
+  'deleteGeneralCollateral': [
+    {
+      'description': 'Fridges and stoves. Proceeds: Accts Receivable.'
+    }
+  ],
+  'addGeneralCollateral': [
+    {
+      'description': '1985 white Fender Stratocaster Guitar #1234'
+    }
+  ]
+}
+
+
+# testdata pattern is ({description}, {registration data}, {valid}, {message contents})
+TEST_COLLATERAL_IDS_DATA = [
+    ('Valid collateral IDs', AMENDMENT_VALID, True, None),
+    ('Missing delete vehicle id', AMENDMENT_INVALID, False, validator.DELETE_MISSING_ID_VEHICLE),
+    ('Missing delete general id', AMENDMENT_INVALID, False, validator.DELETE_MISSING_ID_GENERAL)
+]
+
+
+@pytest.mark.parametrize('desc,json_data,valid,message_content', TEST_COLLATERAL_IDS_DATA)
+def test_validate_collateral_ids(session, desc, json_data, valid, message_content):
+    """Assert that registration delete collateral id provided validation works as expected."""
+    error_msg = validator.validate_collateral_ids(json_data)
+    if valid:
+        assert error_msg == ''
+    elif message_content:
+        assert error_msg != ''
+        assert error_msg.find(message_content) != -1
+
+
+def test_actual_collateral_ids(session):
+    """Assert that delete collateral id validation works as expected on an existing financing statement."""
+    json_data = copy.deepcopy(AMENDMENT_VALID)
+    statement = FinancingStatement.find_by_registration_number('TEST0001', False)
+    # example registration collateral ID's are bogus
+    error_msg = validator.validate_collateral_ids(json_data, statement)
+    assert error_msg != ''
+    assert error_msg.find('Invalid vehicleId') != -1
+    assert error_msg.find('Invalid collateralId') != -1
+
+    json_data['deleteVehicleCollateral'][0]['vehicleId'] = statement.vehicle_collateral[0].id
+    json_data['deleteGeneralCollateral'][0]['collateralId'] = statement.general_collateral[0].id
+    error_msg = validator.validate_collateral_ids(json_data, statement)
+    if error_msg != '':
+        print(error_msg)
+    assert error_msg == ''


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
-- Add address region, country validation to create financing statements and registrations. 
-- Move endpoint extra validation to the same step as schema validation. Refactor client party code validation.
-- Update resource unit tests to use pytest with parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
