### PR TITLE
API no fee amendments by reg type, req updates

### DIFF
--- a/ppr-api/src/ppr_api/models/registration.py
+++ b/ppr-api/src/ppr_api/models/registration.py
@@ -50,12 +50,15 @@ class CrownChargeTypes(str, Enum):
     INSURANCE_TAX = 'IP'
     INCOME_TAX = 'IT'
     LOGGING_TAX = 'LO'
+    MINERAL_LAND_TAX = 'MD'
     MINING_TAX = 'MI'
     MINERAL_TAX = 'MR'
     OTHER = 'OT'
     PETROLEUM_TAX = 'PG'
     PROV_SALES_TAX = 'PS'
+    PROPERTY_TRANSFER_TAX = 'PT'
     RURAL_TAX = 'RA'
+    SCHOOL_ACT = 'SC'
     SOCIAL_TAX = 'SS'
     TAX_LIEN = 'TL'
 
@@ -379,7 +382,7 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes
                     status_code=HTTPStatus.UNAUTHORIZED
                 )
 
-        if not staff and model_utils.is_historical(registration.financing_statement):
+        if not staff and model_utils.is_historical(registration.financing_statement, False):
             raise BusinessException(
                 error=model_utils.ERR_FINANCING_HISTORICAL.format(registration_num=registration_num),
                 status_code=HTTPStatus.BAD_REQUEST

--- a/ppr-api/src/ppr_api/models/search_result.py
+++ b/ppr-api/src/ppr_api/models/search_result.py
@@ -186,7 +186,8 @@ class SearchResult(db.Model):  # pylint: disable=too-many-instance-attributes
                     if statement['financingStatement']['baseRegistrationNumber'] == reg_num:
                         found = True
             if not found:  # No duplicates.
-                financing = FinancingStatement.find_by_registration_number(reg_num, account_id=None, staff=False)
+                # Set to staff for small performance gain: skip account id/historical checks.
+                financing = FinancingStatement.find_by_registration_number(reg_num, None, True, False)
                 financing.mark_update_json = mark_added  # Added for PDF, indicate if party or collateral was added.
                 # Set to true to include change history.
                 financing.include_changes_json = True
@@ -212,7 +213,8 @@ class SearchResult(db.Model):  # pylint: disable=too-many-instance-attributes
         detail_results = []
         for result in search_json:
             reg_num = result['baseRegistrationNumber']
-            financing = FinancingStatement.find_by_registration_number(reg_num, account_id=None, staff=False)
+            # Set to staff for small performance gain: skip account id/historical checks.
+            financing = FinancingStatement.find_by_registration_number(reg_num, None, True, False)
             # Set to true to include change history.
             financing.include_changes_json = True
             financing_json = {

--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -215,7 +215,7 @@ class AmendmentResource(Resource):
 
             # Fetch base registration information: business exception thrown if not
             # found or historical.
-            statement = FinancingStatement.find_by_registration_number(registration_num, False)
+            statement = FinancingStatement.find_by_registration_number(registration_num, account_id, False, True)
 
             # Verify base debtor (bypassed for staff)
             if not statement.validate_debtor_name(request_json['debtorName'], is_staff(jwt)):
@@ -329,7 +329,7 @@ class ChangeResource(Resource):
 
             # Fetch base registration information: business exception thrown if not
             # found or historical.
-            statement = FinancingStatement.find_by_registration_number(registration_num, False)
+            statement = FinancingStatement.find_by_registration_number(registration_num, account_id, False, True)
 
             # Verify base debtor (bypassed for staff)
             if not statement.validate_debtor_name(request_json['debtorName'], is_staff(jwt)):
@@ -436,7 +436,7 @@ class RenewalResource(Resource):
 
             # Fetch base registration information: business exception thrown if not
             # found or historical.
-            statement = FinancingStatement.find_by_registration_number(registration_num, False)
+            statement = FinancingStatement.find_by_registration_number(registration_num, account_id, False, True)
             extra_validation_msg = resource_utils.validate_renewal(request_json, statement)
             if extra_validation_msg != '':
                 return resource_utils.validation_error_response(errors, VAL_ERROR, extra_validation_msg)
@@ -547,7 +547,7 @@ class DischargeResource(Resource):
 
             # Fetch base registration information: business exception thrown if not
             # found or historical.
-            statement = FinancingStatement.find_by_registration_number(registration_num, False)
+            statement = FinancingStatement.find_by_registration_number(registration_num, account_id, False, True)
 
             # Verify base debtor (bypassed for staff)
             if not statement.validate_debtor_name(request_json['debtorName'], is_staff(jwt)):
@@ -845,6 +845,8 @@ def pay_and_save(request_json, registration_class, financing_statement, registra
         fee_quantity = 1
         if registration_class == model_utils.REG_CLASS_AMEND:
             pay_trans_type = TransactionTypes.AMENDMENT.value
+            if resource_utils.no_fee_amendment(financing_statement.registration[0].registration_type):
+                pay_trans_type = TransactionTypes.AMENDMENT_NO_FEE.value
         elif registration_class == model_utils.REG_CLASS_RENEWAL and registration.life == model_utils.LIFE_INFINITE:
             pay_trans_type = TransactionTypes.RENEWAL_INFINITE.value
         elif registration_class == model_utils.REG_CLASS_RENEWAL:

--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from flask import jsonify, current_app
 
 from ppr_api.exceptions import BusinessException
+from ppr_api.models.registration import CrownChargeTypes, MiscellaneousTypes, PPSATypes
 from ppr_api.services.authz import user_orgs
 from ppr_api.utils.validators import financing_validator, party_validator, registration_validator
 
@@ -237,3 +238,22 @@ def check_access_registration(token: str, staff: bool, account_id: str, statemen
             error=ACCOUNT_ACCESS.format(account_id=account_id, registration_num=reg_num),
             status_code=HTTPStatus.UNAUTHORIZED
         )
+
+
+def no_fee_amendment(registration_type: str) -> bool:
+    """Amendment registration check if no fee registration type."""
+    if registration_type == PPSATypes.LAND_TAX.value:
+        return True
+    for reg_type in MiscellaneousTypes:
+        if reg_type.value == registration_type:
+            return True
+    for reg_type in CrownChargeTypes:
+        if reg_type.value == registration_type and \
+                registration_type not in (CrownChargeTypes.CORP_TAX.value,
+                                          CrownChargeTypes.CONSUMPTION_TAX.value,
+                                          CrownChargeTypes.MINERAL_TAX.value,
+                                          CrownChargeTypes.SOCIAL_TAX.value,
+                                          CrownChargeTypes.HOTEL_TAX.value,
+                                          CrownChargeTypes.MINING_TAX.value):
+            return True
+    return False

--- a/ppr-api/src/ppr_api/services/payment/client/__init__.py
+++ b/ppr-api/src/ppr_api/services/payment/client/__init__.py
@@ -30,6 +30,7 @@ MSG_INVALID_HTTP_VERB = 'Invalid HTTP verb'
 # Mapping from PPR transaction to Pay API filing type
 TRANSACTION_TO_FILING_TYPE = {
     'AMENDMENT': 'FSCHG',
+    'AMENDMENT_NO_FEE': 'NCCHG',
     'CHANGE': 'FSCHG',
     'DISCHARGE': 'FSDIS',  # No charge fee.
     'FINANCING_FR': 'FLREG',  # Special flat rate fee for the FR registration type.

--- a/ppr-api/src/ppr_api/services/payment/payment.py
+++ b/ppr-api/src/ppr_api/services/payment/payment.py
@@ -25,6 +25,7 @@ class TransactionTypes(Enum):
     """Derive payment request filing type from transaction type."""
 
     AMENDMENT = 'AMENDMENT'
+    AMENDMENT_NO_FEE = 'AMENDMENT_NO_FEE'
     CHANGE = 'CHANGE'
     DISCHARGE = 'DISCHARGE'
     FINANCING_FR = 'FINANCING_FR'  # Special flat rate fee for FR registration type.

--- a/ppr-api/test_data/postgres_data_files/test0013.sql
+++ b/ppr-api/test_data/postgres_data_files/test0013.sql
@@ -4,7 +4,7 @@ INSERT INTO drafts(id, document_number, account_id, create_ts, registration_type
                   registration_number, update_ts, draft)
   VALUES(200000017, 'D-T-0013', 'PS12345', CURRENT_TIMESTAMP, 'PPSALIEN', 'SA', 'TEST0013', null, '{}');
 INSERT INTO financing_statements(id, state_type, expire_date, life, discharged, renewed)
-  VALUES(200000007, 'HEX', CURRENT_TIMESTAMP - interval '100 days', 1, null , null)
+  VALUES(200000007, 'ACT', CURRENT_TIMESTAMP - interval '100 days', 1, null , null)
 ;
 INSERT INTO registrations(id, financing_id, registration_number, base_reg_number, registration_type,
                          registration_type_cl, registration_ts, draft_id, life, lien_value,

--- a/ppr-api/tests/unit/api/test_utils.py
+++ b/ppr-api/tests/unit/api/test_utils.py
@@ -21,7 +21,7 @@ import copy
 import pytest
 from flask import current_app
 
-from ppr_api.resources.utils import get_account_name, validate_financing, validate_registration
+from ppr_api.resources import utils as resource_utils
 from ppr_api.services.authz import PPR_ROLE
 from tests.unit.services.utils import helper_create_jwt
 from tests.unit.utils.test_financing_validator import FINANCING
@@ -45,6 +45,44 @@ TEST_VALIDATE_FINANCING_DATA = [
     ('Valid financing statement registration', True),
     ('Invalid financing statement registration', False)
 ]
+# testdata pattern is ({reg type}, {no fee})
+TEST_NO_FEE_AMENDMENT_DATA = [
+    ('SA', False),
+    ('SG', False),
+    ('RL', False),
+    ('FA', False),
+    ('FR', False),
+    ('FS', False),
+    ('FL', False),
+    ('MH', False),
+    ('CC', False),
+    ('DP', False),
+    ('HR', False),
+    ('MI', False),
+    ('MR', False),
+    ('SS', False),
+    ('CT', True),
+    ('ET', True),
+    ('FO', True),
+    ('FT', True),
+    ('IP', True),
+    ('IP', True),
+    ('LO', True),
+    ('MD', True),
+    ('OT', True),
+    ('PG', True),
+    ('PS', True),
+    ('PT', True),
+    ('RA', True),
+    ('SC', True),
+    ('TL', True),
+    ('HN', True),
+    ('ML', True),
+    ('MN', True),
+    ('PN', True),
+    ('WL', True),
+    ('LT', True)
+]
 
 
 @pytest.mark.parametrize('desc, account_id, has_name', TEST_USER_ORGS_DATA_JSON)
@@ -55,7 +93,7 @@ def test_get_account_name(session, client, jwt, desc, account_id, has_name):
     token = helper_create_jwt(jwt, [PPR_ROLE]) if has_name else None
 
     # test
-    name = get_account_name(token, account_id)
+    name = resource_utils.get_account_name(token, account_id)
 
     # check
     if has_name:
@@ -73,7 +111,7 @@ def test_validate_financing(session, client, jwt, desc, valid):
         del json_data['authorizationReceived']
 
     # test
-    error_msg = validate_financing(json_data)
+    error_msg = resource_utils.validate_financing(json_data)
     if valid:
         assert error_msg == ''
     else:
@@ -89,8 +127,18 @@ def test_validate_registration(session, client, jwt, desc, valid):
         del json_data['authorizationReceived']
 
     # test
-    error_msg = validate_registration(json_data)
+    error_msg = resource_utils.validate_registration(json_data)
     if valid:
         assert error_msg == ''
     else:
         assert error_msg != ''
+
+
+@pytest.mark.parametrize('reg_type, no_fee', TEST_NO_FEE_AMENDMENT_DATA)
+def test_no_fee_amendment(session, client, jwt, reg_type, no_fee):
+    """Assert that amendment no fee by registration type works as expected."""
+    # setup
+
+    # test
+    result = resource_utils.no_fee_amendment(reg_type)
+    assert result == no_fee


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#9875

*Description of changes:*
- 9875 API implement no fee charge for amendment by registration type
- amendment, discharge, renewal always check expiry date as well as expired state.
- Correct legacy general collateral for financing statement consolidated/current view. Include all records. For amendments, try and group add/delete in one registration together.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
