### PR TITLE
UI API update account name in reports.

### DIFF
--- a/ppr-api/src/ppr_api/reports/__init__.py
+++ b/ppr-api/src/ppr_api/reports/__init__.py
@@ -14,12 +14,15 @@ from http import HTTPStatus
 from flask import jsonify
 from flask_babel import _
 
+from ppr_api.resources.utils import get_account_name
+
 from .report import Report, ReportTypes
 
 
-def get_pdf(report_data, account_id, report_type=None, account_name=None):
+def get_pdf(report_data, account_id, report_type=None, token=None):
     """Generate a PDF of the provided report type using the provided data."""
     try:
+        account_name = get_account_name(token)
         return Report(report_data, account_id, report_type, account_name).get_pdf()
     except FileNotFoundError:
         # We don't have a template for it, so it must only be available on paper.

--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -114,9 +114,9 @@ class FinancingResource(Resource):
             statement = pay_and_save_financing(request_json, account_id)
 
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(statement.json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(statement.json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return statement.json, HTTPStatus.CREATED
 
@@ -170,9 +170,9 @@ class GetFinancingResource(Resource):
             else:
                 statement.current_view_json = current_param
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(statement.json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(statement.json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return statement.json, HTTPStatus.OK
 
@@ -238,12 +238,11 @@ class AmendmentResource(Resource):
 
             response_json = registration.verification_json('amendmentRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
                 return get_pdf(response_json,
                                account_id,
                                ReportTypes.FINANCING_STATEMENT_REPORT.value,
-                               token['name'])
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.CREATED
 
@@ -286,9 +285,9 @@ class GetAmendmentResource(Resource):
 
             response_json = statement.verification_json('amendmentRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.OK
 
@@ -301,7 +300,7 @@ class GetAmendmentResource(Resource):
 @cors_preflight('POST,OPTIONS')
 @API.route('/<path:registration_num>/changes', methods=['POST', 'OPTIONS'])
 class ChangeResource(Resource):
-    """Resource to register an change statement by registration number."""
+    """Resource to fetch a change statement by registration number."""
 
     @staticmethod
     @cors.crossdomain(origin='*')
@@ -354,9 +353,9 @@ class ChangeResource(Resource):
 
             response_json = registration.verification_json('changeRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.CREATED
 
@@ -399,9 +398,9 @@ class GetChangeResource(Resource):
 
             response_json = statement.verification_json('changeRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.OK
 
@@ -464,9 +463,9 @@ class RenewalResource(Resource):
 
             response_json = registration.verification_json('renewalRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.CREATED
 
@@ -509,9 +508,9 @@ class GetRenewalResource(Resource):
 
             response_json = statement.verification_json('renewalRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value, token['name'])
+                return get_pdf(response_json, account_id, ReportTypes.FINANCING_STATEMENT_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.OK
 
@@ -574,12 +573,11 @@ class DischargeResource(Resource):
                                         account_id)
             response_json = registration.verification_json('dischargeRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
                 return get_pdf(response_json,
                                account_id,
                                ReportTypes.FINANCING_STATEMENT_REPORT.value,
-                               token['name'])
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.CREATED
 
@@ -622,12 +620,11 @@ class GetDischargeResource(Resource):
 
             response_json = statement.verification_json('dischargeRegistrationNumber')
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
                 return get_pdf(response_json,
                                account_id,
                                ReportTypes.FINANCING_STATEMENT_REPORT.value,
-                               token['name'])
+                               jwt.get_token_auth_header())
 
             return response_json, HTTPStatus.OK
 

--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -17,7 +17,7 @@
 
 from http import HTTPStatus
 
-from flask import request, current_app, jsonify, g
+from flask import request, current_app, jsonify
 from flask_restx import Namespace, Resource, cors
 from registry_schemas import utils as schema_utils
 
@@ -73,9 +73,9 @@ class SearchResultsResource(Resource):
 
             response_data = search_detail.json
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_data, account_id, ReportTypes.SEARCH_DETAIL_REPORT.value, token['name'])
+                return get_pdf(response_data, account_id, ReportTypes.SEARCH_DETAIL_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return jsonify(response_data), HTTPStatus.OK
 
@@ -110,9 +110,9 @@ class SearchResultsResource(Resource):
 
             response_data = search_detail.json
             if resource_utils.is_pdf(request):
-                token = g.jwt_oidc_token_info
                 # Return report if request header Accept MIME type is application/pdf.
-                return get_pdf(response_data, account_id, ReportTypes.SEARCH_DETAIL_REPORT.value, token['name'])
+                return get_pdf(response_data, account_id, ReportTypes.SEARCH_DETAIL_REPORT.value,
+                               jwt.get_token_auth_header())
 
             return jsonify(response_data), HTTPStatus.OK
 

--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from flask import jsonify, current_app
 
 from ppr_api.exceptions import BusinessException
+from ppr_api.services.authz import user_orgs
 from ppr_api.utils.validators import financing_validator, party_validator, registration_validator
 
 
@@ -160,3 +161,15 @@ def validate_delete_ids(json_data, financing_statement):
             error=error_msg,
             status_code=HTTPStatus.BAD_REQUEST
         )
+
+
+def get_account_name(token: str, account_id: str = None):
+    """Lookup the account organization name from the user token with an auth api call."""
+    orgs = user_orgs(token)
+    if orgs and 'orgs' in orgs:
+        if (len(orgs) == 1 or not account_id):
+            return orgs['orgs'][0]['name']
+        for org in orgs:
+            if org['id'] == int(account_id):
+                return org['name']
+    return None

--- a/ppr-api/tests/unit/api/test_utils.py
+++ b/ppr-api/tests/unit/api/test_utils.py
@@ -1,0 +1,50 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the party-codes endpoint.
+
+Test-Suite to ensure that the /party-codes endpoint is working as expected.
+"""
+import pytest
+from flask import current_app
+
+from ppr_api.resources.utils import get_account_name
+from ppr_api.services.authz import PPR_ROLE
+from tests.unit.services.utils import helper_create_jwt
+
+
+MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
+# testdata pattern is ({description}, {account id}, {has name})
+TEST_USER_ORGS_DATA_JSON = [
+    ('Valid no account', None, True),
+    ('Valid account', '2617', True),
+    ('No token', '2617', False),
+]
+
+
+@pytest.mark.parametrize('desc, account_id, has_name', TEST_USER_ORGS_DATA_JSON)
+def test_get_account_name(session, client, jwt, desc, account_id, has_name):
+    """Assert that a get user profile returns the expected response code and data."""
+    # setup
+    current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
+    token = helper_create_jwt(jwt, [PPR_ROLE]) if has_name else None
+
+    # test
+    name = get_account_name(token, account_id)
+
+    # check
+    if has_name:
+        assert name
+    else:
+        assert not name

--- a/ppr-api/tests/unit/services/test_authorization.py
+++ b/ppr-api/tests/unit/services/test_authorization.py
@@ -1,0 +1,49 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the auth-api integration.
+
+Test-Suite to ensure that the client for the auth-api service is working as expected.
+"""
+from flask import current_app
+
+from ppr_api.services.authz import PPR_ROLE, user_orgs
+from tests.unit.services.utils import helper_create_jwt
+
+
+MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
+MOCK_URL = 'https://bcregistry-bcregistry-mock.apigee.net/auth/api/v1/'
+
+
+def test_user_orgs_mock(client, jwt):
+    """Assert that a auth-api user orgs request works as expected with the mock service endpoint."""
+    # setup
+    current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
+    # print('env auth-api url=' + current_app.config.get('AUTH_SVC_URL'))
+    token = helper_create_jwt(jwt, [PPR_ROLE])
+
+    # test
+    org_data = user_orgs(token)
+    print(org_data)
+
+    # check
+    assert org_data
+    assert 'orgs' in org_data
+    assert len(org_data['orgs']) == 1
+    org = org_data['orgs'][0]
+    assert org['orgStatus'] == 'ACTIVE'
+    assert org['statusCode'] == 'ACTIVE'
+    assert org['orgType'] == 'PREMIUM'
+    assert org['id']
+    assert org['name']


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8969

*Description of changes:*
- Make an auth api call to get the group/org account name for reports from the user token.
- First use of env variable AUTH_SVC_URL which should end in /ap/v1. 
- For dev: https://auth-api-dev.apps.silver.devops.gov.bc.ca/api/v1/users/orgs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
