### PR TITLE
9181 - remove serial number validation when manufactured home number entered

### DIFF
--- a/ppr-ui/src/components/collateral/vehicleCollateral/EditCollateral.vue
+++ b/ppr-ui/src/components/collateral/vehicleCollateral/EditCollateral.vue
@@ -258,6 +258,10 @@ export default defineComponent({
         validateSerial(currentVehicle.value)
       } else {
         validateInput(fieldname, currentVehicle.value[fieldname])
+        // remove serial number validation if manufactured home number entered
+        if (fieldname === 'manufacturedHomeRegistrationNumber') {
+          validateSerial(currentVehicle.value)
+        }
       }
     }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9181

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
