### PR TITLE
8509 UI reset stepper state on starting new financing statement.

### DIFF
--- a/ppr-ui/src/store/mutations/mutations-model.ts
+++ b/ppr-ui/src/store/mutations/mutations-model.ts
@@ -63,6 +63,7 @@ export const mutateLengthTrust = (state: StateIF, lengthTrust: LengthTrustIF) =>
 }
 
 export const mutateNewRegistration = (state: StateIF) => {
+  state.stateModel.registration.showStepErrors = false
   state.stateModel.registration.lengthTrust.valid = false
   state.stateModel.registration.lengthTrust.showInvalid = false
   state.stateModel.registration.lengthTrust.lifeInfinite = false


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8509

*Description of changes:*
Bug fix: reset stepper state when starting a new financing statement registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
