### PR TITLE
Allow get search results when no selection, no exact.

### DIFF
--- a/ppr-api/report-templates/template-parts/stylePage.html
+++ b/ppr-api/report-templates/template-parts/stylePage.html
@@ -13,7 +13,7 @@
 			color: #003366;
 			margin-right: 5px;
 			margin-bottom: 10px;
-			content: "TEST DATA  | Page " counter(page) " of " counter(pages);
+			content: "Page " counter(page) " of " counter(pages);
 			width: 100%;
 		}
 

--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -150,8 +150,9 @@ class SearchResultsResource(Resource):
             if not search_detail:
                 return resource_utils.not_found_error_response('searchId', search_id)
 
-            # If no search selection (step 2) return an error.
-            if not search_detail.search_select and search_detail.search.total_results_size > 0:
+            # If no search selection (step 2) return an error. Could be results
+            # with no exact matches and no results selected - nil, which is valid.
+            if search_detail.search_select is None and search_detail.search.total_results_size > 0:
                 return resource_utils.bad_request_response(GET_DETAILS_ERROR)
 
             # If the request is for an async large report, fetch binary data from doc storage.


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10827

*Description of changes:*
- Fix to allow get search results when no results selected in search step 2, and there are no exact matches.
- Also remove TEST DATA from prod report template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
