### PR TITLE
Account reg summary non-base reg num missing changes fix.

### DIFF
--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -495,7 +495,6 @@ QUERY_ACCOUNT_CHANGE_REG_BASE = """
 SELECT arv2.financing_id
   FROM account_registration_vw arv2
  WHERE arv2.account_id = :query_account
-   AND arv2.registration_type_cl IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')
 """
 
 QUERY_ACCOUNT_CHANGE_REG = """

--- a/ppr-api/tests/unit/models/test_registration_utils.py
+++ b/ppr-api/tests/unit/models/test_registration_utils.py
@@ -295,6 +295,8 @@ def test_find_all_by_account_id_filter(session, reg_num, reg_type, client_ref, r
             assert statement['registeringName']
             assert statement['clientReferenceId']
         assert statement['baseRegistrationNumber']
+        if reg_num == 'TEST0018A':
+            assert len(statement['changes']) > 0
         if 'changes' in statement:
             for change in statement['changes']:
                 assert change['registrationNumber']


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10903

*Description of changes:*
- Fix to include change summary when filtering on non-base registration number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
