### PR TITLE
repr doesn't always return a string, and therefore concate will fail,…

### DIFF
--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -165,9 +165,9 @@ def pay_exception_response(exception: SBCPaymentException, account_id: str = Non
 
 def default_exception_response(exception):
     """Build default 500 exception error response."""
-    current_app.logger.error(repr(exception))
+    current_app.logger.error(str(exception))
     message = DEFAULT.format(code=ResourceErrorCodes.DEFAULT_ERR)
-    return jsonify({'message': message, 'detail': repr(exception)}), HTTPStatus.INTERNAL_SERVER_ERROR
+    return jsonify({'message': message, 'detail': str(exception)}), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 def service_exception_response(message):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10995

*Description of changes:*
repr doesn't always return a string, and therefore concatenation will, fail changing this one which account for a few hundred messages a day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
