### PR TITLE
API consumer add account reg summary filters

### DIFF
--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -541,7 +541,6 @@ SELECT registration_number, registration_ts, registration_type, registration_typ
 ORDER BY registration_ts DESC
 """
 
-
 # Error messages
 ERR_FINANCING_NOT_FOUND = '{code}: no Financing Statement found for registration number {registration_num}.'
 ERR_REGISTRATION_NOT_FOUND = '{code}: no registration found for registration number {registration_num}.'
@@ -555,6 +554,8 @@ ERR_DRAFT_USED = '{code}: Draft Statement for Document ID {document_number} has 
 ERR_SEARCH_TOO_OLD = '{code}: search get details search ID {search_id} timestamp too old: must be after {min_ts}.'
 ERR_SEARCH_COMPLETE = '{code}: search select results failed: results already provided for search ID {search_id}.'
 ERR_SEARCH_NOT_FOUND = '{code}: search select results failed: invalid search ID {search_id}.'
+
+SEARCH_RESULTS_DOC_NAME = 'search-results-report-{search_id}.pdf'
 
 
 def get_max_registrations_size():
@@ -726,6 +727,13 @@ def get_doc_storage_name(registration):
     name = registration.registration_ts.isoformat()[:10]
     name = name.replace('-', '/') + '/' + registration.registration_type_cl.lower()
     name += '-' + str(registration.id) + '-' + registration.registration_num + '.pdf'
+    return name
+
+
+def get_search_doc_storage_name(search_request):
+    """Get a search document storage name in the format YYYY/MM/DD/search-results-report-search_id.pdf."""
+    name = search_request.search_ts.isoformat()[:10]
+    name = name.replace('-', '/') + '/' + SEARCH_RESULTS_DOC_NAME.format(search_id=search_request.id)
     return name
 
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#11267

*Description of changes:*
- 11267 add query parameters to GET account registration summary activity for high volume API consumers.
- Store search summary reports in folders by date.
- Identical to closed, previously approved PR 628. Merging without re-review.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
