### PR TITLE
8557 display middle name in search query results.

### DIFF
--- a/ppr-ui/src/components/tables/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/SearchedResults.vue
@@ -70,7 +70,10 @@
             {{ item.vehicleCollateral.make }} {{ item.vehicleCollateral.model }}
           </template>
           <template v-slot:[`item.debtor.personName`]="{ item }">
-            {{ item.debtor.personName.first }} {{ item.debtor.personName.second }} {{ item.debtor.personName.last }}
+            {{ item.debtor.personName.first }}
+            {{ item.debtor.personName.second }}
+            {{ item.debtor.personName.middle }}
+            {{ item.debtor.personName.last }}
           </template>
           <template v-slot:[`item.debtor.birthDate`]="{ item }">
             {{ displayDate(item.debtor.birthDate) }}


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8557

*Description of changes:*
Bug fix to display the debtor middle name in the individual debtor search results.
Background:
There is an inconsistency in the representation of a middle name in the API. Individual Debtor search criteria uses second name; everywhere else in the API uses middle name. The Search History table displays criteria values ("second" name); the search query results uses "middle" name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
