### PR TITLE
8422 API reg number search non-financing reg type

### DIFF
--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -240,6 +240,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                 mapping = row._mapping  # pylint: disable=protected-access; follows documentation
                 registration_type = str(mapping['registration_type'])
                 timestamp = mapping['base_registration_ts']
+                birth_date = mapping['birth_date']
                 person = {
                     'last': str(mapping['last_name']),
                     'first': str(mapping['first_name'])
@@ -251,6 +252,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                     'personName': person,
                     'partyId': int(mapping['id'])
                 }
+                if birth_date:
+                    debtor['birthDate'] = model_utils.format_ts(birth_date)
                 result_json = {
                     'baseRegistrationNumber': str(mapping['base_registration_num']),
                     'matchType': str(mapping['match_type']),

--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -240,7 +240,6 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                 mapping = row._mapping  # pylint: disable=protected-access; follows documentation
                 registration_type = str(mapping['registration_type'])
                 timestamp = mapping['base_registration_ts']
-                birth_date = mapping['birth_date']
                 person = {
                     'last': str(mapping['last_name']),
                     'first': str(mapping['first_name'])
@@ -252,8 +251,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                     'personName': person,
                     'partyId': int(mapping['id'])
                 }
-                if birth_date:
-                    debtor['birthDate'] = model_utils.format_ts(birth_date)
+                if mapping['birth_date']:
+                    debtor['birthDate'] = model_utils.format_ts(mapping['birth_date'])
                 result_json = {
                     'baseRegistrationNumber': str(mapping['base_registration_num']),
                     'matchType': str(mapping['match_type']),

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -55,7 +55,16 @@ SELECT r.registration_type,r.registration_ts AS base_registration_ts,
 
 # Equivalent logic as DB view search_by_reg_num_vw, but API determines the where clause.
 REG_NUM_QUERY = """
-SELECT r.registration_type,r.registration_ts AS base_registration_ts,
+SELECT CASE WHEN r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
+            THEN r.registration_type 
+            ELSE (SELECT r2.registration_type 
+                   FROM registrations r2 
+                  WHERE r2.registration_number = r.base_reg_number) END registration_type,
+       CASE WHEN r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
+            THEN r.registration_ts
+            ELSE (SELECT r2.registration_ts 
+                   FROM registrations r2 
+                  WHERE r2.registration_number = r.base_reg_number) END base_registration_ts,
        CASE WHEN r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
             THEN r.registration_number 
             ELSE r.base_reg_number END base_registration_num,

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -127,7 +127,7 @@ SELECT r.registration_type,r.registration_ts AS base_registration_ts,
        p.last_name,p.first_name,p.middle_initial,p.id,
        r.registration_number AS base_registration_num,
        CASE WHEN p.last_name = :query_last AND p.first_name = :query_first THEN 'EXACT' ELSE 'SIMILAR' END match_type,
-       fs.expire_date,fs.state_type
+       fs.expire_date,fs.state_type, p.birth_date
   FROM registrations r, financing_statements fs, parties p
  WHERE r.financing_id = fs.id
    AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')

--- a/ppr-api/test_data/postgres_data_files/test0001.sql
+++ b/ppr-api/test_data/postgres_data_files/test0001.sql
@@ -26,7 +26,8 @@ INSERT INTO parties(id, party_type, registration_id, financing_id, registration_
 INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
                   middle_initial, last_name, business_name, birth_date, address_id, first_name_key, last_name_key)
     VALUES(200000001, 'DI', 200000000, 200000000, null, null, 'TEST IND', '1', 'DEBTOR', null,
-           null, 200000002, searchkey_first_name('TEST IND'), searchkey_last_name('DEBTOR'))
+           timestamp with time zone '2005-04-02 07:00:00-0700', 200000002, searchkey_first_name('TEST IND'), 
+           searchkey_last_name('DEBTOR'))
 ;
 INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
                   middle_initial, last_name, business_name, birth_date, address_id, business_srch_key)

--- a/ppr-api/test_data/postgres_data_files/test0004.sql
+++ b/ppr-api/test_data/postgres_data_files/test0004.sql
@@ -26,7 +26,8 @@ INSERT INTO parties(id, party_type, registration_id, financing_id, registration_
 INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
                   middle_initial, last_name, business_name, birth_date, address_id, first_name_key, last_name_key)
     VALUES(200000012, 'DI', 200000003, 200000003, null, null, 'TEST IND', '4', 'DEBTOR', null,
-           null, 200000005, searchkey_first_name('TEST IND'), searchkey_last_name('DEBTOR'))
+           timestamp with time zone '2005-04-02 07:00:00-0700', 200000005, searchkey_first_name('TEST IND'), 
+           searchkey_last_name('DEBTOR'))
 ;
 INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
                   middle_initial, last_name, business_name, birth_date, address_id)

--- a/ppr-api/tests/unit/models/test_search_request.py
+++ b/ppr-api/tests/unit/models/test_search_request.py
@@ -399,6 +399,8 @@ def test_search_valid(session, search_type, json_data):
         assert result['results'][0]['debtor']['personName']
         assert result['results'][0]['debtor']['personName']['last'] == 'DEBTOR'
         assert result['results'][0]['debtor']['personName']['first'] == 'TEST IND'
+        if result['results'][0]['baseRegistrationNumber'] == 'TEST0004':
+            assert result['results'][0]['debtor']['birthDate']
     elif search_type == 'AM':
         assert result['results'][0]['baseRegistrationNumber'] == 'TEST0001'
         assert result['results'][0]['registrationNumber'] == 'TEST0007'


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8422

*Description of changes:*
- When searching by registration number on a non-financing registration, return the financing statement (base registration) registration type, not the discharge, renewal...registration type.
- 8422 added: include debtor birth date in summary search results for an individual debtor search.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
