### PR TITLE
API final search results report change from UX assurance.

### DIFF
--- a/ppr-api/report-templates/financingStatement.html
+++ b/ppr-api/report-templates/financingStatement.html
@@ -23,7 +23,9 @@
           </td>
           <td>
             <div class="report-type">{{ registrationDescription }}</div>
-            <div class="report-type-desc">{{ registrationAct }}</div>
+            {# Add back when act descriptions are finalized.
+              <div class="report-type-desc">{{ registrationAct }}</div>
+            #}
           </td>
         </tr>
       </table>

--- a/ppr-api/report-templates/template-parts/search-result/financingStatement.html
+++ b/ppr-api/report-templates/template-parts/search-result/financingStatement.html
@@ -18,11 +18,11 @@
       <td>Registration Type:</td>
       <td>{{ detail.financingStatement.registrationDescription }}</td>
     </tr>
-    <tr>
+    {# Add back when act descriptions are finalized.<tr>
       <td>Act:</td>
       <td>{{ detail.financingStatement.registrationAct }}</td>
     </tr>
-    <tr>
+    <tr>#}
       <td>Base Registration Date and Time:</td>
       <td>{{detail.financingStatement.createDateTime}}</td>
     </tr>

--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -114,7 +114,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
     def search_by_registration_number(self):
         """Execute a search by registration number query."""
         reg_num = self.request_json['criteria']['value']
-        result = db.session.execute(search_utils.REG_NUM_QUERY, {'query_value': reg_num})
+        result = db.session.execute(search_utils.REG_NUM_QUERY, {'query_value': reg_num.strip().upper()})
         row = result.first()
         if row is not None:
             mapping = row._mapping  # pylint: disable=protected-access; follows documentation
@@ -148,7 +148,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
             query = search_utils.AIRCRAFT_DOT_QUERY
 
         max_results_size = int(current_app.config.get('ACCOUNT_SEARCH_MAX_RESULTS'))
-        result = db.session.execute(query, {'query_value': search_value, 'max_results_size': max_results_size})
+        result = db.session.execute(query, {'query_value': search_value.strip().upper(),
+                                            'max_results_size': max_results_size})
         rows = result.fetchall()
         if rows is not None:
             results_json = []

--- a/ppr-api/src/ppr_api/models/vehicle_collateral.py
+++ b/ppr-api/src/ppr_api/models/vehicle_collateral.py
@@ -142,6 +142,7 @@ class VehicleCollateral(db.Model):  # pylint: disable=too-many-instance-attribut
         if 'model' in json_data:
             collateral.model = json_data['model']
         if collateral.serial_number:
+            collateral.serial_number = collateral.serial_number.strip().upper()
             collateral.search_vin = VehicleCollateral.get_search_vin(collateral.vehicle_type,
                                                                      collateral.serial_number)
         if collateral.vehicle_type == VehicleCollateral.SerialTypes.MANUFACTURED_HOME.value:


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#7885

*Description of changes:*
- 7885 Financing Statement remove Registration Act from reports.
- 8422 Search by registration number workaround for legacy migration records where registrations.base_reg_number is null for non financing statement registrations.
- 8483 Fix to ignore case in search criteria when searching by registration number, serial number, aircraft DOT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
