### PR TITLE
8453 API add path to get debtor names.

### DIFF
--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -51,4 +51,4 @@ sentry-sdk==1.1.0
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.5
-git+https://github.com/bcgov/registry-schemas.git@1.4.2#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.4.3#egg=registry_schemas

--- a/ppr-api/requirements/bcregistry-libraries.txt
+++ b/ppr-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.4.2#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.4.3#egg=registry_schemas

--- a/ppr-api/tests/unit/api/test_amendment.py
+++ b/ppr-api/tests/unit/api/test_amendment.py
@@ -30,7 +30,7 @@ from tests.unit.services.utils import create_header, create_header_account
 SAMPLE_JSON = copy.deepcopy(AMENDMENT_STATEMENT)
 STATEMENT_VALID = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -61,7 +61,7 @@ STATEMENT_VALID = {
 }
 INVALID_REG_NUM = {
   'baseRegistrationNumber': 'TESTXXX1',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -120,8 +120,8 @@ MISSING_BASE_DEBTOR = {
 }
 INVALID_BASE_DEBTOR = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
-      'businessName': 'TEST BUS 3 DEBTOR'
+  'debtorName': {
+      'businessName': 'XXXX BUS 3 DEBTOR'
   },
   'registeringParty': {
       'businessName': 'ABC SEARCHING COMPANY',
@@ -151,7 +151,7 @@ INVALID_BASE_DEBTOR = {
 }
 INVALID_HISTORICAL = {
   'baseRegistrationNumber': 'TEST0003',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -182,7 +182,7 @@ INVALID_HISTORICAL = {
 }
 INVALID_CODE = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -205,7 +205,7 @@ INVALID_CODE = {
 }
 INVALID_ADDRESS = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -310,7 +310,7 @@ def test_amendment_court_order_success(session, client, jwt):
 
     json_data = copy.deepcopy(SAMPLE_JSON)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     json_data['changeType'] = 'CO'
     del json_data['createDateTime']
     del json_data['amendmentRegistrationNumber']
@@ -349,7 +349,7 @@ def test_amendment_success(session, client, jwt):
 
     json_data = copy.deepcopy(SAMPLE_JSON)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     json_data['changeType'] = 'AM'
     del json_data['courtOrderInformation']
     del json_data['createDateTime']

--- a/ppr-api/tests/unit/api/test_change.py
+++ b/ppr-api/tests/unit/api/test_change.py
@@ -30,7 +30,7 @@ from tests.unit.services.utils import create_header, create_header_account
 SAMPLE_JSON = copy.deepcopy(CHANGE_STATEMENT)
 STATEMENT_VALID = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -61,7 +61,7 @@ STATEMENT_VALID = {
 }
 INVALID_REG_NUM = {
   'baseRegistrationNumber': 'TESTXXX1',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -112,8 +112,8 @@ MISSING_BASE_DEBTOR = {
 }
 INVALID_BASE_DEBTOR = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
-      'businessName': 'TEST BUS 3 DEBTOR'
+  'debtorName': {
+      'businessName': 'TEXT BUS 3 DEBTOR'
   },
   'registeringParty': {
       'businessName': 'ABC SEARCHING COMPANY',
@@ -139,7 +139,7 @@ INVALID_BASE_DEBTOR = {
 }
 INVALID_HISTORICAL = {
   'baseRegistrationNumber': 'TEST0003',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -166,7 +166,7 @@ INVALID_HISTORICAL = {
 }
 INVALID_CODE = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -185,7 +185,7 @@ INVALID_CODE = {
 }
 INVALID_ADDRESS = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -285,7 +285,7 @@ def test_change_substitute_collateral_success(session, client, jwt):
 
     json_data = copy.deepcopy(SAMPLE_JSON)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     json_data['changeType'] = 'SU'
     del json_data['createDateTime']
     del json_data['changeRegistrationNumber']
@@ -320,7 +320,7 @@ def test_change_debtor_transfer_success(session, client, jwt):
 
     json_data = copy.deepcopy(SAMPLE_JSON)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     json_data['changeType'] = 'DT'
     del json_data['createDateTime']
     del json_data['changeRegistrationNumber']

--- a/ppr-api/tests/unit/api/test_discharge.py
+++ b/ppr-api/tests/unit/api/test_discharge.py
@@ -29,7 +29,7 @@ from tests.unit.services.utils import create_header, create_header_account
 # prep sample post discharge statement data
 STATEMENT_VALID = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -50,7 +50,7 @@ STATEMENT_VALID = {
 }
 INVALID_REG_NUM = {
   'baseRegistrationNumber': 'TESTXXX1',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -85,8 +85,8 @@ MISSING_BASE_DEBTOR = {
 }
 INVALID_BASE_DEBTOR = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
-      'businessName': 'TEST BUS 3 DEBTOR'
+  'debtorName': {
+      'businessName': 'TXST BUS 3 DEBTOR'
   },
   'registeringParty': {
       'businessName': 'ABC SEARCHING COMPANY',
@@ -102,7 +102,7 @@ INVALID_BASE_DEBTOR = {
 }
 INVALID_HISTORICAL = {
   'baseRegistrationNumber': 'TEST0003',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -119,7 +119,7 @@ INVALID_HISTORICAL = {
 }
 INVALID_CODE = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -128,7 +128,7 @@ INVALID_CODE = {
 }
 INVALID_ADDRESS = {
   'baseRegistrationNumber': 'TEST0001',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'TEST BUS 2 DEBTOR'
   },
   'registeringParty': {
@@ -229,7 +229,7 @@ def test_discharge_success(session, client, jwt):
     base_reg_num = rv1.json['baseRegistrationNumber']
 
     json_data = copy.deepcopy(STATEMENT_VALID)
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     json_data['baseRegistrationNumber'] = base_reg_num
     del json_data['payment']
 

--- a/ppr-api/tests/unit/api/test_renewal.py
+++ b/ppr-api/tests/unit/api/test_renewal.py
@@ -32,7 +32,7 @@ from tests.unit.services.utils import create_header, create_header_account
 STATEMENT_VALID = {
     'baseRegistrationNumber': 'TEST0001',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'TEST BUS 2 DEBTOR'
     },
     'registeringParty': {
@@ -75,8 +75,8 @@ MISSING_BASE_DEBTOR = {
 INVALID_BASE_DEBTOR = {
     'baseRegistrationNumber': 'TEST0001',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
-        'businessName': 'TEST BUS 3 DEBTOR'
+    'debtorName': {
+        'businessName': 'XEST BUS 3 DEBTOR'
     },
     'registeringParty': {
         'businessName': 'ABC SEARCHING COMPANY',
@@ -98,7 +98,7 @@ INVALID_BASE_DEBTOR = {
 INVALID_REG_NUM = {
     'baseRegistrationNumber': 'TESTXXX1',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'TEST BUS 2 DEBTOR'
     },
     'registeringParty': {
@@ -121,7 +121,7 @@ INVALID_REG_NUM = {
 INVALID_HISTORICAL = {
     'baseRegistrationNumber': 'TEST0003',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'TEST BUS 2 DEBTOR'
     },
     'registeringParty': {
@@ -144,7 +144,7 @@ INVALID_HISTORICAL = {
 INVALID_CODE = {
     'baseRegistrationNumber': 'TEST0001',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'TEST BUS 2 DEBTOR'
     },
     'registeringParty': {
@@ -159,7 +159,7 @@ INVALID_CODE = {
 INVALID_ADDRESS = {
     'baseRegistrationNumber': 'TEST0001',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'TEST BUS 2 DEBTOR'
     },
     'registeringParty': {
@@ -251,7 +251,7 @@ def test_renewal_sa_success(session, client, jwt):
 
     json_data = copy.deepcopy(STATEMENT_VALID)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     del json_data['payment']
 
     # test
@@ -273,7 +273,7 @@ def test_renewal_rl_success(session, client, jwt):
 
     json_data = copy.deepcopy(STATEMENT_VALID)
     json_data['baseRegistrationNumber'] = base_reg_num
-    json_data['baseDebtor']['businessName'] = 'TEST BUS 2 DEBTOR'
+    json_data['debtorName']['businessName'] = 'TEST BUS 2 DEBTOR'
     del json_data['payment']
 
     # test


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8453

*Description of changes:*
- Add new API endpoint GET /ppr/api/v1/financing-statements/{registration_num}/debtorNames to get a list of all debtor names in chronological order.
- Rename baseDebtor to debtorName. Remove references to base debtor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
