### PR TITLE
Add reg to account restrict misc lien types.

### DIFF
--- a/ppr-api/src/ppr_api/resources/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/financing_statements.py
@@ -670,7 +670,7 @@ class AccountRegistrationResource(Resource):
                 return resource_utils.duplicate_error_response(message)
             # Restricted access check for crown charge class of registration types.
             if not is_all_staff_account(account_id) and \
-                    registration['registrationClass'] == model_utils.REG_CLASS_CROWN and \
+                    registration['registrationClass'] in (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC) and \
                     not AccountBcolId.crown_charge_account(account_id):
                 return resource_utils.cc_forbidden_error_response(account_id)
             if registration['accountId'] != account_id:


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#11791

*Description of changes:*
When adding a registration to an account restrict misc. lien registration types to only crown charge accounts (similar to crown charge registration types).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
