### PR TITLE
Report gc descriptions preserve whitespace. Improve API error messages.

### DIFF
--- a/ppr-api/report-templates/template-parts/registration/generalCollateral.html
+++ b/ppr-api/report-templates/template-parts/registration/generalCollateral.html
@@ -12,15 +12,7 @@
          <div class="section-data-bold pt-3 pb-2">{{ collateral.addedDateTime }}</div>
       {% endif %}
       {% if collateral.description is defined %}
-         <div class="section-data page-break-inside : auto">
-            {% set list1 = collateral.description.split('\n') %}
-            {% for item in list1 %}
-               {{ item }}
-               {% if not loop.last %}
-                  <br/>
-               {% endif %}
-            {% endfor %}
-         </div>
+         <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
       {% else %}
          {% if collateral.descriptionDelete is defined %}
             {% if collateral.descriptionAdd is defined %}
@@ -28,27 +20,11 @@
             {% else %}
                <div class="pb-1"><span class="label">DELETED</span></div>
             {% endif %}
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.descriptionDelete.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-            </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.descriptionDelete}}</div>
          {% endif %}
          {% if collateral.descriptionAdd is defined %}
             <div class="pb-1"><span class="label">ADDED</span></div>
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.descriptionAdd.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}   
-            </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.descriptionAdd}}</div>
          {% endif %}
       {% endif %}
       {% if not loop.last %}
@@ -61,15 +37,7 @@
       {% for collateral in deleteGeneralCollateral %}
          {% if collateral.edit is not defined %}
             <div class="pt-3 pb-1"><span class="label">DELETED</span></div>
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.description.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-               </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
             {% if loop.last == false  %}
                <div class="separator-section mt-4 mb-1"></div>
             {% endif %}
@@ -79,15 +47,7 @@
    {% if addGeneralCollateral is defined %}
       {% for collateral in addGeneralCollateral %}
          <div class="pt-3 pb-1"><span class="label">{% if collateral.edit is not defined %}ADDED{% else %}AMENDED{% endif %}</span></div>
-         <div class="section-data page-break-inside : auto">
-            {% set list1 = collateral.description.split('\n') %}
-            {% for item in list1 %}
-               {{ item }}
-               {% if not loop.last %}
-                  <br/>
-               {% endif %}
-            {% endfor %}
-        </div>
+         <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
          {% if loop.last == false  %}
             <div class="separator-section mt-4 mb-1"></div>
          {% endif %}
@@ -99,15 +59,7 @@
       {% for collateral in change.deleteGeneralCollateral %}
          {% if collateral.edit is not defined %}
             <div class="pt-3 pb-1"><span class="label">DELETED</span></div>
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.description.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-               </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
             {% if loop.last == false  %}
                <div class="separator-section mt-4 mb-1"></div>
             {% endif %}
@@ -117,15 +69,7 @@
    {% if change.addGeneralCollateral is defined %}
       {% for collateral in change.addGeneralCollateral %}
          <div class="pt-3 pb-1"><span class="label">{% if collateral.edit is not defined %}ADDED{% else %}AMENDED{% endif %}</span></div>
-         <div class="section-data page-break-inside : auto">
-            {% set list1 = collateral.description.split('\n') %}
-            {% for item in list1 %}
-               {{ item }}
-               {% if not loop.last %}
-                  <br/>
-               {% endif %}
-            {% endfor %}
-         </div>
+         <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
          {% if loop.last == false  %}
             <div class="separator-section mt-4 mb-1"></div>
          {% endif %}

--- a/ppr-api/report-templates/template-parts/search-result/generalCollateral.html
+++ b/ppr-api/report-templates/template-parts/search-result/generalCollateral.html
@@ -12,15 +12,7 @@
          <div class="general-collateral-datetime pt-3 pb-2">{{ collateral.addedDateTime }}</div>
       {% endif %}
       {% if collateral.description is defined %}
-         <div class="section-data page-break-inside : auto">
-            {% set list1 = collateral.description.split('\n') %}
-            {% for item in list1 %}
-               {{ item }}
-               {% if not loop.last %}
-                  <br/>
-               {% endif %}
-            {% endfor %}
-      </div>
+         <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
       {% else %}
          {% if collateral.descriptionDelete is defined %}
             {% if collateral.descriptionAdd is defined %}
@@ -28,27 +20,11 @@
             {% else %}
                <div class="pb-1"><span class="label">DELETED</span></div>
             {% endif %}
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.descriptionDelete.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-            </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.descriptionDelete}}</div>
          {% endif %}
          {% if collateral.descriptionAdd is defined %}
             <div class="pb-1"><span class="label">ADDED</span></div>
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.descriptionAdd.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-            </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.descriptionAdd}}</div>
          {% endif %}
       {% endif %}
       {% if not loop.last %}
@@ -61,15 +37,7 @@
       {% for collateral in change.deleteGeneralCollateral %}
          {% if collateral.edit is not defined %}
             <div class="pt-3 pb-1"><span class="label">DELETED</span></div>
-            <div class="section-data page-break-inside : auto">
-               {% set list1 = collateral.description.split('\n') %}
-               {% for item in list1 %}
-                  {{ item }}
-                  {% if not loop.last %}
-                     <br/>
-                  {% endif %}
-               {% endfor %}
-            </div>
+            <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
             {% if loop.last == false  %}
                <div class="separator-section mt-4 mb-1"></div>
             {% endif %}
@@ -79,15 +47,7 @@
    {% if change.addGeneralCollateral is defined %}
       {% for collateral in change.addGeneralCollateral %}
          <div class="pt-3 pb-1"><span class="label">{% if collateral.edit is not defined %}ADDED{% else %}AMENDED{% endif %}</span></div>
-         <div class="section-data page-break-inside : auto">
-            {% set list1 = collateral.description.split('\n') %}
-            {% for item in list1 %}
-               {{ item }}
-               {% if not loop.last %}
-                  <br/>
-               {% endif %}
-            {% endfor %}
-         </div>
+         <div class="section-data-gc page-break-inside : auto">{{collateral.description}}</div>
          {% if not loop.last %}
             <div class="separator-section mt-4 mb-1"></div>
          {% endif %}

--- a/ppr-api/report-templates/template-parts/style.html
+++ b/ppr-api/report-templates/template-parts/style.html
@@ -410,6 +410,15 @@
 		text-align: left;
 	}
 
+	.section-data-gc {
+		font-family: 'BCSans-Regular', sans-serif !important;
+		color: #313132;
+		font-size: 11pt;
+		line-height: 13pt;
+		text-align: left;
+		white-space: pre-wrap !important;
+	}
+
 	.cover-data {
 		font-family: 'BCSans-Regular', sans-serif !important;
 		color: #313132;

--- a/ppr-api/src/ppr_api/services/payment/client/__init__.py
+++ b/ppr-api/src/ppr_api/services/payment/client/__init__.py
@@ -172,7 +172,11 @@ class ApiRequestError(Exception):
         """Set up the exception."""
         if response is not None:
             self.status_code = response.status_code
-            self.json_data = json.loads(response.text)
+            try:
+                self.json_data = json.loads(response.text)
+            except Exception:   # noqa: B902; return nicer default error
+                current_app.logger.error('Pay api non-JSON response: ' + response.text)
+                self.json_data = {'message': 'Error parsing payment error response as JSON.'}
             self.json_data['status_code'] = response.status_code
             self.detail = self.json_data.get('detail', '')
             self.title = self.json_data.get('title', '')

--- a/ppr-api/src/ppr_api/utils/validators/financing_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/financing_validator.py
@@ -23,29 +23,29 @@ from ppr_api.models.registration import MiscellaneousTypes, PPSATypes
 
 
 # Error messages
-AUTHORIZATION_INVALID = 'Authorization Received indicator is required with this registration.\n'
-TYPE_NOT_ALLOWED = 'A new Financing Statement cannot be created with the submitted registration type.\n'
-GC_NOT_ALLOWED = 'General Collateral is not allowed with this registration type.\n'
-GC_REQUIRED = 'General Collateral is required with this registration type.\n'
-LA_NOT_ALLOWED = 'Lien Amount is not allowed with this registration type.\n'
-LY_NOT_ALLOWED = 'Life years is not allowed with this registration type.\n'
-LI_NOT_ALLOWED = 'Life Infinite is not allowed with this registration type.\n'
-LI_INVALID = 'Life Infinite must be true with this registration type.\n'
-LIFE_MISSING = 'Either Life Years or Life Infinite is required with this registration type.\n'
-LIFE_INVALID = 'Only one of Life Years or Life Infinite is allowed.\n'
-OT_MISSING_DESCRIPTION = 'When type is OT Other Type Description is required.\n'
-OT_NOT_ALLOWED = 'Other Type Description is not allowed with this registration type.\n'
-RL_AMOUNT_REQUIRED = "Lien Amount is required with a Repairer's Lien.\n"
-RL_AMOUNT_INVALID = 'The Lien Amount must be a number greater than 0.\n'
-RL_DATE_REQUIRED = "Surrender Date is required with a Repairer's Lien.\n"
-RL_DATE_INVALID = 'The Surrender Date cannot be more than 21 days in the past.\n'
-SD_NOT_ALLOWED = 'Surrender Date is not allowed with this registration type.\n'
-TI_NOT_ALLOWED = 'Trust Indendure is not allowed with this registration type.\n'
-VC_NOT_ALLOWED = 'Vehicle Collateral is not allowed with this registration type.\n'
-VC_REQUIRED = 'Vehicle Collateral is required with this registration type.\n'
-VC_MH_ONLY = 'Only Vehicle Collateral type MH is allowed with this registration type.\n'
-VC_MH_NOT_ALLOWED = 'Vehicle Collateral type MH is not allowed with this registration type.\n'
-VC_AP_NOT_ALLOWED = 'Vehicle Collateral type AP is not allowed.\n'
+AUTHORIZATION_INVALID = 'Authorization Received indicator is required with this registration. '
+TYPE_NOT_ALLOWED = 'A new Financing Statement cannot be created with the submitted registration type. '
+GC_NOT_ALLOWED = 'General Collateral is not allowed with this registration type. '
+GC_REQUIRED = 'General Collateral is required with this registration type. '
+LA_NOT_ALLOWED = 'Lien Amount is not allowed with this registration type. '
+LY_NOT_ALLOWED = 'Life years is not allowed with this registration type. '
+LI_NOT_ALLOWED = 'Life Infinite is not allowed with this registration type. '
+LI_INVALID = 'Life Infinite must be true with this registration type. '
+LIFE_MISSING = 'Either Life Years or Life Infinite is required with this registration type. '
+LIFE_INVALID = 'Only one of Life Years or Life Infinite is allowed. '
+OT_MISSING_DESCRIPTION = 'When type is OT Other Type Description is required. '
+OT_NOT_ALLOWED = 'Other Type Description is not allowed with this registration type. '
+RL_AMOUNT_REQUIRED = "Lien Amount is required with a Repairer's Lien. "
+RL_AMOUNT_INVALID = 'The Lien Amount must be a number greater than 0. '
+RL_DATE_REQUIRED = "Surrender Date is required with a Repairer's Lien. "
+RL_DATE_INVALID = 'The Surrender Date cannot be more than 21 days in the past. '
+SD_NOT_ALLOWED = 'Surrender Date is not allowed with this registration type. '
+TI_NOT_ALLOWED = 'Trust Indendure is not allowed with this registration type. '
+VC_NOT_ALLOWED = 'Vehicle Collateral is not allowed with this registration type. '
+VC_REQUIRED = 'Vehicle Collateral is required with this registration type. '
+VC_MH_ONLY = 'Only Vehicle Collateral type MH is allowed with this registration type. '
+VC_MH_NOT_ALLOWED = 'Vehicle Collateral type MH is not allowed with this registration type. '
+VC_AP_NOT_ALLOWED = 'Vehicle Collateral type AP is not allowed. '
 
 GC_NOT_ALLOWED_LIST = [MiscellaneousTypes.MH_NOTICE.value,
                        PPSATypes.MARRIAGE_SEPARATION.value,

--- a/ppr-api/src/ppr_api/utils/validators/party_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/party_validator.py
@@ -34,7 +34,7 @@ INVALID_COUNTRY_SECURED = 'Secured Party country {} is invalid. '
 INVALID_REGION_SECURED = 'Secured Party region {} is invalid. '
 INVALID_COUNTRY_DEBTOR = 'Debtor country {} is invalid. '
 INVALID_REGION_DEBTOR = 'Debtor region {} is invalid. '
-CHARACTER_SET_UNSUPPORTED = 'The character set is not supported for name {}.\n'
+CHARACTER_SET_UNSUPPORTED = 'The character set is not supported for name {}. '
 
 
 def validate_financing_parties(json_data):
@@ -189,7 +189,7 @@ def validate_address(json_party, country_message: str, region_message: str):
                 country_prefix = country.alpha_2 + '-' if country else 'CA-'
                 # test_code = country_prefix + json_address['region'].strip().upper()
                 region_code = pycountry.subdivisions.get(code=(country_prefix + json_address['region'].strip().upper()))
-            if not region_code and country in ('CA', 'US'):
+            if not region_code and json_country in ('CA', 'US'):
                 error_msg += region_message.format(json_address['region'])
             # not checking region validity for outside CA + US but still must be under 2 chars
             if len(json_address['region'].strip()) > 2:

--- a/ppr-api/src/ppr_api/utils/validators/registration_validator.py
+++ b/ppr-api/src/ppr_api/utils/validators/registration_validator.py
@@ -18,20 +18,20 @@ Validation includes verifying delete collateral ID's and timestamps.
 from ppr_api.models import utils as model_utils, VehicleCollateral
 
 
-COURT_ORDER_INVALID = 'CourtOrderInformation is not allowed with a base registration type of {}.\n'
-COURT_ORDER_MISSING = 'Required courtOrderInformation is missing.\n'
+COURT_ORDER_INVALID = 'CourtOrderInformation is not allowed with a base registration type of {}. '
+COURT_ORDER_MISSING = 'Required courtOrderInformation is missing. '
 COURT_ORDER_INVALID_DATE = 'Invalid courtOrderInformation.orderDate: the value must be between the base ' + \
-                           'registration date and the current system date.\n'
-AUTHORIZATION_INVALID = 'Authorization Received indicator is required with this registration.\n'
-DELETE_MISSING_ID_VEHICLE = 'Required vehicleId missing in delete Vehicle Collateral.\n'
-DELETE_MISSING_ID_GENERAL = 'Required collateralId missing in delete General Collateral.\n'
-DELETE_INVALID_ID_VEHICLE = 'Invalid vehicleId {} in delete Vehicle Collateral.\n'
-DELETE_INVALID_ID_GENERAL = 'Invalid collateralId {} in delete General Collateral.\n'
-LI_NOT_ALLOWED = 'Life Infinite is not allowed with this registration type.\n'
-RENEWAL_INVALID = 'Renewal registration is now allowed: the base registration has an infinite life.\n'
-LIFE_MISSING = 'Either Life Years or Life Infinite is required with this registration type.\n'
-LIFE_INVALID = 'Only one of Life Years or Life Infinite is allowed.\n'
-VC_AP_NOT_ALLOWED = 'Vehicle Collateral type AP is not allowed.\n'
+                           'registration date and the current system date. '
+AUTHORIZATION_INVALID = 'Authorization Received indicator is required with this registration. '
+DELETE_MISSING_ID_VEHICLE = 'Required vehicleId missing in delete Vehicle Collateral. '
+DELETE_MISSING_ID_GENERAL = 'Required collateralId missing in delete General Collateral. '
+DELETE_INVALID_ID_VEHICLE = 'Invalid vehicleId {} in delete Vehicle Collateral. '
+DELETE_INVALID_ID_GENERAL = 'Invalid collateralId {} in delete General Collateral. '
+LI_NOT_ALLOWED = 'Life Infinite is not allowed with this registration type. '
+RENEWAL_INVALID = 'Renewal registration is now allowed: the base registration has an infinite life. '
+LIFE_MISSING = 'Either Life Years or Life Infinite is required with this registration type. '
+LIFE_INVALID = 'Only one of Life Years or Life Infinite is allowed. '
+VC_AP_NOT_ALLOWED = 'Vehicle Collateral type AP is not allowed. '
 
 
 def validate_registration(json_data, financing_statement=None):

--- a/ppr-api/tests/unit/utils/test_party_validator.py
+++ b/ppr-api/tests/unit/utils/test_party_validator.py
@@ -16,6 +16,8 @@ import copy
 
 import pytest
 
+from flask import current_app
+
 from ppr_api.models import FinancingStatement
 from ppr_api.utils.validators import party_validator as validator
 
@@ -85,11 +87,22 @@ FINANCING_INVALID = {
             'address': {
                 'street': '3720 BEACON AVENUE',
                 'city': 'SIDNEY',
-                'region': 'BX',
+                'region': 'BC',
                 'country': 'XX',
                 'postalCode': 'V7R 1R7'
             },
             'partyId': 1321095
+        },
+        {
+            'businessName': 'BANK OF BRITISH COLUMBIA',
+            'address': {
+                'street': '3720 BEACON AVENUE',
+                'city': 'SIDNEY',
+                'region': 'BX',
+                'country': 'CA',
+                'postalCode': 'V7R 1R7'
+            },
+            'partyId': 1321096
         },
         {
             'code': '300000000'
@@ -539,6 +552,7 @@ def test_validate_party_addresses_registration(session, desc, json_data, valid, 
 def test_validate_registration_parties(session, desc, json_data, valid, message_content):
     """Assert that registration statement party validation works as expected."""
     error_msg = validator.validate_registration_parties(json_data)
+    current_app.logger.info(error_msg)
     if valid:
         assert error_msg == ''
     elif message_content:


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10913
 /bcgov/entity#10904

*Description of changes:*
- 10904 update report general collateral descriptions to preserve whitespace.
- 10913 handle pay api response that are not JSON. Do not return trailing new line character in API error responses.
- Improve party address region validation for CA, US addresses.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
