### PR TITLE
API BCOL staff cannot submit registrations.

### DIFF
--- a/ppr-api/src/ppr_api/models/registration.py
+++ b/ppr-api/src/ppr_api/models/registration.py
@@ -257,7 +257,7 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes
                 registration['addVehicleCollateral'] = collateral
 
         # delete vehicle collateral
-        if self.financing_statement.general_collateral and self.is_change():
+        if self.financing_statement.vehicle_collateral and self.is_change():
             collateral = []
             for vehicle_c in self.financing_statement.vehicle_collateral:
                 if vehicle_c.registration_id_end == registration_id:

--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -26,7 +26,7 @@ from ppr_api.models import AccountBcolId, FinancingStatement, Registration, User
 from ppr_api.models import utils as model_utils
 from ppr_api.reports import ReportTypes, get_pdf
 from ppr_api.resources import utils as resource_utils
-from ppr_api.services.authz import authorized, is_staff
+from ppr_api.services.authz import authorized, is_staff, is_bcol_help
 from ppr_api.services.payment.exceptions import SBCPaymentException
 from ppr_api.services.payment.payment import Payment, TransactionTypes
 from ppr_api.utils.auth import jwt
@@ -93,9 +93,8 @@ class FinancingResource(Resource):
             account_id = resource_utils.get_account_id(request)
             if not is_staff(jwt) and account_id is None:
                 return resource_utils.account_required_response()
-
-            # Verify request JWT and account ID
-            if not authorized(account_id, jwt):
+            # Verify request JWT and account ID. BCOL helpdesk is not allowed to submit this request.
+            if not authorized(account_id, jwt) or is_bcol_help(account_id):
                 return resource_utils.unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)
@@ -196,8 +195,8 @@ class AmendmentResource(Resource):
             if not is_staff(jwt) and account_id is None:
                 return resource_utils.account_required_response()
 
-            # Verify request JWT and account ID
-            if not authorized(account_id, jwt):
+            # Verify request JWT and account ID. BCOL helpdesk is not allowed to submit this request.
+            if not authorized(account_id, jwt) or is_bcol_help(account_id):
                 return resource_utils.unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)
@@ -310,8 +309,8 @@ class ChangeResource(Resource):
             if not is_staff(jwt) and account_id is None:
                 return resource_utils.account_required_response()
 
-            # Verify request JWT and account ID
-            if not authorized(account_id, jwt):
+            # Verify request JWT and account ID. BCOL helpdesk is not allowed to submit this request.
+            if not authorized(account_id, jwt) or is_bcol_help(account_id):
                 return resource_utils.unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)
@@ -420,8 +419,8 @@ class RenewalResource(Resource):
             account_id = resource_utils.get_account_id(request)
             if not is_staff(jwt) and account_id is None:
                 return resource_utils.account_required_response()
-            # Verify request JWT and account ID
-            if not authorized(account_id, jwt):
+            # Verify request JWT and account ID. BCOL helpdesk is not allowed to submit this request.
+            if not authorized(account_id, jwt) or is_bcol_help(account_id):
                 return resource_utils.unauthorized_error_response(account_id)
             request_json = request.get_json(silent=True)
             # Validate request data against the schema.
@@ -522,14 +521,12 @@ class DischargeResource(Resource):
         try:
             if registration_num is None:
                 return resource_utils.path_param_error_response('registration number')
-
             # Quick check: must be staff or provide an account ID.
             account_id = resource_utils.get_account_id(request)
             if not is_staff(jwt) and account_id is None:
                 return resource_utils.account_required_response()
-
-            # Verify request JWT and account ID
-            if not authorized(account_id, jwt):
+            # Verify request JWT and account ID. BCOL helpdesk is not allowed to submit this request.
+            if not authorized(account_id, jwt) or is_bcol_help(account_id):
                 return resource_utils.unauthorized_error_response(account_id)
 
             request_json = request.get_json(silent=True)

--- a/ppr-api/src/ppr_api/services/payment/client/__init__.py
+++ b/ppr-api/src/ppr_api/services/payment/client/__init__.py
@@ -200,14 +200,19 @@ class BaseClient:
             self.detail_label = None
             self.detail_value = None
 
-    def call_api(self, method, relative_path, data=None, token=None):
+    def call_api(self,  # pylint: disable=too-many-arguments
+                 method,
+                 relative_path,
+                 data=None,
+                 token=None,
+                 include_account: bool = True):
         """Call the Pay API."""
         try:
             headers = {
                 'Authorization': 'Bearer ' + token if token is not None else 'Bearer ' + self.jwt,
                 'Content-Type': 'application/json'
             }
-            if self.account_id:
+            if include_account and self.account_id:
                 headers['Account-Id'] = self.account_id
             if self.api_key:
                 headers['x-apikey'] = self.api_key
@@ -331,9 +336,10 @@ class SBCPaymentClient(BaseClient):
             data['details'][0]['value'] = self.detail_value
         else:
             del data['details']
-        # current_app.logger.debug('create paymnent payload:')
-        # current_app.logger.debug(json.dumps(data))
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data)
+        current_app.logger.debug('staff search create payment payload for account: ' + self.account_id)
+        current_app.logger.debug(json.dumps(data))
+        # self.account_id = None
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=False)
         return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def cancel_payment(self, invoice_id):


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10086

*Description of changes:*
- API change to prevent BCOL staff from  submitting registrations.
- also fix for amendment delete vehicle collateral verification statement data
- Staff payment pay api call do not include an account id in the request headers
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
