### PR TITLE
API add checks on accessing registration report data.

### DIFF
--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -243,7 +243,7 @@ FETCH FIRST :max_results_size ROWS ONLY
 """
 
 QUERY_ACCOUNT_REGISTRATIONS = """
-SELECT r.registration_number, r.registration_ts, r.registration_type, r.registration_type_cl,
+SELECT r.registration_number, r.registration_ts, r.registration_type, r.registration_type_cl, r.account_id,
        rt.registration_desc, r.base_reg_number, fs.state_type AS state,
        CASE WHEN fs.life = 99 THEN -99
             ELSE CAST(EXTRACT(day from (fs.expire_date - (now() at time zone 'utc'))) AS INT) END expire_days,
@@ -288,7 +288,7 @@ SELECT r.registration_number, r.registration_ts, r.registration_type, r.registra
                       AND r3.registration_type_cl = 'DISCHARGE'
                       AND r3.registration_ts < ((now() at time zone 'utc') - interval '30 days'))
 UNION (
-SELECT r.registration_number, r.registration_ts, r.registration_type, r.registration_type_cl,
+SELECT r.registration_number, r.registration_ts, r.registration_type, r.registration_type_cl, r.account_id,
        rt.registration_desc, r.base_reg_number, fs.state_type AS state,
        CASE WHEN fs.life = 99 THEN -99
             ELSE CAST(EXTRACT(day from (fs.expire_date - (now() at time zone 'utc'))) AS INT) END expire_days,

--- a/ppr-api/test_data/postgres_create_first.sql
+++ b/ppr-api/test_data/postgres_create_first.sql
@@ -23,6 +23,12 @@ INSERT INTO client_codes(HEAD_ID, ID, ADDRESS_ID, NAME, BCONLINE_ACCOUNT, CONTAC
 			            CONTACT_PHONE_NUMBER, EMAIL_ADDRESS, USERS_ID, USER_ID, DATE_TS)
   VALUES (200000002,200000002,200000001,'TEST PARTY CODE 3',200000002,'TEST 3 CONTACT NAME','604','2171234',
           'test-3-client@gmail.com',null,'T3USER',null);
+-- Name matches auth mock service org name
+INSERT INTO client_codes(HEAD_ID, ID, ADDRESS_ID, NAME, BCONLINE_ACCOUNT, CONTACT_NAME,CONTACT_AREA_CD,
+			            CONTACT_PHONE_NUMBER, EMAIL_ADDRESS, USERS_ID, USER_ID, DATE_TS)
+  VALUES (200000003,200000003,200000001,'PH Testing PPR with PAD',200000002,'TEST 4 CONTACT NAME','604','2171234',
+          'test-4-client@gmail.com',null,'T4USER',null);
+
 
 -- Account ID BCOL Account Number mapping
 INSERT INTO account_bcol_ids(id, account_id, bconline_account, crown_charge_ind)

--- a/ppr-api/test_data/postgres_data_files/test0021.sql
+++ b/ppr-api/test_data/postgres_data_files/test0021.sql
@@ -1,0 +1,142 @@
+-- TEST0019 extended: renewal, discharge created with another account; base reg added to test account.
+-- No match on registering, secured party names, so test account GETs are unauthorized.
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000035, 'D-T-0019RE', 'PS00001', timestamp with time zone '2021-09-03 15:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0019', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000032, 200000013, 'TEST0019RE', 'TEST0019', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-09-03 15:00:00-07' at time zone 'utc', 200000035, 5,
+           null, null, 'PS00001', 'TEST-RE-0019', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000034, 'TEST-0019RE', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000074, 'RG', 200000032, 200000013, null, null, 'TEST-RENEWAL', '19', 'REGISTERING', null,
+           null, 200000034)
+;
+
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000036, 'D-T-0019DC', 'PS00001', CURRENT_TIMESTAMP at time zone 'utc', 
+         'DISCHARGE', 'DC', 'TEST0019', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000033, 200000013, 'TEST0019DC', 'TEST0019', 'DC', 'DISCHARGE', 
+           CURRENT_TIMESTAMP at time zone 'utc', 200000036, 0,
+           null, null, 'PS00001', 'TEST-DC-0019', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000035, 'TEST-0019DC', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000075, 'RG', 200000033, 200000013, null, null, 'TEST-DISCHARGE', '19', 'REGISTERING', null,
+           null, 200000035)
+;
+
+-- Now create a financing statement, amendment, renewal, discharge on another account with matching registering party
+-- or secured party name, and add it to the test account.
+-- Financing statement secured party should match user account name
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000037, 'D-T-0021', 'PS00001', timestamp with time zone '2021-09-03 12:00:00-07' at time zone 'utc', 
+         'PPSALIEN', 'SA', 'TEST0021', null, '{}');
+INSERT INTO financing_statements(id, state_type, expire_date, life, discharged, renewed)
+  VALUES(200000016, 'ACT', timestamp with time zone '2026-09-03 23:59:59-07' at time zone 'utc', 5, 'N' , null)
+;
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000034, 200000016, 'TEST0021', null, 'SA', 'PPSALIEN', 
+           timestamp with time zone '2021-09-03 12:00:00-07' at time zone 'utc', 200000037, 5,
+           null, null, 'PS00001', 'TEST-SA-0021', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000036, 'TEST-0021', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000076, 'SP', 200000034, 200000016, null, 200000003, null, null, null, null, null, null)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000077, 'RG', 200000034, 200000016, null, 200000001, null, null, null, null, null, null)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id, business_srch_key)
+    VALUES(200000078, 'DB', 200000034, 200000016, null, null, null, null, null, 'TEST 21 DEBTOR INC.',
+           null, 200000036, searchkey_business_name('TEST 21 DEBTOR INC.'))
+;
+INSERT INTO general_collateral(id, registration_id, financing_id, registration_id_end, description, status)
+  VALUES(200000014, 200000034, 200000016, null, 'TEST0021 GC 1', null)
+;
+
+-- Add an amendment with matching reg party name.
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000038, 'D-T-0021AM', 'PS00001', timestamp with time zone '2021-09-03 14:00:00-07' at time zone 'utc', 
+         'PPSALIEN', 'SA', 'TEST0021', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000035, 200000016, 'TEST0021AM', 'TEST0021', 'AM', 'AMENDMENT',
+           timestamp with time zone '2021-09-03 14:00:00-07' at time zone 'utc', 200000038, null,
+           null, null, 'PS00001', 'TEST-AM1-0021', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(200000037, 'TEST-0021AM', 'line 2', 'city', 'BC', 'V8R3A5', 'CA')
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000079, 'RG', 200000035, 200000016, null, null, null, null, null, 'PH Testing PPR with PAD',
+           null, 200000037);
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id, business_srch_key)
+    VALUES(200000080, 'DB', 200000035, 200000016, null, null, null, null, null, 'TEST 21 AMEND ADD DEBTOR',
+           null, 200000037, searchkey_business_name('TEST 21 AMEND ADD DEBTOR'))
+;
+
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000039, 'D-T-0021RE', 'PS00001', timestamp with time zone '2021-09-03 15:00:00-07' at time zone 'utc', 
+         'RENEWAL', 'RE', 'TEST0021', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000036, 200000016, 'TEST0021RE', 'TEST0021', 'RE', 'RENEWAL', 
+           timestamp with time zone '2021-09-03 15:00:00-07' at time zone 'utc', 200000039, 5,
+           null, null, 'PS00001', 'TEST-RE-0021', null, null)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000081, 'RG', 200000036, 200000016, null, 200000003, null, null, null, null,
+           null, null)
+;
+
+INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type_cl, registration_type,
+                  registration_number, update_ts, draft)
+  VALUES(200000040, 'D-T-0021DC', 'PS00001', CURRENT_TIMESTAMP at time zone 'utc', 
+         'DISCHARGE', 'DC', 'TEST0021', null, '{}');
+INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
+                         registration_type_cl, registration_ts, draft_id, life, lien_value,
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+    VALUES(200000037, 200000016, 'TEST0021DC', 'TEST0021', 'DC', 'DISCHARGE', 
+           CURRENT_TIMESTAMP at time zone 'utc', 200000040, 0,
+           null, null, 'PS00001', 'TEST-DC-0021', null, null)
+;
+INSERT INTO parties(id, party_type, registration_id, financing_id, registration_id_end, branch_id, first_name,
+                  middle_initial, last_name, business_name, birth_date, address_id)
+    VALUES(200000082, 'RG', 200000037, 200000016, null, 200000003, null, null, null, null,
+           null, null)
+;
+
+
+INSERT INTO user_extra_registrations(id, account_id, registration_number, removed_ind)
+  VALUES(200000003, 'PS12345', 'TEST0021', null)
+;


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#9197

*Description of changes:*
- User registrations summary conditionally return a path to the registration report/data for registrations created by other accounts.
- Apply same logic when requesting individual registration report/data with other financing statement and registration endpoints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
