### PR TITLE
convert order date correctly after error

### DIFF
--- a/ppr-ui/src/components/common/CourtOrder.vue
+++ b/ppr-ui/src/components/common/CourtOrder.vue
@@ -387,7 +387,13 @@ export default defineComponent({
         }
         setCourtOrderInformation(newCourtOrderInfo)
       } else {
-        localState.orderDate = localState.courtOrderInfo.orderDate?.substring(0, 10)
+        if (localState.courtOrderInfo.orderDate?.length > 10) {
+          // convert back to local iso date string
+          const orderDate = new Date(localState.courtOrderInfo.orderDate)
+          localState.orderDate = orderDate.toLocaleDateString('en-CA', { timeZone: 'America/Vancouver' })
+        } else {
+          localState.orderDate = localState.courtOrderInfo.orderDate
+        }
         localState.effectOfOrder = localState.courtOrderInfo.effectOfOrder
         localState.courtName = localState.courtOrderInfo.courtName
         localState.courtRegistry = localState.courtOrderInfo.courtRegistry


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#10146

*Description of changes:*
- if the api errs then the date is now repopulated correctly (before it was putting in the UTC date)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
