### PR TITLE
Fix api search report incomplete search selection.

### DIFF
--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -29,6 +29,7 @@ flask-jwt-oidc==0.3.0
 flask-restx==0.4.0
 google-auth==2.3.3
 google-auth-oauthlib==0.4.6
+google-cloud-pubsub==2.9.0
 greenlet==1.1.0
 gunicorn==20.1.0
 idna==2.10

--- a/ppr-api/requirements/prod.txt
+++ b/ppr-api/requirements/prod.txt
@@ -13,6 +13,7 @@ datedelta
 dpath==1.4.2
 google-auth
 google-auth-oauthlib
+google-cloud-pubsub
 gunicorn
 jsonschema
 launchdarkly-server-sdk

--- a/ppr-api/src/ppr_api/callback/auth/token_service.py
+++ b/ppr-api/src/ppr_api/callback/auth/token_service.py
@@ -68,3 +68,12 @@ class GoogleStorageTokenService(TokenService):  # pylint: disable=too-few-public
         cls.credentials.refresh(request)
         current_app.logger.info('Call successful: obtained token.')
         return cls.credentials.token
+
+    @classmethod
+    def get_credentials(cls):
+        """Generate GCP auth credentials to pass to a GCP client."""
+        if cls.credentials is None:
+            cls.credentials = service_account.Credentials.from_service_account_info(cls.service_account_info,
+                                                                                    scopes=cls.GCP_SA_SCOPES)
+        current_app.logger.info('Call successful: obtained credentials.')
+        return cls.credentials

--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -174,6 +174,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     GCP_SA_SCOPES = json.loads(os.getenv('GCP_SA_SCOPES', '["https://www.googleapis.com/auth/cloud-platform"]'))
     GCP_CS_BUCKET_ID = os.getenv('GCP_CS_BUCKET_ID', 'ppr_search_results_dev')
     GCP_CLOUD_STORAGE_URL = os.getenv('GCP_CLOUD_STORAGE_URL', 'https://storage.googleapis.com')
+    # Pub/Sub
+    GCP_PS_PROJECT_ID = os.getenv('GCP_PS_PROJECT_ID')
+    GCP_PS_SEARCH_REPORT_TOPIC = os.getenv('GCP_PS_SEARCH_REPORT_TOPIC')
+    GCP_PS_NOTIFICATION_TOPIC = os.getenv('GCP_PS_NOTIFICATION_TOPIC')
 
     GATEWAY_URL = os.getenv('GATEWAY_URL', 'https://bcregistry-dev.apigee.net')
 

--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -146,7 +146,7 @@ class SearchResultsResource(Resource):
                 return resource_utils.not_found_error_response('searchId', search_id)
 
             # If no search selection (step 2) return an error.
-            if not search_detail.search_select:
+            if not search_detail.search_select and search_detail.search.total_results_size > 0:
                 return resource_utils.bad_request_response(GET_DETAILS_ERROR)
 
             # If the request is for an async large report, fetch binary data from doc storage.

--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -26,6 +26,7 @@ from ppr_api.utils.auth import jwt
 from ppr_api.utils.util import cors_preflight
 from ppr_api.exceptions import BusinessException
 from ppr_api.services.authz import authorized
+from ppr_api.services.queue_service import GoogleQueueService
 from ppr_api.models import EventTracking, SearchResult, utils as model_utils
 from ppr_api.resources import utils as resource_utils
 from ppr_api.reports import ReportTypes, get_pdf
@@ -104,6 +105,7 @@ class SearchResultsResource(Resource):
                 # If results over threshold return JSON with callbackURL, getReportURL
                 if callback_url is not None:
                     # Add enqueue report generation event here.
+                    enqueue_search_report(search_id)
                     response_data['callbackURL'] = callback_url
                     response_data['getReportURL'] = REPORT_URL.format(search_id=search_id)
                     return jsonify(response_data), HTTPStatus.OK
@@ -172,14 +174,14 @@ class SearchResultsResource(Resource):
             return resource_utils.default_exception_response(default_exception)
 
 
-@cors_preflight('PATCH,OPTIONS')
-@API.route('/callback/<path:search_id>', methods=['PATCH', 'OPTIONS'])
+@cors_preflight('POST,OPTIONS')
+@API.route('/callback/<path:search_id>', methods=['POST', 'OPTIONS'])
 class PatchSearchResultsResource(Resource):
     """Resource to generate a large search result report for a queue callback."""
 
     @staticmethod
     @cors.crossdomain(origin='*')
-    def patch(search_id):  # pylint: disable=too-many-branches
+    def post(search_id):  # pylint: disable=too-many-branches
         """Generate and store a report, update search_result.doc_storage_url."""
         try:
             if search_id is None:
@@ -245,6 +247,7 @@ class PatchSearchResultsResource(Resource):
             else:  # Enqueue notification event.
                 current_app.logger.info(f'Queueing report notification for id={search_id}, callback=' +
                                         search_detail.callback_url)
+                enqueue_notification(search_id)
 
             return response, HTTPStatus.OK
 
@@ -335,6 +338,10 @@ def callback_error(code: str, search_id: str, status_code, message: str = None):
     current_app.logger.error(error)
     # Track event here.
     EventTracking.create(search_id, EventTracking.EventTrackingTypes.SEARCH_REPORT, status_code, message)
+    if status_code != HTTPStatus.BAD_REQUEST and code not in (resource_utils.CallbackExceptionCodes.MAX_RETRIES,
+                                                              resource_utils.CallbackExceptionCodes.UNKNOWN_ID):
+        # set up retry
+        enqueue_search_report(search_id)
     return resource_utils.error_response(status_code, error)
 
 
@@ -346,6 +353,10 @@ def notification_error(code: str, search_id: str, status_code, message: str = No
     current_app.logger.error(error)
     # Track event here.
     EventTracking.create(search_id, EventTracking.EventTrackingTypes.API_NOTIFICATION, status_code, message)
+    if status_code != HTTPStatus.BAD_REQUEST and code not in (resource_utils.CallbackExceptionCodes.MAX_RETRIES,
+                                                              resource_utils.CallbackExceptionCodes.UNKNOWN_ID):
+        # set up retry
+        enqueue_notification(search_id)
     return resource_utils.error_response(status_code, error)
 
 
@@ -366,7 +377,7 @@ def send_notification(callback_url: str, search_id):
     return response
 
 
-def is_async(search_detail: SearchResult, search_select):
+def is_async(search_detail: SearchResult, search_select) -> bool:
     """Check if the request number of financing statements exceeds the real time threshold."""
     threshold = current_app.config.get('SEARCH_PDF_ASYNC_THRESHOLD')
     if search_detail.search.total_results_size < threshold:
@@ -390,3 +401,27 @@ def is_async(search_detail: SearchResult, search_select):
         return True
 
     return False
+
+
+def enqueue_search_report(search_id: str):
+    """Add the search report request to the queue."""
+    try:
+        payload = {
+            'searchId': search_id
+        }
+        GoogleQueueService().publish_search_report(payload)
+        current_app.logger.info(f'Enqueue search report successful for id={search_id}.')
+    except Exception as err:  # noqa: B902; return nicer default error
+        current_app.logger.error(f'Enqueue search report failed for id={search_id}: ' + repr(err))
+
+
+def enqueue_notification(search_id: str):
+    """Add the notification request to the queue."""
+    try:
+        payload = {
+            'searchId': search_id
+        }
+        GoogleQueueService().publish_notification(payload)
+        current_app.logger.info(f'Enqueue notification successful for id={search_id}.')
+    except Exception as err:  # noqa: B902; return nicer default error
+        current_app.logger.error(f'Enqueue notification failed for id={search_id}: ' + repr(err))

--- a/ppr-api/src/ppr_api/services/queue_service.py
+++ b/ppr-api/src/ppr_api/services/queue_service.py
@@ -1,0 +1,60 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This class enqueues messages for the PPR API asynchronous events."""
+import json
+
+from flask import current_app
+from google.cloud import pubsub_v1
+
+from ppr_api.callback.auth.token_service import GoogleStorageTokenService
+
+
+class GoogleQueueService():
+    """Google Pub/Sub implementation to publish/enqueue events.
+
+    Publish aync messages for downstream processing.
+    """
+
+    def __init__(self):
+        """Initialize the publisher."""
+        credentials = GoogleStorageTokenService.get_credentials()
+        self.publisher = pubsub_v1.PublisherClient(credentials=credentials)
+        self.project_id = str(current_app.config.get('GCP_PS_PROJECT_ID'))
+        self.search_report_topic = str(current_app.config.get('GCP_PS_SEARCH_REPORT_TOPIC'))
+        self.notification_topic = str(current_app.config.get('GCP_PS_NOTIFICATION_TOPIC'))
+        self.search_report_topic_name = f'projects/{self.project_id}/topics/{self.search_report_topic}'
+        self.notification_topic_name = f'projects/{self.project_id}/topics/{self.notification_topic}'
+
+    def publish_search_report(self, payload):
+        """Publish the search report request json payload to the Queue Service."""
+        try:
+            self.publish(self.search_report_topic_name, payload)
+        except Exception as err:
+            current_app.logger.error('Error: ' + repr(err))
+            raise err
+
+    def publish_notification(self, payload):
+        """Publish the api notification request json payload to the Queue Service."""
+        try:
+            self.publish(self.notification_topic_name, payload)
+        except Exception as err:
+            current_app.logger.error('Error: ' + repr(err))
+            raise err
+
+    def publish(self, topic_name, payload_json):
+        """Publish the payload to the specified topic."""
+        payload = json.dumps(payload_json).encode('utf-8')
+        # current_app.logger.info('Publishing topic=' + topic_name + ', payload=' + json.dumps(payload_json))
+        future = self.publisher.publish(topic_name, payload)
+        future.result()

--- a/ppr-api/src/ppr_api/services/queue_service.py
+++ b/ppr-api/src/ppr_api/services/queue_service.py
@@ -40,7 +40,7 @@ class GoogleQueueService():
         """Publish the search report request json payload to the Queue Service."""
         try:
             self.publish(self.search_report_topic_name, payload)
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-except # noqa F841;
             current_app.logger.error('Error: ' + repr(err))
             raise err
 
@@ -48,7 +48,7 @@ class GoogleQueueService():
         """Publish the api notification request json payload to the Queue Service."""
         try:
             self.publish(self.notification_topic_name, payload)
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-except # noqa F841;
             current_app.logger.error('Error: ' + repr(err))
             raise err
 

--- a/ppr-api/tests/unit/api/test_search_results.py
+++ b/ppr-api/tests/unit/api/test_search_results.py
@@ -260,8 +260,8 @@ def test_get_search_detail(session, client, jwt, desc, roles, status, has_accoun
 def test_callback_search_report(session, client, jwt, desc, status, search_id):
     """Assert that a callback request returns the expected status."""
     # test
-    rv = client.patch('/api/v1/search-results/callback/' + str(search_id),
-                      headers=None)
+    rv = client.post('/api/v1/search-results/callback/' + str(search_id),
+                     headers=None)
     # check
     assert rv.status_code == status
 
@@ -285,8 +285,8 @@ def test_valid_callback_search_report(session, client, jwt):
     search_detail.update_selection(select_json, 'UNIT TEST INC.', 'CALLBACK_URL')
 
     # test
-    rv = client.patch('/api/v1/search-results/callback/' + str(search_detail.search_id),
-                      headers=None)
+    rv = client.post('/api/v1/search-results/callback/' + str(search_detail.search_id),
+                     headers=None)
     # check
     print(rv.json)
     assert rv.status_code == HTTPStatus.OK

--- a/ppr-api/tests/unit/services/test_queue_service.py
+++ b/ppr-api/tests/unit/services/test_queue_service.py
@@ -1,0 +1,30 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Google Storage token tests."""
+from ppr_api.services.queue_service import GoogleQueueService
+
+
+TEST_PAYLOAD = {
+    'searchId': 999999999
+}
+
+
+def test_publish_search_report(session):
+    """Assert that enqueuing/publishing a search report event works as expected."""
+    GoogleQueueService().publish_search_report(TEST_PAYLOAD)
+
+
+def test_publish_api_notification(session):
+    """Assert that enqueuing/publishing an api notification event works as expected."""
+    GoogleQueueService().publish_notification(TEST_PAYLOAD)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10488

*Description of changes:*
- Change to build the report TOC data from original selection data matching on request reg number.
- Add publish/queue events for search result report and api notifications report is available. 
- Fix for recent check that prevents fetching of nil search detail report from completing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
