### PR TITLE
small fix for add registration response for sbc staff

### DIFF
--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -666,7 +666,8 @@ class AccountRegistrationResource(Resource):
                 return resource_utils.unauthorized_error_response(account_id)
             # Try to fetch summary registration by registration number
             account_name = resource_utils.get_account_name(jwt.get_token_auth_header(), account_id)
-            registration = Registration.find_summary_by_reg_num(account_id, registration_num, account_name)
+            sbc_staff: bool = is_sbc_office_account(jwt.get_token_auth_header(), account_id)
+            registration = Registration.find_summary_by_reg_num(account_id, registration_num, account_name, sbc_staff)
             if registration is None:
                 return resource_utils.not_found_error_response('Financing Statement registration', registration_num)
             # Save the base registration: request may be a change registration number.


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#9904

*Description of changes:*
- pass in sbc staff var on post to denote whether or not they can see pdf / registered by

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
