### PR TITLE
adding support for unix-socket support in the SQL connection

### DIFF
--- a/ppr-api/requirements/dev.txt
+++ b/ppr-api/requirements/dev.txt
@@ -1,6 +1,3 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
-
 # Testing
 attrs<=19.1.0
 coverage

--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -80,22 +80,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     DB_HOST = os.getenv('DATABASE_HOST', '')
     DB_PORT = os.getenv('DATABASE_PORT', '5432')  # POSTGRESQL
     # POSTGRESQL
-    SQLALCHEMY_DATABASE_URI = 'postgresql://{user}:{password}@{host}:{port}/{name}'.format(
-        user=DB_USER,
-        password=DB_PASSWORD,
-        host=DB_HOST,
-        port=int(DB_PORT),
-        name=DB_NAME,
-    )
-
-    # ORACLE
-    # SQLALCHEMY_DATABASE_URI = 'oracle+cx_oracle://{user}:{password}@{host}:{port}/{name}'.format(
-    #    user=DB_USER,
-    #    password=DB_PASSWORD,
-    #    host=DB_HOST,
-    #    port=int(DB_PORT),
-    #    name=DB_NAME,
-    # )
+    if DB_UNIX_SOCKET := os.getenv('DATABASE_UNIX_SOCKET', None):
+        SQLALCHEMY_DATABASE_URI = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@/{DB_NAME}?host={DB_UNIX_SOCKET}'
+    else:
+        SQLALCHEMY_DATABASE_URI = f'postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}'
 
     # Connection pool settings
     DB_MIN_POOL_SIZE = os.getenv('DATABASE_MIN_POOL_SIZE', '5')

--- a/ppr-api/wsgi.py
+++ b/ppr-api/wsgi.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 """Provides the WSGI entry point for running the application
 """
+import os
+
 from ppr_api import create_app
 
 # Openshift s2i expects a lower case name of application
 application = create_app() # pylint: disable=invalid-name
 
 if __name__ == "__main__":
-    application.run()
+    server_port = os.environ.get('PORT', '8080')
+    application.run(debug=False, port=server_port, host='0.0.0.0')


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
- adding support for UNIX-Sockets to the SQL URL for CloudSQL-Postgres
- adding PORT to the startup of wsgi/gunicorn for CloudRun

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
