### PR TITLE
API consumer add account reg summary filters

### DIFF
--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -143,17 +143,20 @@ def build_account_collapsed_json(financing_json, registrations_json):
     return financing_json
 
 
-def build_account_collapsed_filter_json(financing_json, registrations_json, params: AccountRegistrationParams):
+def build_account_collapsed_filter_json(financing_json,
+                                        registrations_json,
+                                        params: AccountRegistrationParams,
+                                        api_filter: bool = False):
     """Organize account registrations as parent/child financing statement/change registrations."""
     for statement in financing_json:
         changes = []
         for registration in registrations_json:
             if statement['registrationNumber'] == registration['baseRegistrationNumber']:
                 changes.append(registration)
-                if params.registration_number and \
+                if not api_filter and params.registration_number and \
                         registration['registrationNumber'].startswith(params.registration_number):
                     statement['expand'] = True
-                elif params.client_reference_id and \
+                elif not api_filter and params.client_reference_id and \
                         registration['clientReferenceId'].startswith(params.client_reference_id):
                     statement['expand'] = True
         if changes:
@@ -281,9 +284,10 @@ def build_account_change_query(params: AccountRegistrationParams, base_json: dic
     return query
 
 
-def build_account_query_params(params: AccountRegistrationParams) -> dict:
+def build_account_query_params(params: AccountRegistrationParams, api_filter: bool = False) -> dict:
     """Build the account query runtime parameter set from the provided parameters."""
-    page_size: int = model_utils.get_max_registrations_size()
+    page_size: int = model_utils.MAX_ACCOUNT_REGISTRATIONS_DEFAULT if api_filter \
+        else model_utils.get_max_registrations_size()
     page_offset: int = params.page_number
     if page_offset <= 1:
         page_offset = 0
@@ -312,7 +316,7 @@ def build_account_query_params(params: AccountRegistrationParams) -> dict:
     return query_params
 
 
-def build_account_base_reg_results(params, rows) -> dict:
+def build_account_base_reg_results(params, rows, api_filter: bool = False) -> dict:
     """Build the account query base registration results from the query result set."""
     results_json = []
     if rows is not None:
@@ -320,12 +324,12 @@ def build_account_base_reg_results(params, rows) -> dict:
             mapping = row._mapping  # pylint: disable=protected-access; follows documentation
             reg_class = str(mapping['registration_type_cl'])
             if model_utils.is_financing(reg_class):
-                results_json.append(__build_account_reg_result(params, mapping, reg_class))
+                results_json.append(__build_account_reg_result(params, mapping, reg_class, api_filter))
 
     return results_json
 
 
-def update_account_reg_results(params, rows, results_json) -> dict:
+def update_account_reg_results(params, rows, results_json, api_filter: bool = False) -> dict:
     """Build the account query base registration results from the query result set."""
     if results_json and rows is not None:
         changes_json = []
@@ -333,13 +337,13 @@ def update_account_reg_results(params, rows, results_json) -> dict:
             mapping = row._mapping  # pylint: disable=protected-access; follows documentation
             reg_class = str(mapping['registration_type_cl'])
             if not model_utils.is_financing(reg_class):
-                changes_json.append(__build_account_reg_result(params, mapping, reg_class))
+                changes_json.append(__build_account_reg_result(params, mapping, reg_class, api_filter))
         if changes_json:
-            return build_account_collapsed_filter_json(results_json, changes_json, params)
+            return build_account_collapsed_filter_json(results_json, changes_json, params, api_filter)
     return results_json
 
 
-def __build_account_reg_result(params, mapping, reg_class) -> dict:
+def __build_account_reg_result(params, mapping, reg_class, api_filter: bool = False) -> dict:
     """Build a registration result from a query result set row."""
     reg_num = str(mapping['registration_number'])
     base_reg_num = str(mapping['base_reg_number'])
@@ -360,13 +364,25 @@ def __build_account_reg_result(params, mapping, reg_class) -> dict:
         'registeringParty': str(mapping['registering_party']),
         'securedParties': str(mapping['secured_party']),
         'clientReferenceId': str(mapping['client_reference_id']),
-        'registeringName': registering_name,
-        'vehicleCount': int(mapping['vehicle_count'])
+        'registeringName': registering_name
     }
-    if model_utils.is_financing(reg_class):
+    if not api_filter:
+        result['vehicleCount'] = int(mapping['vehicle_count'])
+    if model_utils.is_financing(reg_class) and not api_filter:
         result['expand'] = False
     result = set_path(params, result, reg_num, base_reg_num, int(mapping['pending_count']))
     result = update_summary_optional(result, params.account_id, params.sbc_staff)
     if 'accountId' in result:
         del result['accountId']  # Only use this for report access checking.
     return result
+
+
+def api_account_reg_filter(params: AccountRegistrationParams) -> bool:
+    """Check if api account registration summary request includes filter parameters.
+
+    Filter parameters may be a client reference ID, a timestamp range, or a registration number.
+    """
+    if not params.from_ui and (params.client_reference_id or params.registration_number or \
+            (params.start_date_time and params.end_date_time)):
+        return True
+    return False

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -541,7 +541,6 @@ SELECT registration_number, registration_ts, registration_type, registration_typ
 ORDER BY registration_ts DESC
 """
 
-
 # Error messages
 ERR_FINANCING_NOT_FOUND = '{code}: no Financing Statement found for registration number {registration_num}.'
 ERR_REGISTRATION_NOT_FOUND = '{code}: no registration found for registration number {registration_num}.'
@@ -555,6 +554,8 @@ ERR_DRAFT_USED = '{code}: Draft Statement for Document ID {document_number} has 
 ERR_SEARCH_TOO_OLD = '{code}: search get details search ID {search_id} timestamp too old: must be after {min_ts}.'
 ERR_SEARCH_COMPLETE = '{code}: search select results failed: results already provided for search ID {search_id}.'
 ERR_SEARCH_NOT_FOUND = '{code}: search select results failed: invalid search ID {search_id}.'
+
+SEARCH_RESULTS_DOC_NAME = 'search-results-report-{search_id}.pdf'
 
 
 def get_max_registrations_size():
@@ -723,6 +724,13 @@ def get_doc_storage_name(registration):
     name = registration.registration_ts.isoformat()[:10]
     name = name.replace('-', '/') + '/' + registration.registration_type_cl.lower()
     name += '-' + str(registration.id) + '-' + registration.registration_num + '.pdf'
+    return name
+
+
+def get_search_doc_storage_name(search_request):
+    """Get a search document storage name in the format YYYY/MM/DD/search-results-report-search_id.pdf."""
+    name = search_request.search_ts.isoformat()[:10]
+    name = name.replace('-', '/') + '/' + SEARCH_RESULTS_DOC_NAME.format(search_id=search_request.id)
     return name
 
 

--- a/ppr-api/tests/unit/models/test_utils.py
+++ b/ppr-api/tests/unit/models/test_utils.py
@@ -18,7 +18,7 @@ from datetime import timedelta as _timedelta
 import pytest
 from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT
 
-from ppr_api.models import utils as model_utils, Registration
+from ppr_api.models import utils as model_utils, Registration, SearchRequest
 
 
 # testdata pattern is ({registration_ts}, {years}, {expiry_ts})
@@ -431,4 +431,13 @@ def test_doc_storage_name(session, desc, reg_num, doc_name):
     test_name = test_name.replace('-', '/') + '/' + registration.registration_type_cl.lower() + \
                 '-' + str(registration.id) + '-' + registration.registration_num + '.pdf'
     name = model_utils.get_doc_storage_name(registration)
+    assert test_name == name
+
+
+def test_search_doc_storage_name(session):
+    """Assert that building a search storage document name works as expected."""
+    search: SearchRequest = SearchRequest(id=2000, search_ts=model_utils.now_ts())
+    test_name = search.search_ts.isoformat()[:10]
+    test_name = test_name.replace('-', '/') + '/search-results-report-2000.pdf'
+    name = model_utils.get_search_doc_storage_name(search)
     assert test_name == name


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#11267

*Description of changes:*
- 11267 add query parameters to GET account registration summary activity for high volume API consumers.
- Store search summary reports in folders by date.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
