### PR TITLE
always display something for cert name

### DIFF
--- a/ppr-ui/src/components/common/CertifyInformation.vue
+++ b/ppr-ui/src/components/common/CertifyInformation.vue
@@ -204,10 +204,24 @@ export default defineComponent({
         try {
           const token = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
           const decodedToken = JSON.parse(atob(token.split('.')[1]))
-          certifyInfo.legalName = decodedToken.firstname + ' ' + decodedToken.lastname
+          console.log(decodedToken)
+          if (decodedToken.firstname && decodedToken.lastname) {
+            certifyInfo.legalName = decodedToken.firstname + ' ' + decodedToken.lastname
+          } else if (decodedToken.name) {
+            certifyInfo.legalName = decodedToken.name
+          } else if (decodedToken.firstname) {
+            certifyInfo.legalName = decodedToken.firstName
+          } else if (decodedToken.lastname) {
+            certifyInfo.legalName = decodedToken.lastname
+          } else if (decodedToken.username) {
+            certifyInfo.legalName = decodedToken.username
+          } else {
+            certifyInfo.legalName = 'Not Available'
+          }
           email = decodedToken.email
         } catch (e) {
           console.error(e)
+          certifyInfo.legalName = 'Not Available'
         }
       }
       if (isRoleStaff.value) {

--- a/ppr-ui/src/components/common/CertifyInformation.vue
+++ b/ppr-ui/src/components/common/CertifyInformation.vue
@@ -204,7 +204,6 @@ export default defineComponent({
         try {
           const token = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
           const decodedToken = JSON.parse(atob(token.split('.')[1]))
-          console.log(decodedToken)
           if (decodedToken.firstname && decodedToken.lastname) {
             certifyInfo.legalName = decodedToken.firstname + ' ' + decodedToken.lastname
           } else if (decodedToken.name) {


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#10750

*Description of changes:*
updated cert name logic to always display something if expected fields are not in the token

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
