### PR TITLE
UI minor changes for renewal RL

### DIFF
--- a/ppr-ui/src/components/collateral/generalCollateral/GenColSummary.vue
+++ b/ppr-ui/src/components/collateral/generalCollateral/GenColSummary.vue
@@ -120,9 +120,12 @@
       </v-btn>
       <div v-if="showingHistory" class="general-collateral-summary">
         <v-row v-for="(item, index) in generalCollateral" :key="index" no-gutters>
-          <v-col v-if="item.addedDateTime" :class="[{ 'border-btm': index !== baseGenCollateralIndex,
-            'pb-30px': index !== baseGenCollateralIndex }, 'pt-30px']">
-            <b>{{ asOfDateTime(item.addedDateTime) }}</b>
+          <v-col v-if="item.addedDateTime"
+                 :class="[{ 'border-btm': index !== baseGenCollateralIndex, 'pb-30px':
+                                          index !== baseGenCollateralIndex }, 'pt-30px']">
+            <div v-if="!item.description || registrationFlowType === RegistrationFlowType.NEW">
+              <b>{{ asOfDateTime(item.addedDateTime) }}</b>
+            </div>
             <div v-if="item.descriptionDelete" class="gc-description-delete pt-5">
               <v-chip class="badge-delete" color="primary" label text-color="white" x-small>
                 <b>DELETED</b>
@@ -139,11 +142,16 @@
                 <span style="white-space: pre-wrap;">{{ item.descriptionAdd }}</span>
               </p>
             </div>
-            <div v-if="item.description && index === baseGenCollateralIndex" class="gc-description pt-5">
-              <b v-if="registrationFlowType !== RegistrationFlowType.NEW">
-                Base Registration General Collateral:
-              </b>
-              <p v-if="item.description" class="pt-5 ma-0">
+            <div v-if="item.description" class="gc-description">
+              <div v-if="registrationFlowType !== RegistrationFlowType.NEW && index === firstBaseGenCollateralIndex"
+                   class="pb-5">
+                <b>{{ asOfDateTime(item.addedDateTime) }}</b>
+              </div>
+              <div v-if="registrationFlowType !== RegistrationFlowType.NEW && index === firstBaseGenCollateralIndex"
+                   class="pb-5">
+                <b>Base Registration General Collateral:</b>
+              </div>
+              <p v-if="item.description" class="ma-0">
                 <span style="white-space: pre-wrap;">{{ item.description }}</span>
               </p>
             </div>
@@ -215,6 +223,15 @@ export default defineComponent({
           }
         }
         return curIndex
+      }),
+      firstBaseGenCollateralIndex: computed(() => {
+        // find the index of the first base registration general collateral record to display label once.
+        for (var i = 0; i < localState.generalCollateral.length; i++) {
+          if (localState.generalCollateral[i].description && localState.generalCollateral[i].collateralId) {
+            return i
+          }
+        }
+        return -1
       }),
       generalCollateral: computed((): GeneralCollateralIF[] => {
         return (getGeneralCollateral.value as GeneralCollateralIF[]) || []

--- a/ppr-ui/src/components/common/CourtOrder.vue
+++ b/ppr-ui/src/components/common/CourtOrder.vue
@@ -206,7 +206,7 @@
 <script lang="ts">
 import { APIRegistrationTypes } from '@/enums'
 import { CourtOrderIF } from '@/interfaces' // eslint-disable-line no-unused-vars
-import { convertDate } from '@/utils'
+import { convertDate, tzOffsetMinutes } from '@/utils'
 import {
   defineComponent,
   reactive,
@@ -288,14 +288,19 @@ export default defineComponent({
       }),
       minCourtDate: computed((): string => {
         if (registrationType === APIRegistrationTypes.REPAIRERS_LIEN) {
-          var minDate = new Date(getRegistrationCreationDate.value)
+          const minDate = new Date(getRegistrationCreationDate.value)
           return minDate.toISOString()
         } else {
           return '0'
         }
       }),
       maxCourtDate: computed((): string => {
-        var maxDate = new Date()
+        const maxDate = new Date()
+        const offset = tzOffsetMinutes(maxDate)
+        maxDate.setHours(23)
+        maxDate.setMinutes(59)
+        maxDate.setSeconds(59)
+        maxDate.setTime(maxDate.getTime() - (offset * 60 * 1000)) // Subtract to get locale as Pacific
         return maxDate.toISOString()
       })
     })

--- a/ppr-ui/src/components/common/CourtOrder.vue
+++ b/ppr-ui/src/components/common/CourtOrder.vue
@@ -1,5 +1,31 @@
 <template>
-  <v-container v-if="isSummary">
+  <v-container v-if="renewalView && isSummary" class="pa-0">
+    <h2 class="pt-2 pb-5">Court Order</h2>
+    <v-container class="white" style="padding: 40px 30px;">
+      <v-row no-gutters class="pb-7">
+            <v-col cols="3" class="generic-label">Court Name</v-col>
+            <v-col cols="9" id="court-name-display">{{ courtName }}</v-col>
+      </v-row>
+      <v-row no-gutters class="pb-7">
+            <v-col cols="3" class="generic-label">Court Registry</v-col>
+            <v-col cols="9" id="court-registry-display">{{ courtRegistry }}</v-col>
+      </v-row>
+      <v-row no-gutters class="pb-7">
+            <v-col cols="3" class="generic-label">Court File Number</v-col>
+            <v-col cols="9" id="file-number-display"> {{ fileNumber }}
+            </v-col>
+      </v-row>
+      <v-row no-gutters class="pb-7">
+            <v-col cols="3" class="generic-label">Date of Order</v-col>
+            <v-col cols="9" id="date-display">{{ computedDateFormatted }}</v-col>
+      </v-row>
+      <v-row no-gutters>
+            <v-col cols="3" class="generic-label">Effect of Order</v-col>
+            <v-col cols="9" id="effect-display"><span style="white-space: pre-wrap">{{ effectOfOrder }}</span></v-col>
+      </v-row>
+    </v-container>
+  </v-container>
+  <v-container v-else-if="isSummary">
     <v-row no-gutters class="pa-2">
       <v-col cols="auto">
         <label>
@@ -28,7 +54,6 @@
           <v-col cols="3" class="generic-label">Effect of Order</v-col>
           <v-col cols="9" id="effect-display"><span style="white-space: pre-wrap">{{ effectOfOrder }}</span></v-col>
     </v-row>
-
   </v-container>
   <v-container v-else fluid no-gutters class="pb-6  px-0 rounded">
     <v-row no-gutters class="summary-header pa-2 mb-8">
@@ -40,7 +65,12 @@
       </v-col>
     </v-row>
     <v-row no-gutters class="pb-6">
-      <v-col>
+      <v-col v-if="requireCourtOrder && registrationType === APIRegistrationTypes.REPAIRERS_LIEN">
+        A court order is required to renew a Repairer's Lien. Enter the court
+        order information below. A default Effect of Order is provided; you can
+        modify this default text if you wish.
+      </v-col>
+      <v-col v-else>
         If this registration is pursuant to a court order, enter the court order
         information below, otherwise leave the Court Order information empty.
       </v-col>
@@ -198,6 +228,10 @@ export default defineComponent({
     },
     setSummary: {
       default: false
+    },
+    isRenewal: {
+      type: Boolean,
+      default: false
     }
   },
   setup (props, { emit }) {
@@ -217,6 +251,7 @@ export default defineComponent({
     const modal = false
     const registrationType = getRegistrationType.value?.registrationTypeAPI
     const localState = reactive({
+      renewalView: props.isRenewal,
       courtName: '',
       courtRegistry: '',
       fileNumber: '',
@@ -346,9 +381,9 @@ export default defineComponent({
           courtRegistry: '',
           fileNumber: ''
         }
-        if (registrationType === APIRegistrationTypes.REPAIRERS_LIEN) {
+        if (localState.requireCourtOrder && registrationType === APIRegistrationTypes.REPAIRERS_LIEN) {
           localState.effectOfOrder = 'Order directs the effective life of the Repairer\'s Lien be extended' +
-                                      ' an additional 180 days'
+                                      ' an additional 180 days.'
         }
         setCourtOrderInformation(newCourtOrderInfo)
       } else {
@@ -357,6 +392,16 @@ export default defineComponent({
         localState.courtName = localState.courtOrderInfo.courtName
         localState.courtRegistry = localState.courtOrderInfo.courtRegistry
         localState.fileNumber = localState.courtOrderInfo.fileNumber
+        if (localState.requireCourtOrder &&
+            registrationType === APIRegistrationTypes.REPAIRERS_LIEN &&
+            localState.orderDate === '' &&
+            localState.effectOfOrder === '' &&
+            localState.courtName === '' &&
+            localState.courtRegistry === '' &&
+            localState.fileNumber === '') {
+          localState.effectOfOrder = 'Order directs the effective life of the Repairer\'s Lien be extended' +
+                                      ' an additional 180 days.'
+        }
       }
     })
 
@@ -364,6 +409,8 @@ export default defineComponent({
       modal,
       errors,
       valid,
+      registrationType,
+      APIRegistrationTypes,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/store/mutations/mutations-model.ts
+++ b/ppr-ui/src/store/mutations/mutations-model.ts
@@ -122,6 +122,7 @@ export const mutateNewRegistration = (state: StateIF) => {
     certified: false,
     legalName: ''
   }
+  state.stateModel.folioOrReferenceNumber = ''
 }
 
 export const mutateRegistrationConfirmDebtorName = (state: StateIF, debtorName: DebtorNameIF) => {

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -29,3 +29,11 @@ export function convertDate (date: Date, includeTime: boolean, includeTz: boolea
   if (includeTz) return moment(date).format('MMMM D, Y') + ` at ${datetime} ${timezone}`
   else return moment(date).format('MMMM D, Y') + ` ${datetime}`
 }
+
+export function tzOffsetMinutes (date: Date): number {
+  let offset = 8 * 60
+  if (moment(date).isDST()) {
+    offset = 7 * 60
+  }
+  return offset
+}

--- a/ppr-ui/src/views/discharge/ReviewRegistration.vue
+++ b/ppr-ui/src/views/discharge/ReviewRegistration.vue
@@ -72,6 +72,7 @@ import { FeeSummaryTypes } from '@/composables/fees/enums'
 import {
   ActionBindingIF, ErrorIF, AddPartiesIF, // eslint-disable-line no-unused-vars
   RegistrationTypeIF, AddCollateralIF, LengthTrustIF, // eslint-disable-line no-unused-vars
+  CertifyIF, // eslint-disable-line no-unused-vars
   DebtorNameIF // eslint-disable-line no-unused-vars
 } from '@/interfaces'
 import { RegistrationTypes } from '@/resources'
@@ -101,6 +102,8 @@ export default class ReviewRegistration extends Vue {
   @Action setRegistrationNumber: ActionBindingIF
   @Action setRegistrationType: ActionBindingIF
   @Action setRegistrationFlowType: ActionBindingIF
+  @Action setCertifyInformation: ActionBindingIF
+  @Action setFolioOrReferenceNumber: ActionBindingIF
 
   /** Whether App is ready. */
   @Prop({ default: false })
@@ -183,6 +186,12 @@ export default class ReviewRegistration extends Vue {
         securedParties: financingStatement.securedParties,
         debtors: financingStatement.debtors
       } as AddPartiesIF
+      const certifyInfo: CertifyIF = {
+        valid: false,
+        certified: false,
+        legalName: '',
+        registeringParty: null
+      }
       this.setRegistrationCreationDate(financingStatement.createDateTime)
       this.setRegistrationExpiryDate(financingStatement.expiryDate)
       this.setRegistrationNumber(financingStatement.baseRegistrationNumber)
@@ -191,6 +200,8 @@ export default class ReviewRegistration extends Vue {
       this.setLengthTrust(lengthTrust)
       this.setAddSecuredPartiesAndDebtors(parties)
       this.setRegistrationFlowType(RegistrationFlowType.DISCHARGE)
+      this.setFolioOrReferenceNumber('')
+      this.setCertifyInformation(certifyInfo)
     }
   }
 

--- a/ppr-ui/src/views/renew/ConfirmRenewal.vue
+++ b/ppr-ui/src/views/renew/ConfirmRenewal.vue
@@ -44,6 +44,10 @@
           />
           <registration-length-trust-summary class="mt-10" :isRenewal="true"
           />
+          <div v-if="showCourtOrderInfo">
+            <court-order :setSummary="true" :isRenewal="true" class="pt-10" />
+          </div>
+
           <folio-number-summary
             @folioValid="setFolioValid($event)"
             :setShowErrors="showErrors"
@@ -88,6 +92,7 @@ import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import {
   FolioNumberSummary,
   CertifyInformation,
+  CourtOrder,
   StickyContainer
 } from '@/components/common'
 import { BaseDialog } from '@/components/dialogs'
@@ -116,6 +121,7 @@ import { convertDate, getFeatureFlag, getFinancingStatement, saveRenewal } from 
 @Component({
   components: {
     BaseDialog,
+    CourtOrder,
     FolioNumberSummary,
     RegisteringPartySummary,
     RegistrationLengthTrustSummary,
@@ -194,6 +200,10 @@ export default class ConfirmDischarge extends Vue {
       return '< Please complete required information'
     }
     return ''
+  }
+
+  private get showCourtOrderInfo (): boolean {
+    return (this.registrationType && this.registrationType === APIRegistrationTypes.REPAIRERS_LIEN)
   }
 
   private cancel (val: boolean): void {

--- a/ppr-ui/src/views/renew/RenewRegistration.vue
+++ b/ppr-ui/src/views/renew/RenewRegistration.vue
@@ -101,6 +101,7 @@ import {
   ActionBindingIF, // eslint-disable-line no-unused-vars
   ErrorIF, // eslint-disable-line no-unused-vars
   AddPartiesIF, // eslint-disable-line no-unused-vars
+  CertifyIF, // eslint-disable-line no-unused-vars
   RegistrationTypeIF, // eslint-disable-line no-unused-vars
   AddCollateralIF, // eslint-disable-line no-unused-vars
   LengthTrustIF, // eslint-disable-line no-unused-vars
@@ -143,6 +144,8 @@ export default class ReviewRegistration extends Vue {
   @Action setRegistrationType: ActionBindingIF
   @Action setRegistrationFlowType: ActionBindingIF
   @Action setCourtOrderInformation: ActionBindingIF
+  @Action setCertifyInformation: ActionBindingIF
+  @Action setFolioOrReferenceNumber: ActionBindingIF
 
   /** Whether App is ready. */
   @Prop({ default: false })
@@ -254,6 +257,12 @@ export default class ReviewRegistration extends Vue {
           effectOfOrder: '',
           orderDate: ''
         }
+        const certifyInfo: CertifyIF = {
+          valid: false,
+          certified: false,
+          legalName: '',
+          registeringParty: null
+        }
         this.setCourtOrderInformation(courtOrder)
         this.setRegistrationCreationDate(financingStatement.createDateTime)
         this.setRegistrationExpiryDate(financingStatement.expiryDate)
@@ -263,6 +272,8 @@ export default class ReviewRegistration extends Vue {
         this.setLengthTrust(lengthTrust)
         this.setAddSecuredPartiesAndDebtors(parties)
         this.setRegistrationFlowType(RegistrationFlowType.RENEWAL)
+        this.setFolioOrReferenceNumber('')
+        this.setCertifyInformation(certifyInfo)
       }
     }
   }

--- a/ppr-ui/tests/unit/test-data/mock-registration-new.ts
+++ b/ppr-ui/tests/unit/test-data/mock-registration-new.ts
@@ -94,7 +94,8 @@ export const mockedGeneralCollateral2: GeneralCollateralIF[] = [
   },
   {
     addedDateTime: '2021-09-17T18:56:20Z',
-    description: 'test base reg description'
+    description: 'test base reg description',
+    collateralId: 12343
   }
 ]
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#9919

*Description of changes:*
- Add court order to RL renewal confirmation. 
- Set RL renewal court order defaults, conditional validation.
- 9851 review general collateral allow for multiple gc base registration legacy records.
- 9179 reset folio, authorization on start of another registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
