### PR TITLE
Fix always generate report for ui large requests

### DIFF
--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -88,14 +88,15 @@ class SearchResultsResource(Resource):
             # Large report threshold check, require/save callbackURL parameter.
             # UI may not request a report in step 2.
             callback_url = request.args.get(CALLBACK_PARAM)
-            if is_async(search_detail, request_json) and (resource_utils.is_pdf(request) or
-                                                          callback_url == SearchResult.UI_CALLBACK_URL):
+            is_ui_pdf = (callback_url is not None and callback_url == current_app.config.get('UI_SEARCH_CALLBACK_URL'))
+            if is_async(search_detail, request_json) and (resource_utils.is_pdf(request) or is_ui_pdf):
                 if callback_url is None:
                     error = f'Large search report required callbackURL parameter missing for {search_id}.'
                     current_app.logger.warn(error)
                     return resource_utils.error_response(HTTPStatus.BAD_REQUEST, error)
             else:
                 callback_url = None
+                is_ui_pdf = False
             # Save the search query selection and details that match the selection.
             account_name = resource_utils.get_account_name(jwt.get_token_auth_header(), account_id)
             search_detail.update_selection(request_json, account_name, callback_url)
@@ -103,7 +104,7 @@ class SearchResultsResource(Resource):
                 return resource_utils.unprocessable_error_response('search result details')
 
             response_data = search_detail.json
-            if resource_utils.is_pdf(request):
+            if resource_utils.is_pdf(request) or is_ui_pdf:
                 # If results over threshold return JSON with callbackURL, getReportURL
                 if callback_url is not None:
                     # Add enqueue report generation event here.


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
Fix UI requests for large search results: always request pdf on search step 2 even if format is not pdf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
