### PR TITLE
8818 8727 api correct expiry timestamps

### DIFF
--- a/ppr-api/report-templates/template-parts/registration/renewalStatement.html
+++ b/ppr-api/report-templates/template-parts/registration/renewalStatement.html
@@ -16,6 +16,8 @@
                 <div class="pt-2">
                     {% if change.lifeInfinite is defined and change.lifeInfinite %}
                         Infinite
+                    {% elif change.lifeYears is not defined or change.lifeYears == 0 %}
+                        180 Days
                     {% elif change.lifeYears is defined %}
                         {{change.lifeYears}} {% if change.lifeYears > 1 %} Years {% else %} Year {% endif %}
                     {% endif %}

--- a/ppr-api/src/ppr_api/models/financing_statement.py
+++ b/ppr-api/src/ppr_api/models/financing_statement.py
@@ -423,7 +423,7 @@ class FinancingStatement(db.Model):  # pylint: disable=too-many-instance-attribu
         statement.registration = [Registration.create_financing_from_json(json_data, account_id, user_id)]
         statement.life = statement.registration[0].life
         if reg_type == model_utils.REG_TYPE_REPAIRER_LIEN:
-            statement.expire_date = model_utils.now_ts_offset(model_utils.REPAIRER_LIEN_DAYS, True)
+            statement.expire_date = model_utils.expiry_dt_repairer_lien()
         elif statement.life and statement.life != model_utils.LIFE_INFINITE:
             statement.expire_date = model_utils.expiry_dt_from_years(statement.life)
 

--- a/ppr-api/src/ppr_api/reports/report.py
+++ b/ppr-api/src/ppr_api/reports/report.py
@@ -17,10 +17,10 @@ from http import HTTPStatus
 from pathlib import Path
 
 import pycountry
-import pytz
 import requests
 from flask import current_app, jsonify
 
+from ppr_api.models import utils as model_utils
 from ppr_api.utils.auth import jwt
 
 
@@ -567,9 +567,7 @@ class Report:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _to_report_datetime(date_time: str, include_time: bool = True):
         """Convert ISO formatted date time or date string to report format."""
-        utc_datetime = datetime.fromisoformat(date_time)
-        # local_datetime = datetime.fromtimestamp(utc_datetime.timestamp())
-        local_datetime = utc_datetime.astimezone(pytz.timezone('Canada/Pacific'))
+        local_datetime = model_utils.to_local_timestamp(datetime.fromisoformat(date_time))
         if include_time:
             timestamp = local_datetime.strftime('%B %-d, %Y at %-I:%M:%S %p Pacific time')
             if timestamp.find(' AM ') > 0:

--- a/ppr-api/src/ppr_api/utils/validators/financing_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/financing_validator.py
@@ -16,6 +16,8 @@
 Validation includes rules captured in the PPR Registration Types spreadsheet:
 https://docs.google.com/spreadsheets/d/18eTumnf5H6TG2qWXwXJ_iAA-Gc7iNMpnm0ly7ctceTI/edit#gid=0
 """
+# pylint: disable=superfluous-parens
+
 from ppr_api.models import utils as model_utils
 from ppr_api.models.registration import MiscellaneousTypes, PPSATypes
 
@@ -188,7 +190,7 @@ def validate_rl(json_data, reg_type: str):
 def get_registration_class(reg_type: str):
     """Derive the registration class from the registration type."""
     try:
-        if reg_class := model_utils.REG_TYPE_TO_REG_CLASS[reg_type] in \
+        if (reg_class := model_utils.REG_TYPE_TO_REG_CLASS[reg_type]) in \
                 (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC, model_utils.REG_CLASS_PPSA):
             return reg_class
 

--- a/ppr-api/src/ppr_api/utils/validators/financing_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/financing_validator.py
@@ -188,8 +188,8 @@ def validate_rl(json_data, reg_type: str):
 def get_registration_class(reg_type: str):
     """Derive the registration class from the registration type."""
     try:
-        if (reg_class := model_utils.REG_TYPE_TO_REG_CLASS[reg_type]) in \
-            (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC, model_utils.REG_CLASS_PPSA):
+        if reg_class := model_utils.REG_TYPE_TO_REG_CLASS[reg_type] in \
+                (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC, model_utils.REG_CLASS_PPSA):
             return reg_class
 
         return ''

--- a/ppr-api/test_data/postgres_data_files/test0016.sql
+++ b/ppr-api/test_data/postgres_data_files/test0016.sql
@@ -1,0 +1,185 @@
+-- TEST0016 SA and RL expiry date tests: financing statements with multiple renewals. 
+-- SA begin
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000021, 'D-T-0016', 'PS12345', timestamp with time zone '2021-09-03 12:00:00-07' at time zone 'utc', 
+         'PPSALIEN', 'SA', 'TEST0016', null, '{}');
+INSERT INTO financing_statements(id, state_type, expire_date, life, discharged, renewed)
+  VALUES(200000010, 'ACT', timestamp with time zone '2026-09-03 23:59:59-07' at time zone 'utc', 5, 'N' , null)
+;
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000018, 200000010, 'TEST0016', null, 'SA', 'PPSALIEN', 
+           timestamp with time zone '2021-09-03 12:00:00-07' at time zone 'utc', 200000021, 5,
+           null, null, 'PS12345', 'TEST-SA-0016', null, null)
+;
+INSERT INTO trust_indentures(id, registration_id, financing_id, trust_indenture, registration_id_end)
+  VALUES(200000008, 200000018, 200000010, 'Y', null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000020, 'TEST-0016', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000047, 'RG', 200000018, 200000010, null, null, 'TEST', '16', 'REGISTERING', null,
+           null, 200000020)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id, business_srch_key)
+    VALUES(200000048, 'DB', 200000018, 200000010, null, null, null, null, null, 'TEST 16 DEBTOR INC.',
+           null, 200000020, searchkey_business_name('TEST 16 DEBTOR INC.'))
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000049, 'SP', 200000018, 200000010, null, null, null, null, null, 'TEST 16 SECURED PARTY',
+           null, 200000020)
+;
+INSERT INTO serial_collateral(id, serial_type, registration_id, financing_id, registration_id_end,
+                              year, make, model, serial_number, mhr_number, srch_vin)
+  VALUES(200000022, 'MV', 200000018, 200000010, null, 2012, 'JAGUAR', 'S-TYPE', 'VIN123434344', null,
+         searchkey_vehicle('VIN123434344'))
+;
+
+-- Renewal #1 10 years
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000022, 'D-T-0016R1', 'PS12345', timestamp with time zone '2021-09-03 13:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0016R1', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000019, 200000010, 'TEST0016R1', 'TEST0016', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-09-03 13:00:00-07' at time zone 'utc', 200000022, 10,
+           null, null, 'PS12345', 'TEST-REN-0016-1', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000021, 'TEST-0016R1', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000050, 'RG', 200000019, 200000010, null, null, 'TEST-0016-RENEWAL', '16-1', 'REGISTERING', null,
+           null, 200000021)
+;
+
+-- Renewal #2 5 years
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000023, 'D-T-0016R2', 'PS12345', timestamp with time zone '2021-09-03 14:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0016R2', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000020, 200000010, 'TEST0016R2', 'TEST0016', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-09-03 14:00:00-07' at time zone 'utc', 200000023, 5,
+           null, null, 'PS12345', 'TEST-REN-0016-2', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000022, 'TEST-00R5', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000051, 'RG', 200000020, 200000010, null, null, 'TEST-0016-RENEWAL', '16-2', 'REGISTERING', null,
+           null, 200000022)
+;
+
+UPDATE financing_statements
+   SET expire_date = expire_date + interval '15 years', life = 20
+ WHERE id = 200000010
+;
+
+-- SA end
+
+-- RL begin
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000024, 'D-T-0017', 'PS12345', timestamp with time zone '2021-08-31 12:00:00-07' at time zone 'utc', 
+         'PPSALIEN', 'RL', 'TEST0017', null, '{}');
+INSERT INTO financing_statements(id, state_type, expire_date, life, discharged, renewed)
+  VALUES(200000011, 'ACT', timestamp with time zone '2022-02-27 23:59:59-07' at time zone 'utc', 0, 'N' , null)
+;
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000021, 200000011, 'TEST0017', null, 'RL', 'PPSALIEN', 
+           timestamp with time zone '2021-08-31 12:00:00-07' at time zone 'utc', 200000024, 0,
+           '1000.00', current_timestamp, 'PS12345', 'TEST-RL-0017', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000023, 'TEST-0017', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000052, 'RG', 200000021, 200000011, null, null, 'TEST', '17', 'REGISTERING', null,
+           null, 200000023)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id, business_srch_key)
+    VALUES(200000053, 'DB', 200000021, 200000011, null, null, null, null, null, 'TEST 17 DEBTOR INC.',
+           null, 200000023, searchkey_business_name('TEST 17 DEBTOR INC.'))
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000054, 'SP', 200000021, 200000011, null, null, null, null, null, 'TEST 17 SECURED PARTY',
+           null, 200000023)
+;
+INSERT INTO serial_collateral(id, serial_type, registration_id, financing_id, registration_id_end,
+                              year, make, model, serial_number, mhr_number, srch_vin)
+  VALUES(200000023, 'MV', 200000021, 200000011, null, 2012, 'JAGUAR', 'R-TYPE', 'VIN123434366', null,
+         searchkey_vehicle('VIN123434366'))
+;
+
+-- Renewal #1
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000025, 'D-T-0017R1', 'PS12345', timestamp with time zone '2021-08-31 13:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0017R1', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000022, 200000011, 'TEST0017R1', 'TEST0017', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-08-31 13:00:00-07' at time zone 'utc', 200000025, 0,
+           null, null, 'PS12345', 'TEST-REN-0017-1', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000024, 'TEST-0017R1', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000055, 'RG', 200000022, 200000011, null, null, 'TEST-0017-RENEWAL', '17-1', 'REGISTERING', null,
+           null, 200000024)
+;
+
+-- Renewal #2
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000026, 'D-T-0017R2', 'PS12345', timestamp with time zone '2021-08-31 14:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0017R2', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000023, 200000011, 'TEST0017R2', 'TEST0017', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-08-31 14:00:00-07' at time zone 'utc', 200000026, 0,
+           null, null, 'PS12345', 'TEST-REN-0017-2', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000025, 'TEST-0017R2', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000056, 'RG', 200000023, 200000011, null, null, 'TEST-0017-RENEWAL', '17-2', 'REGISTERING', null,
+           null, 200000025)
+;
+
+UPDATE financing_statements
+   SET expire_date = expire_date + interval '360 days'
+ WHERE id = 200000011
+;
+UPDATE financing_statements
+   SET expire_date = expire_date + interval '1 hours'
+ WHERE id = 200000011
+;
+
+-- RL end
+
+-- TEST0016 end

--- a/ppr-api/tests/unit/api/test_party_codes.py
+++ b/ppr-api/tests/unit/api/test_party_codes.py
@@ -34,7 +34,7 @@ TEST_DATA_PARTY_CODE = [
 ]
 # testdata pattern is ({description}, {is staff}, {include account}, {response status}, {role}, {search_value})
 TEST_DATA_HEAD_OFFICE = [
-    ('Valid non-staff code exists', False, True, HTTPStatus.OK, PPR_ROLE, '9999'),
+    ('Valid non-staff code exists', False, True, HTTPStatus.OK, PPR_ROLE, '999'),
     ('Valid non-staff name exists', False, True, HTTPStatus.OK, PPR_ROLE, 'rbc royal bank'),
     ('Valid non-staff non-existent', False, True, HTTPStatus.OK, PPR_ROLE, '8999'),
     ('Non-staff missing account ID', False, False, HTTPStatus.BAD_REQUEST, PPR_ROLE, '9999'),

--- a/ppr-api/tests/unit/models/test_client_code.py
+++ b/ppr-api/tests/unit/models/test_client_code.py
@@ -26,11 +26,31 @@ TEST_DATA_PARTY_CODE = [
     ('Exists', True, '200000000'),
     ('Does not exist', False, '12345')
 ]
-# testdata pattern is ({description}, {exists}, {search_value}, {results_size}, {fuzzy_search})
+# testdata pattern is ({description}, {results_size}, {search_value})
+TEST_DATA_ACCOUNT_NUMBER = [
+    ('No results', 0, 99999),
+    ('Results', 6, 12345)
+]
+# testdata pattern is ({description}, {results_size}, {search_value})
+TEST_DATA_BRANCH_CODE = [
+    ('No results exact', 0, '020'),
+    ('No results start 3', 0, '998'),
+    ('Results start 3', 4, '999'),
+    ('No results start 4', 0, '9998'),
+    ('Results start 4', 4, '9999'),
+    ('Results start 5', 4, '99990'),
+    ('Results start 6', 4, '999900'),
+    ('Results start 7', 4, '9999000'),
+    ('Results start 8 exact', 1, '99990002')
+]
+# testdata pattern is ({description}, {results_size}, {search_value}, {fuzzy_search})
 TEST_DATA_HEAD_OFFICE = [
-    ('Code exists', 4, '9999', False),
+    ('Code exists 3 digits', 4, '999', False),
+    ('No code exists 3 digits', 0, '998', False),
+    ('Code exists 4 digits', 4, '9999', False),
+    ('No code exists 4', 0, '9998', False),
+    ('Code exists 5 digits', 4, '99990', False),
     ('Name exists', 4, 'rbc royal bank', False),
-    ('Code does not exist', 0, '9998', False),
     ('Name does not exist', 0, 'XXX royal bank', False),
     ('Fuzzy name search exists', 4, 'rbc', True),
     ('Fuzzy name search does not exist', 0, 'xxx', True),
@@ -59,8 +79,56 @@ def test_find_party_code(session, desc, exists, search_value):
         assert not party
 
 
+@pytest.mark.parametrize('desc,results_size,search_value', TEST_DATA_BRANCH_CODE)
+def test_find_by_branch_code(session, desc, results_size, search_value):
+    """Assert that find client parties by branch code matching contains all expected elements."""
+    parties = ClientCode.find_by_branch_start(search_value)
+    if results_size > 0:
+        assert parties
+        assert len(parties) >= results_size
+        for party in parties:
+            assert len(party['code']) >= 5
+            assert party['businessName']
+            assert party['address']
+            assert party['address']['street']
+            assert party['address']['city']
+            assert party['address']['region']
+            assert party['address']['postalCode']
+            assert party['contact']
+            assert party['contact']['name']
+            assert party['contact']['areaCode']
+            assert party['contact']['phoneNumber']
+            assert party['emailAddress']
+    else:
+        assert not parties
+
+
+@pytest.mark.parametrize('desc,results_size,search_value', TEST_DATA_ACCOUNT_NUMBER)
+def test_find_by_account_number(session, desc, results_size, search_value):
+    """Assert that find client parties by account number matching contains all expected elements."""
+    parties = ClientCode.find_by_account_number(search_value)
+    if results_size > 0:
+        assert parties
+        assert len(parties) >= results_size
+        for party in parties:
+            assert len(party['code']) >= 5
+            assert party['businessName']
+            assert party['address']
+            assert party['address']['street']
+            assert party['address']['city']
+            assert party['address']['region']
+            assert party['address']['postalCode']
+            assert party['contact']
+            assert party['contact']['name']
+            assert party['contact']['areaCode']
+            assert party['contact']['phoneNumber']
+            assert party['emailAddress']
+    else:
+        assert not parties
+
+
 @pytest.mark.parametrize('desc,results_size,search_value,fuzzy_search', TEST_DATA_HEAD_OFFICE)
-def test_find_head_office_codes(session, desc, results_size, search_value, fuzzy_search):
+def test_find_by_head_office(session, desc, results_size, search_value, fuzzy_search):
     """Assert that find client party by head office contains all expected elements."""
     parties = ClientCode.find_by_head_office(search_value, fuzzy_search)
     if results_size > 0:

--- a/ppr-api/tests/unit/models/test_registration.py
+++ b/ppr-api/tests/unit/models/test_registration.py
@@ -63,6 +63,15 @@ TEST_LIFE_EXPIRY_DATA = [
     ('OT', None, True, model_utils.LIFE_INFINITE),
     ('ML', 1, False, model_utils.LIFE_INFINITE),
 ]
+# testdata pattern is ({reg_num}, {reg_type}, {expected_ts})
+TEST_EXPIRY_DATA = [
+    ('TEST0016', 'SA', '2041-09-04T06:59:59+00:00'),
+    ('TEST0016R1', 'RE', '2036-09-04T06:59:59+00:00'),
+    ('TEST0016R2', 'RE', '2041-09-04T06:59:59+00:00'),
+    ('TEST0017', 'RL', '2023-02-23T07:59:59+00:00'),
+    ('TEST0017R1', 'RE', '2022-08-27T06:59:59+00:00'),
+    ('TEST0017R2', 'RE', '2023-02-23T07:59:59+00:00')
+]
 
 
 def test_find_by_id(session):
@@ -581,3 +590,13 @@ def test_life_years(session, reg_type, life, life_infinite, expected_life):
     json_data['lifeInfinite'] = life_infinite
     registration = Registration.create_financing_from_json(json_data, 'PS12345', 'TESTID')
     assert registration.life == expected_life
+
+
+@pytest.mark.parametrize('reg_num, reg_type, expiry_ts', TEST_EXPIRY_DATA)
+def test_expiry(session, reg_num, reg_type, expiry_ts):
+    """Assert that creating a registration with renewals return the expected expiry date."""
+    registration = Registration.find_by_registration_number(reg_num, 'PS12345', True)
+    json_data = registration.json if reg_type == 'RE' else registration.financing_statement.json
+    assert 'expiryDate' in json_data
+    print(json_data['expiryDate'] + ' ' + expiry_ts)
+    assert json_data['expiryDate'] == expiry_ts

--- a/ppr-api/tests/unit/models/test_utils.py
+++ b/ppr-api/tests/unit/models/test_utils.py
@@ -12,10 +12,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test Suite to ensure the datetime utility functions are working as expected."""
-
 from datetime import timedelta as _timedelta
 
+import pytest
+
 from ppr_api.models import utils as model_utils
+
+
+# testdata pattern is ({registration_ts}, {years}, {expiry_ts})
+TEST_DATA_EXPIRY = [
+    ('2021-08-31T00:00:01-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T01:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T04:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T08:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T12:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T16:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T16:01:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T17:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T17:01:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T18:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T19:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T20:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T21:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T22:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T23:00:00-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-08-31T23:59:59-07:00', 1, '2022-09-01T06:59:59+00:00'),
+    ('2021-09-01T00:00:01-07:00', 4, '2025-09-02T06:59:59+00:00'),
+    ('2021-11-30T00:00:01-08:00', 4, '2025-12-01T07:59:59+00:00')
+]
+# testdata pattern is ({registration_ts}, {expiry_ts})
+TEST_DATA_EXPIRY_RL = [
+    ('2021-08-31T00:00:01-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T01:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T04:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T08:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T12:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T16:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T16:01:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T17:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T18:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T19:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T20:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T21:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T22:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T23:00:00-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-08-31T23:59:59-07:00', '2022-02-28T07:59:59+00:00'),
+    ('2021-01-01T01:00:00-07:00', '2021-07-01T06:59:59+00:00')
+]
+# testdata pattern is ({registration_ts}, {add_1}, {add_2}, {add_3}, {expiry_ts})
+TEST_DATA_EXPIRY_ADD = [
+    ('2021-08-31T00:00:01-07:00', 10, 5, 2, '2038-09-01T06:59:59+00:00'),
+    ('2021-01-31T00:00:01-08:00', 2, 3, 5, '2031-02-01T07:59:59+00:00')
+]
+# testdata pattern is ({desc}, {registration_ts}, {renew_count}, {expiry_ts})
+TEST_DATA_EXPIRY_RENEW_RL = [
+    ('Registration', '2021-08-31T00:00:01-07:00', 0, '2022-02-28T07:59:59+00:00'),
+    ('1 renewal', '2021-08-31T00:00:01-07:00', 1, '2022-08-27T06:59:59+00:00'),
+    ('2 renewals', '2021-08-31T00:00:01-07:00', 2, '2023-02-23T07:59:59+00:00')
+]
+# testdata pattern is ({desc}, {registration_ts}, {hour})
+TEST_DATA_EXPIRY_REGISTRATION = [
+    ('Daylight savings', '2021-08-31T12:00:01-07:00', 5, 6),
+    ('No daylight savings', '2021-01-31T13:00:01-07:00', 10, 7)
+]
+
+
+@pytest.mark.parametrize('registration_ts,offset,expiry_ts', TEST_DATA_EXPIRY)
+def test_expiry_date(session, registration_ts, offset, expiry_ts):
+    """Assert that computing expiry ts from registraton ts works as expected."""
+    # reg_ts = model_utils.ts_from_iso_format(registration_ts)
+    expiry_test = model_utils.expiry_dt_from_years(offset, registration_ts)
+    expiry_iso = model_utils.format_ts(expiry_test)
+    # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
+    assert expiry_ts == expiry_iso
+
+
+@pytest.mark.parametrize('registration_ts,expiry_ts', TEST_DATA_EXPIRY_RL)
+def test_expiry_date_rl(session, registration_ts, expiry_ts):
+    """Assert that computing an RL expiry ts from registraton ts works as expected."""
+    reg_ts = model_utils.ts_from_iso_format(registration_ts)
+    expiry_test = model_utils.expiry_dt_repairer_lien(reg_ts)
+    expiry_iso = model_utils.format_ts(expiry_test)
+    # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
+    assert expiry_ts == expiry_iso
+
+
+@pytest.mark.parametrize('registration_ts,add_1,add_2,add_3,expiry_ts', TEST_DATA_EXPIRY_ADD)
+def test_expiry_date_add(session, registration_ts, add_1, add_2, add_3, expiry_ts):
+    """Assert that computing an renewal non-RL expiry ts from registraton ts works as expected."""
+    reg_ts = model_utils.ts_from_iso_format(registration_ts)
+    expiry_add_1 = model_utils.expiry_dt_from_years(add_1, registration_ts)
+    assert expiry_add_1.year - add_1 == reg_ts.year
+    assert expiry_add_1.hour in (6, 7)
+    assert expiry_add_1.minute == 59
+    assert expiry_add_1.second == 59
+    expiry_add_2 = model_utils.expiry_dt_add_years(expiry_add_1, add_2)
+    assert expiry_add_2.year - expiry_add_1.year == add_2
+    assert expiry_add_2.hour in (6, 7)
+    assert expiry_add_2.minute == 59
+    assert expiry_add_2.second == 59
+    expiry_add_3 = model_utils.expiry_dt_add_years(expiry_add_2, add_3)
+    assert expiry_add_3.year - expiry_add_2.year == add_3
+    assert expiry_add_3.hour in (6, 7)
+    assert expiry_add_3.minute == 59
+    assert expiry_add_3.second == 59
+    expiry_iso = model_utils.format_ts(expiry_add_3)
+    # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
+    assert expiry_ts == expiry_iso
+
+
+@pytest.mark.parametrize('desc,registration_ts,renew_count,expiry_ts', TEST_DATA_EXPIRY_RENEW_RL)
+def test_expiry_date_renew_rl(session, desc, registration_ts, renew_count, expiry_ts):
+    """Assert that computing multiple RL renewal expiry ts from registration ts works as expected."""
+    reg_ts = model_utils.ts_from_iso_format(registration_ts)
+    expiry_test = model_utils.expiry_dt_repairer_lien(reg_ts)
+    # print(model_utils.format_ts(expiry_test))
+    if renew_count > 0:
+        for x in range(renew_count):
+            expiry_test = model_utils.expiry_dt_repairer_lien(expiry_test)
+            # print(model_utils.format_ts(expiry_test))
+
+    expiry_iso = model_utils.format_ts(expiry_test)
+    assert expiry_ts == expiry_iso
 
 
 def test_expiry_dt_from_years():
@@ -25,10 +143,10 @@ def test_expiry_dt_from_years():
     print('Expiry timestamp: ' + model_utils.format_ts(expiry_ts))
     print('Now timestamp: ' + model_utils.format_ts(now_ts))
     assert (expiry_ts.year - now_ts.year) == 5
-    assert expiry_ts.hour == 23
+    assert expiry_ts.hour in (6, 7)
     assert expiry_ts.minute == 59
     assert expiry_ts.second == 59
-    assert expiry_ts.day == now_ts.day
+    assert expiry_ts.day in (1, now_ts.day, (now_ts.day + 1))
     assert expiry_ts.month in (now_ts.month, (now_ts.month + 1))
 
 
@@ -49,12 +167,12 @@ def test_ts_from_iso_format():
     assert test_ts.hour == 23
 
     test_ts = model_utils.ts_from_iso_format('2021-02-16T13:00:00-08:00')
-    print('Test timestamp: ' + model_utils.format_ts(test_ts))
+    # print('Test timestamp: ' + model_utils.format_ts(test_ts))
     assert test_ts.day == 16
     assert test_ts.hour == 21
 
     test_ts = model_utils.ts_from_iso_format('2021-03-31T23:00:00-08:00')
-    print('Test timestamp: ' + model_utils.format_ts(test_ts))
+    # print('Test timestamp: ' + model_utils.format_ts(test_ts))
     assert test_ts.month == 4
     assert test_ts.day == 1
     assert test_ts.hour == 7
@@ -94,32 +212,32 @@ def test_today_ts_offset():
     """Assert that adjusting UTC today by a number of days is performing as expected."""
     test_now_ts = model_utils.now_ts_offset(7, False)
     test_today_ts = model_utils.today_ts_offset(7, False)
-    print('test now - 7 days: ' + model_utils.format_ts(test_now_ts))
-    print('test today - 7 days: ' + model_utils.format_ts(test_today_ts))
+    # print('test now - 7 days: ' + model_utils.format_ts(test_now_ts))
+    # print('test today - 7 days: ' + model_utils.format_ts(test_today_ts))
     assert test_today_ts.hour == 0
     assert test_today_ts.minute == 0
     assert test_today_ts.second == 0
     assert test_today_ts < test_now_ts
 
 
-def test_expiry_dt_add_years():
-    """Assert that adding years to an expiry date is performing as expected."""
-    expiry_ts = model_utils.expiry_dt_from_years(1)
-    add_ts = model_utils.expiry_dt_add_years(expiry_ts, 4)
-    print('Initial expiry: ' + model_utils.format_ts(expiry_ts))
-    print('Updated expiry: ' + model_utils.format_ts(add_ts))
-    assert (add_ts.year - expiry_ts.year) == 4
+def test_expiry_dt_repairer_lien_now():
+    """Assert that the computed expiry date for a repairer's lien performs as expected."""
+    test_ts = model_utils.expiry_dt_repairer_lien()
+    now_ts = model_utils.now_ts()
+    delta = test_ts - now_ts
+    assert delta.days == model_utils.REPAIRER_LIEN_DAYS
+    assert test_ts.hour in (6, 7)
+    assert test_ts.minute == 59
+    assert test_ts.second == 59
 
 
-def test_expiry_dt_from_renewal():
-    """Assert that creating a UTC datetime object from an ISO date-time formatted string is performing as expected."""
-    test_ts = model_utils.ts_from_iso_format('2021-02-16T08:00:00+00:00')
-    infinite_expiry = model_utils.expiry_dt_from_renewal(test_ts, 99)
-    # print('Renewal infinite expiry: ' + infinite_expiry)
-    assert infinite_expiry == 'Never'
-    rl_expiry = model_utils.expiry_dt_from_renewal(test_ts, 0)
-    # print('Renewal RL expiry: ' + rl_expiry)
-    assert rl_expiry == '2021-08-15T23:59:59+00:00'
-    five_year_expiry = model_utils.expiry_dt_from_renewal(test_ts, 5)
-    # print('Renewal 5 year expiry: ' + five_year_expiry)
-    assert five_year_expiry == '2026-02-16T23:59:59+00:00'
+@pytest.mark.parametrize('desc,registration_ts,life_years,hour', TEST_DATA_EXPIRY_REGISTRATION)
+def test_expiry_dt_from_registration(session, desc, registration_ts, life_years, hour):
+    """Assert that creating an expiry timestamp from a registration timestamp is performing as expected."""
+    test_ts = model_utils.ts_from_iso_format(registration_ts)
+    expiry_ts = model_utils.expiry_dt_from_registration(test_ts, life_years)
+    print(model_utils.format_ts(expiry_ts))
+    assert expiry_ts.year - test_ts.year == life_years
+    assert expiry_ts.hour == hour
+    assert expiry_ts.minute == 59
+    assert expiry_ts.second == 59


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8818

*Description of changes:*
- Store expiry timestamps correctly as UTC regardless of local time of day.
- Display expiry timestamps correctly in reports as local date and time, allowing for daylight savings.
- Update unit tests.
- For renewals, add to existing expiry for all applicable registration types including repairer's lien.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
