### PR TITLE
address fix

### DIFF
--- a/ppr-ui/src/components/parties/debtor/EditDebtor.vue
+++ b/ppr-ui/src/components/parties/debtor/EditDebtor.vue
@@ -343,7 +343,8 @@ export default defineComponent({
       ) {
         addDebtor()
       } else {
-        localState.showAllAddressErrors = true
+        // trigger show validation
+        localState.showAllAddressErrors = !localState.showAllAddressErrors
       }
     }
 

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -385,7 +385,8 @@ export default defineComponent({
           addEditSecuredParty()
         }
       } else {
-        localState.showAllAddressErrors = true
+        // trigger show validation
+        localState.showAllAddressErrors = !localState.showAllAddressErrors
       }
     }
 

--- a/ppr-ui/src/composables/address/BaseAddress.vue
+++ b/ppr-ui/src/composables/address/BaseAddress.vue
@@ -185,12 +185,12 @@ export default defineComponent({
       schemaLocal,
       isSchemaRequired,
       labels
-    } = useAddress(toRefs(props).value, toRefs(props).schema)
+    } = useAddress(toRefs(props).value, props.schema)
 
     const origPostalCodeRules = schemaLocal.value.postalCode
     const origRegionRules = schemaLocal.value.region
 
-    const { addressForm, validate } = useBaseValidations()
+    const { addressForm, resetValidation, validate } = useBaseValidations()
 
     const { enableAddressComplete, uniqueIds } = useAddressComplete(addressLocal)
 
@@ -208,9 +208,6 @@ export default defineComponent({
         schemaLocal.value.region = origRegionRules
       } else {
         schemaLocal.value.postalCode = origPostalCodeRules.concat([baseRules.maxLength(15)])
-        for (let i = 0; i < schemaLocal.value.region.length; i++) {
-          schemaLocal.value.region.pop()
-        }
         schemaLocal.value.region = [baseRules.maxLength(2), ...spaceRules]
       }
       // reset other address fields (check is for loading an existing address)
@@ -221,6 +218,7 @@ export default defineComponent({
         addressLocal.value.region = ''
         addressLocal.value.postalCode = ''
       }
+      resetValidation()
     }
 
     onMounted(() => {
@@ -248,10 +246,8 @@ export default defineComponent({
       countryChangeHandler(val, oldVal)
     })
 
-    watch(() => props.triggerErrors, (val) => {
-      if (val) {
-        validate()
-      }
+    watch(() => props.triggerErrors, () => {
+      validate()
     })
 
     return {

--- a/ppr-ui/src/composables/address/factories/address-factory.ts
+++ b/ppr-ui/src/composables/address/factories/address-factory.ts
@@ -1,16 +1,16 @@
 /* eslint-disable */
-import { computed, reactive, Ref } from '@vue/composition-api'
+import { computed, reactive, ref, Ref } from '@vue/composition-api'
 import { uniqueId } from 'lodash'
 
 import { AddressIF, SchemaIF } from '@/composables/address/interfaces'
 
-export function useAddress (address: Ref<AddressIF>, schema: Ref<SchemaIF>) {
+export function useAddress (address: Ref<AddressIF>, schema: SchemaIF) {
   const addressLocal = address
   /** The Address Country, to simplify the template and so we can watch it directly. */
   const country = computed((): string => {
     return addressLocal.value.country
   })
-  const schemaLocal = schema
+  const schemaLocal = ref(schema)
   const isSchemaRequired = (prop: string): boolean => {
     if (!schemaLocal || !schemaLocal.value[prop]) return false
 

--- a/ppr-ui/src/composables/address/factories/validation-factory.ts
+++ b/ppr-ui/src/composables/address/factories/validation-factory.ts
@@ -6,10 +6,13 @@ import { ValidationRule } from '@/composables/address/enums'
 export function useBaseValidations () {
   /* this variable must be named the same as your ref=___ in your form */
   const addressForm = ref(null)
+  const resetValidation = () => {
+    addressForm.value.resetValidation()
+  }
   const validate = () => {
     addressForm.value.validate()
   }
-  return { addressForm, validate }
+  return { addressForm, resetValidation, validate }
 }
 
 /* Rules used in most schemas */

--- a/ppr-ui/tests/unit/DebtorValidation.spec.ts
+++ b/ppr-ui/tests/unit/DebtorValidation.spec.ts
@@ -60,9 +60,8 @@ describe('Debtor validation tests - business', () => {
     wrapper.find(doneButtonSelector).trigger('click')
     await flushPromises()
     const messages = wrapper.findAll('.v-messages__message')
-    expect(messages.length).toBe(6)
+    expect(messages.length).toBe(2)
     expect(messages.at(0).text()).toBe('Please enter a business name')
-    expect(messages.at(1).text()).toBe('This field is required')
   })
 })
 
@@ -83,11 +82,9 @@ describe('Debtor validation tests - individual', () => {
     wrapper.find(doneButtonSelector).trigger('click')
     await flushPromises()
     const messages = wrapper.findAll('.v-messages__message')
-    expect(messages.length).toBe(7)
+    expect(messages.length).toBe(4)
     expect(messages.at(0).text()).toBe('Please enter a first name')
     expect(messages.at(2).text()).toBe('Please enter a last name')
-    // address validation
-    expect(messages.at(3).text()).toBe('This field is required')
   })
 
   it('validates the birthday', async () => {
@@ -100,10 +97,9 @@ describe('Debtor validation tests - individual', () => {
     wrapper.find(doneButtonSelector).trigger('click')
     await flushPromises()
     const messages = wrapper.findAll('.v-messages__message')
-    expect(messages.length).toBe(8)
+    expect(messages.length).toBe(5)
     expect(messages.at(1).text()).toBe('Please enter a valid month')
     expect(messages.at(2).text()).toBe('Please enter a valid day')
     expect(messages.at(3).text()).toBe('Please enter a valid year')
-    expect(messages.at(4).text()).toBe('This field is required')
   })
 })

--- a/ppr-ui/tests/unit/SecuredPartyValidation.spec.ts
+++ b/ppr-ui/tests/unit/SecuredPartyValidation.spec.ts
@@ -62,9 +62,8 @@ describe('Secured Party validation tests - business', () => {
     wrapper.find(doneButtonSelector).trigger('click')
     await flushPromises()
     const messages = wrapper.findAll('.v-messages__message')
-    expect(messages.length).toBe(6)
+    expect(messages.length).toBe(2)
     expect(messages.at(0).text()).toBe('Please enter a business name')
-    expect(messages.at(1).text()).toBe('This field is required')
   })
 })
 
@@ -91,10 +90,9 @@ describe('Secured Party validation tests - individual', () => {
     wrapper.find(doneButtonSelector).trigger('click')
     await flushPromises()
     const messages = wrapper.findAll('.v-messages__message')
-    expect(messages.length).toBe(6)
+    expect(messages.length).toBe(3)
     expect(messages.at(0).text()).toBe('Please enter a first name')
     expect(messages.at(1).text()).toBe('Please enter a last name')
-    expect(messages.at(3).text()).toBe('This field is required')
   })
 
   it('validates the email', async () => {


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#11160

*Description of changes:*
- prevent party/debtor comps from updating the address schema after init
- trigger all validation when user presses 'done' (before was just happening the first time)
- reset validation when country changes (allows it to be revalidated with updated rules + doesn't show val errors until user types or presses done)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
