### PR TITLE
API amendments add new change types.

### DIFF
--- a/ppr-api/migrations/versions/ca3675d682cc_initial_migration.py
+++ b/ppr-api/migrations/versions/ca3675d682cc_initial_migration.py
@@ -868,6 +868,42 @@ def upgrade():
             'registration_type': 'RE',
             'registration_act': 'PPSA SECURITY ACT',
             'registration_desc': 'RENEWAL'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AA',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'ADDITION OF COLLATERAL/PROCEEDS'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AR',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'DEBTOR RELEASE'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AD',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'DEBTOR TRANSFER'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AP',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'PARTIAL DISCHARGE'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AS',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'SECURED PARTY TRANSFER'
+        },
+        {
+            'registration_type_cl': 'AMENDMENT',
+            'registration_type': 'AU',
+            'registration_act': 'PPSA SECURITY ACT',
+            'registration_desc': 'SUBSTITUTION OF COLLATERAL'
         }
       ]
     )

--- a/ppr-api/report-templates/financingStatement.html
+++ b/ppr-api/report-templates/financingStatement.html
@@ -30,7 +30,7 @@
       <table class="registration-header-table" role="presentation">
         <tr>
           <td>Base Registration Number: {{ baseRegistrationNumber }}</td>
-          <td>
+          <td style="padding-bottom: 2px;">
             {% if statusType == 'HDC' %} 
               <span class="badge-gold">DISCHARGED</span>
             {% elif statusType == 'HEX' %} 

--- a/ppr-api/report-templates/template-parts/style.html
+++ b/ppr-api/report-templates/template-parts/style.html
@@ -899,7 +899,7 @@
 		font-weight: bold;
 		color: #313132;
 		padding: 3px 8px !important;
-		margin: 0 3px !important;
+		margin: 0 3px 0 0 !important; /* 0px 8px !important; */
 		border-radius: 4px;
 		background-color: #e7e7e7;
 	}

--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -51,4 +51,4 @@ sentry-sdk==1.1.0
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.5
-git+https://github.com/bcgov/registry-schemas.git@1.4.5#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.4.6#egg=registry_schemas

--- a/ppr-api/requirements/bcregistry-libraries.txt
+++ b/ppr-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.4.5#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.4.6#egg=registry_schemas

--- a/ppr-api/tests/unit/models/test_trust_indenture.py
+++ b/ppr-api/tests/unit/models/test_trust_indenture.py
@@ -33,15 +33,14 @@ def test_find_by_id(session):
     assert trust_indenture.trust_indenture == 'Y'
 
 
-def test_find_by_registration_num(session):
-    """Assert that find trust indenture by registration number contains all expected elements."""
-    trust_indenture = TrustIndenture.find_by_registration_number('TEST0001')
+def test_find_by_registration_id(session):
+    """Assert that find trust indenture by registration ID contains all expected elements."""
+    trust_indenture = TrustIndenture.find_by_registration_id(200000000)
     assert trust_indenture
-    assert len(trust_indenture) == 1
-    assert trust_indenture[0].id == 200000000
-    assert trust_indenture[0].registration_id == 200000000
-    assert trust_indenture[0].financing_id == 200000000
-    assert trust_indenture[0].trust_indenture == 'Y'
+    assert trust_indenture.id == 200000000
+    assert trust_indenture.registration_id == 200000000
+    assert trust_indenture.financing_id == 200000000
+    assert trust_indenture.trust_indenture == 'Y'
 
 
 def test_find_by_financing_id(session):
@@ -67,9 +66,9 @@ def test_find_by_financing_id_invalid(session):
     assert not trust_indenture
 
 
-def test_find_by_reg_num_invalid(session):
-    """Assert that find trust indenture by non-existent registration number returns the expected result."""
-    trust_indenture = TrustIndenture.find_by_registration_number('300000000')
+def test_find_by_reg_id_invalid(session):
+    """Assert that find trust indenture by non-existent registration ID returns the expected result."""
+    trust_indenture = TrustIndenture.find_by_registration_id('300000000')
     assert not trust_indenture
 
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#9345

*Description of changes:*
- API update to conditionally set the registration type to one of the new change types from the amendment data
- New schema version 1.4.6 includes new change types and amendment description is optional.
- Also update API amendment registration to add/remove a trust indenture (missed in initial implementation).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
