### PR TITLE
Updates to resolve UI registrations table issues.

### DIFF
--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -149,7 +149,8 @@ class GetFinancingResource(Resource):
                                                                        account_id,
                                                                        is_staff(jwt))
             # Extra check account name matches either registering party or a secured party name.
-            resource_utils.check_access_financing(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
+            if resource_utils.is_pdf(request):
+                resource_utils.check_access_financing(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
 
             # Set to false to exclude change history.
             statement.include_changes_json = False
@@ -273,9 +274,11 @@ class GetAmendmentResource(Resource):
                                                                  account_id,
                                                                  is_staff(jwt),
                                                                  registration_num)
-            # Extra check account name matches either registering party or a secured party name.
-            resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
-
+            # If requesting a verification statement report, check the account name matches either
+            # the registering party or a secured party name.
+            if resource_utils.is_pdf(request):
+                resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id,
+                                                         statement)
             response_json = statement.verification_json('amendmentRegistrationNumber')
             if resource_utils.is_pdf(request):
                 # Return report if request header Accept MIME type is application/pdf.
@@ -383,9 +386,11 @@ class GetChangeResource(Resource):
                                                                  account_id,
                                                                  is_staff(jwt),
                                                                  registration_num)
-            # Extra check account name matches either registering party or a secured party name.
-            resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
-
+            # If requesting a verification statement report, check the account name matches either
+            # the registering party or a secured party name.
+            if resource_utils.is_pdf(request):
+                resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id,
+                                                         statement)
             response_json = statement.verification_json('changeRegistrationNumber')
             if resource_utils.is_pdf(request):
                 # Return report if request header Accept MIME type is application/pdf.
@@ -490,9 +495,11 @@ class GetRenewalResource(Resource):
                                                                  account_id,
                                                                  is_staff(jwt),
                                                                  registration_num)
-            # Extra check account name matches either registering party or a secured party name.
-            resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
-
+            # If requesting a verification statement report, check the account name matches either
+            # the registering party or a secured party name.
+            if resource_utils.is_pdf(request):
+                resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id,
+                                                         statement)
             response_json = statement.verification_json('renewalRegistrationNumber')
             if resource_utils.is_pdf(request):
                 # Return report if request header Accept MIME type is application/pdf.
@@ -599,9 +606,11 @@ class GetDischargeResource(Resource):
                                                                  account_id,
                                                                  is_staff(jwt),
                                                                  registration_num)
-            # Extra check account name matches either registering party or a secured party name.
-            resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id, statement)
-
+            # If requesting a verification statement report, check the account name matches either
+            # the registering party or a secured party name.
+            if resource_utils.is_pdf(request):
+                resource_utils.check_access_registration(jwt.get_token_auth_header(), is_staff(jwt), account_id,
+                                                         statement)
             response_json = statement.verification_json('dischargeRegistrationNumber')
             if resource_utils.is_pdf(request):
                 # Return report if request header Accept MIME type is application/pdf.

--- a/ppr-api/test_data/postgres_data_files/test0016.sql
+++ b/ppr-api/test_data/postgres_data_files/test0016.sql
@@ -9,10 +9,10 @@ INSERT INTO financing_statements(id, state_type, expire_date, life, discharged, 
 ;
 INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
                          registration_type_cl, registration_ts, draft_id, life, lien_value,
-                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path)
+                         surrender_date, account_id, client_reference_id, pay_invoice_id, pay_path, user_id)
     VALUES(200000018, 200000010, 'TEST0016', null, 'SA', 'PPSALIEN', 
            timestamp with time zone '2021-09-03 12:00:00-07' at time zone 'utc', 200000021, 5,
-           null, null, 'PS12345', 'TEST-SA-0016', null, null)
+           null, null, 'PS12345', null, null, null, 'INVALID')
 ;
 INSERT INTO trust_indentures(id, registration_id, financing_id, trust_indenture, registration_id_end)
   VALUES(200000008, 200000018, 200000010, 'Y', null)

--- a/ppr-api/test_data/postgres_data_files/test_user_update.sql
+++ b/ppr-api/test_data/postgres_data_files/test_user_update.sql
@@ -2,8 +2,10 @@
 UPDATE registrations
    SET user_id = 'TESTUSER'
  WHERE id >= 200000000
+   AND user_id IS NULL
 ;
 UPDATE drafts
    SET user_id = 'TESTUSER'
  WHERE id >= 200000000
+   AND user_id IS NULL
 ;

--- a/ppr-api/tests/unit/api/test_amendment.py
+++ b/ppr-api/tests/unit/api/test_amendment.py
@@ -25,7 +25,7 @@ from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT, FINANCING_STA
 
 from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE
 from ppr_api.models import utils as model_utils
-from tests.unit.services.utils import create_header, create_header_account
+from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
 MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
@@ -257,7 +257,8 @@ TEST_GET_STATEMENT = [
     ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0007', 'TEST0001'),
     ('Valid Request', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0007', 'TEST0001'),
     ('Valid Request other account', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0021AM', 'TEST0021'),
-    ('Unauthorized Request other account', [PPR_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0019AM', 'TEST0019'),
+    ('Valid Request other account not report', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0019AM', 'TEST0019'),
+    ('Report unauthorized request other account', [PPR_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0019AM', 'TEST0019'),
     ('Invalid Registration Number', [PPR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXXXX', 'TEST0001'),
     ('Mismatch registrations non-staff', [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0007', 'TEST0002'),
     ('Mismatch registrations staff', [PPR_ROLE, STAFF_ROLE], HTTPStatus.OK, True, 'TEST0007', 'TEST0002'),
@@ -301,7 +302,9 @@ def test_get_amendment(session, client, jwt, desc, roles, status, has_account, r
     current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
     headers = None
     # setup
-    if has_account:
+    if status == HTTPStatus.UNAUTHORIZED and desc.startswith('Report'):
+        headers = create_header_account_report(jwt, roles)
+    elif has_account:
         headers = create_header_account(jwt, roles)
     else:
         headers = create_header(jwt, roles)

--- a/ppr-api/tests/unit/api/test_financing.py
+++ b/ppr-api/tests/unit/api/test_financing.py
@@ -27,7 +27,7 @@ from ppr_api.resources.financing_statements import get_payment_details, get_paym
      get_payment_type_financing
 from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE
 from ppr_api.services.payment.payment import TransactionTypes
-from tests.unit.services.utils import create_header, create_header_account
+from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
 MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
@@ -334,7 +334,8 @@ TEST_GET_STATEMENT = [
     ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0001'),
     ('Valid Request', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0001'),
     ('Valid Request other account', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0021'),
-    ('Unauthorized Request other account', [PPR_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0019'),
+    ('Valid Request other account not report', [PPR_ROLE], HTTPStatus.OK, True, 'TEST0019'),
+    ('Report unauthorized request other account', [PPR_ROLE], HTTPStatus.UNAUTHORIZED, True, 'TEST0019'),
     ('Invalid Registration Number', [PPR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXXXX'),
     ('Invalid expired non-staff', [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0013'),
     ('Invalid discharged non-staff', [PPR_ROLE], HTTPStatus.BAD_REQUEST, True, 'TEST0014'),
@@ -527,7 +528,9 @@ def test_get_statement(session, client, jwt, desc, roles, status, has_account, r
     current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
     headers = None
     # setup
-    if has_account:
+    if status == HTTPStatus.UNAUTHORIZED and desc.startswith('Report'):
+        headers = create_header_account_report(jwt, roles)
+    elif has_account:
         headers = create_header_account(jwt, roles)
     else:
         headers = create_header(jwt, roles)

--- a/ppr-api/tests/unit/models/test_registration.py
+++ b/ppr-api/tests/unit/models/test_registration.py
@@ -245,7 +245,12 @@ def test_find_all_by_account_id(session, desc, account_id, collapse, user_added_
         assert statement['statusType']
         assert statement['createDateTime']
         assert statement['lastUpdateDateTime']
-        assert statement['registeringName']
+        if statement['registrationNumber'] == ('TEST0016'):
+            assert statement['registeringName'] == ''
+            assert statement['clientReferenceId'] == ''
+        else:
+            assert statement['registeringName']
+            assert statement['clientReferenceId']
         if statement['registrationNumber'] in ('TEST0019'):
             assert not statement['path']
         elif 'baseRegistrationNumber' in statement and statement['baseRegistrationNumber'] == 'TEST0019':

--- a/ppr-api/tests/unit/services/utils.py
+++ b/ppr-api/tests/unit/services/utils.py
@@ -48,6 +48,13 @@ def create_header(jwt_manager, roles: List[str] = [], username: str = 'test-user
     return headers
 
 
+def create_header_report(jwt_manager, roles: List[str] = [], username: str = 'test-user', **kwargs):
+    """Return a header containing a JWT bearer token."""
+    token = helper_create_jwt(jwt_manager, roles=roles, username=username)
+    headers = {**kwargs, **{'Authorization': 'Bearer ' + token}, **{'Accept': 'application/pdf'}}
+    return headers
+
+
 def create_header_account(jwt_manager,
                           roles: List[str] = [],
                           username: str = 'test-user',
@@ -55,4 +62,15 @@ def create_header_account(jwt_manager,
     """Return a header containing a JWT bearer token and an account ID."""
     token = helper_create_jwt(jwt_manager, roles=roles, username=username)
     headers = {**kwargs, **{'Authorization': 'Bearer ' + token}, **{'Account-Id': account_id}}
+    return headers
+
+
+def create_header_account_report(jwt_manager,
+                                 roles: List[str] = [],
+                                 username: str = 'test-user',
+                                 account_id: str = 'PS12345', **kwargs):
+    """Return a header containing a JWT bearer token and an account ID."""
+    token = helper_create_jwt(jwt_manager, roles=roles, username=username)
+    headers = {**kwargs, **{'Authorization': 'Bearer ' + token},
+               **{'Account-Id': account_id}, **{'Accept': 'application/pdf'}}
     return headers


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#9197

*Description of changes:*
- Account registrations summary return empty string instead of None for registeringName and clientReferenceId
- Relax other accounts access restriction to financing statement/base registration data requests. Only enforce the restriction with pdf requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
