### PR TITLE
Fee Summary - Support Multiples and Mhr Results UX Improvements

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -3,12 +3,13 @@
     <fee-summary
       v-if="showFeeSummary"
       :setFeeOverride="feeOverride"
-      :setFeeType="feeType"
-      :setFeeQuantity="feeQuantity"
+      :setFeeType="setFeeType"
+      :setFeeQuantity="setFeeQuantity"
       :setRegistrationLength="registrationLength"
       :setRegistrationType="registrationType"
       :setStaffReg="isStaffReg"
       :setStaffSBC="isStaffSBC"
+      :additionalFees="setAdditionalFees"
     />
     <buttons-stacked
       v-if="showButtons"
@@ -42,9 +43,15 @@ import { useGetters } from 'vuex-composition-helpers'
 import { ButtonsStacked } from '@/components/common'
 import { FeeSummary } from '@/composables/fees'
 // local enums/interfaces/etc.
-import { UIRegistrationTypes } from '@/enums' // eslint-disable-line no-unused-vars
-import { FeeSummaryTypes } from '@/composables/fees/enums' // eslint-disable-line no-unused-vars
-import { FeeSummaryI, RegistrationLengthI } from '@/composables/fees/interfaces' // eslint-disable-line no-unused-vars
+/* eslint-disable no-unused-vars */
+import { UIRegistrationTypes } from '@/enums'
+import { FeeSummaryTypes } from '@/composables/fees/enums'
+import {
+  AdditionalSearchFeeIF,
+  FeeSummaryI,
+  RegistrationLengthI
+} from '@/composables/fees/interfaces'
+/* eslint-enable no-unused-vars */
 
 export default defineComponent({
   name: 'StickyContainer',
@@ -73,11 +80,19 @@ export default defineComponent({
     setFeeType: {
       type: String as () => FeeSummaryTypes
     },
+    setFeeQuantity: {
+      default: null,
+      type: Number
+    },
     setRegistrationLength: {
       type: Object as () => RegistrationLengthI
     },
     setRegistrationType: {
       type: String as () => UIRegistrationTypes
+    },
+    setAdditionalFees: {
+      default: null,
+      type: Object as () => AdditionalSearchFeeIF
     },
     // buttons
     setBackBtn: {
@@ -98,7 +113,7 @@ export default defineComponent({
   },
   setup (props, { emit }) {
     const {
-      getUserServiceFee, isNonBillable, isRoleStaffReg, isRoleStaffSbc, getSelectedManufacturedHomes
+      getUserServiceFee, isNonBillable, isRoleStaffReg, isRoleStaffSbc
     } = useGetters<any>([
       'getUserServiceFee', 'isNonBillable', 'isRoleStaffReg', 'isRoleStaffSbc', 'getSelectedManufacturedHomes'
     ]
@@ -108,7 +123,6 @@ export default defineComponent({
       backBtn: props.setBackBtn,
       cancelBtn: props.setCancelBtn,
       errMsg: props.setErrMsg,
-      feeType: props.setFeeType,
       leftOffset: props.setLeftOffset,
       registrationType: props.setRegistrationType,
       registrationLength: props.setRegistrationLength,
@@ -134,10 +148,6 @@ export default defineComponent({
       }),
       isStaffSBC: computed(() => {
         return isRoleStaffSbc.value as boolean
-      }),
-      feeQuantity: computed(() => {
-        console.log(getSelectedManufacturedHomes.value.length)
-        return getSelectedManufacturedHomes.value.length
       })
     })
     const back = () => {
@@ -155,10 +165,6 @@ export default defineComponent({
 
     watch(() => props.setErrMsg, (val: string) => {
       localState.errMsg = val
-    })
-
-    watch(() => getSelectedManufacturedHomes, (val: any) => {
-      console.log(getSelectedManufacturedHomes.value.length)
     })
 
     watch(() => props.setRegistrationLength, (val: RegistrationLengthI) => {

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -114,9 +114,8 @@ export default defineComponent({
   setup (props, { emit }) {
     const {
       getUserServiceFee, isNonBillable, isRoleStaffReg, isRoleStaffSbc
-    } = useGetters<any>([
-      'getUserServiceFee', 'isNonBillable', 'isRoleStaffReg', 'isRoleStaffSbc', 'getSelectedManufacturedHomes'
-    ]
+    } = useGetters<any>(
+      ['getUserServiceFee', 'isNonBillable', 'isRoleStaffReg', 'isRoleStaffSbc']
     )
 
     const localState = reactive({

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -4,6 +4,7 @@
       v-if="showFeeSummary"
       :setFeeOverride="feeOverride"
       :setFeeType="feeType"
+      :setFeeQuantity="feeQuantity"
       :setRegistrationLength="registrationLength"
       :setRegistrationType="registrationType"
       :setStaffReg="isStaffReg"
@@ -97,9 +98,10 @@ export default defineComponent({
   },
   setup (props, { emit }) {
     const {
-      getUserServiceFee, isNonBillable, isRoleStaffReg, isRoleStaffSbc
-    } = useGetters<any>(
-      ['getUserServiceFee', 'isNonBillable', 'isRoleStaffReg', 'isRoleStaffSbc']
+      getUserServiceFee, isNonBillable, isRoleStaffReg, isRoleStaffSbc, getSelectedManufacturedHomes
+    } = useGetters<any>([
+      'getUserServiceFee', 'isNonBillable', 'isRoleStaffReg', 'isRoleStaffSbc', 'getSelectedManufacturedHomes'
+    ]
     )
 
     const localState = reactive({
@@ -132,6 +134,10 @@ export default defineComponent({
       }),
       isStaffSBC: computed(() => {
         return isRoleStaffSbc.value as boolean
+      }),
+      feeQuantity: computed(() => {
+        console.log(getSelectedManufacturedHomes.value.length)
+        return getSelectedManufacturedHomes.value.length
       })
     })
     const back = () => {
@@ -149,6 +155,10 @@ export default defineComponent({
 
     watch(() => props.setErrMsg, (val: string) => {
       localState.errMsg = val
+    })
+
+    watch(() => getSelectedManufacturedHomes, (val: any) => {
+      console.log(getSelectedManufacturedHomes.value.length)
     })
 
     watch(() => props.setRegistrationLength, (val: RegistrationLengthI) => {

--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -251,9 +251,24 @@ export default defineComponent({
         return localState.selectAllLien !== localState.areAllLienSelected
       }),
       activeResults: computed((): any => {
+        const selectedResults = cloneDeep(getSelectedManufacturedHomes).value
+        const baseResults = cloneDeep(getManufacturedHomeSearchResults.value.results)
+
+        // Map selected results with base results when user navigates back to edit selections further
+        const activeResults = baseResults.map(result => {
+          const matchedResult = selectedResults.find(({ id }) => id === result.id)
+          return {
+            ...result,
+            ...(matchedResult && {
+              selected: matchedResult.selected,
+              lienSelected: matchedResult.lienSelected
+            })
+          }
+        })
+
         return props.isReviewMode
-          ? cloneDeep(getSelectedManufacturedHomes)
-          : cloneDeep(getManufacturedHomeSearchResults.value.results)
+          ? selectedResults
+          : activeResults
       })
     })
 
@@ -283,17 +298,8 @@ export default defineComponent({
       localState.searchTime = pacificDate(date)
     })
 
-    watch(() => localState.areAllSelected, (val: boolean) => {
-      if (!props.isReviewMode && val) localState.selectAll = localState.areAllSelected
-    })
-
-    watch(() => localState.areAllLienSelected, (val: boolean) => {
-      if (!props.isReviewMode && val) localState.selectAllLien = localState.areAllLienSelected
-    })
-
     watch(() => localState.results, () => {
       const selectedManufacturedHomes = cloneDeep(localState.results.filter(result => result.selected === true))
-
       setSelectedManufacturedHomes(selectedManufacturedHomes)
     }, { deep: true })
 
@@ -303,6 +309,14 @@ export default defineComponent({
 
     watch(() => localState.selectAllLien, (val: boolean) => {
       localState.results = localState.results.map(result => ({ ...result, lienSelected: val }))
+    })
+
+    watch(() => localState.areAllSelected, (val: boolean) => {
+      if (!props.isReviewMode && val) localState.selectAll = localState.areAllSelected
+    })
+
+    watch(() => localState.areAllLienSelected, (val: boolean) => {
+      if (!props.isReviewMode && val) localState.selectAllLien = localState.areAllLienSelected
     })
 
     return {

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -3,7 +3,7 @@
     <header class="font-weight-bold px-3 py-3">
       <slot name="header">Fee Summary</slot>
     </header>
-    <v-slide-y-transition group tag="ul" :class="[$style['fee-list']]">
+    <v-slide-y-transition group tag="ul" :class="[$style['fee-list'], 'px-0']">
       <template>
         <li
           :class="[$style['fee-container'], $style['fee-list__item'], { 'pb-4': !hintFee }, 'pr-4', 'pt-5']"
@@ -24,6 +24,13 @@
           <div v-else :class="$style['fee-list__item-value']">
             ${{ totalFees.toFixed(2) }}
           </div>
+        </li>
+        <li
+          v-if="setFeeQuantity > 1"
+          :class="[$style['fee-container'], $style['fee-list__hint'], 'pb-4', 'mt-n3']"
+          :key="setFeeQuantity"
+        >
+          <div class="fee-list__hint">{{ setFeeQuantity }} @ ${{ feeSummary.feeAmount.toFixed(2) }} each</div>
         </li>
         <li
           v-if="hintFee"
@@ -87,19 +94,13 @@
 
 <script lang="ts">
 // external
-import {
-  computed,
-  defineComponent,
-  reactive,
-  toRefs,
-  watch
-} from '@vue/composition-api'
+import { computed, defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
 import { useGetters } from 'vuex-composition-helpers'
 // local
 import { UIRegistrationTypes } from '@/enums'
 import { FeeSummaryTypes } from './enums' // eslint-disable-line no-unused-vars
 import { FeeSummaryI, RegistrationLengthI } from './interfaces' // eslint-disable-line no-unused-vars
-import { getFeeSummary, getFeeHint } from './factories'
+import { getFeeHint, getFeeSummary } from './factories'
 
 export default defineComponent({
   name: 'FeeSummary',
@@ -110,6 +111,10 @@ export default defineComponent({
     },
     setFeeType: {
       type: String as () => FeeSummaryTypes
+    },
+    setFeeQuantity: {
+      default: null,
+      type: Number
     },
     setRegistrationLength: {
       type: Object as () => RegistrationLengthI
@@ -150,6 +155,9 @@ export default defineComponent({
           localState.registrationType,
           localState.registrationLength
         )
+        if (props.setFeeQuantity) {
+          feeSummary.quantity = props.setFeeQuantity
+        }
         if (localState.feeType === FeeSummaryTypes.RENEW) {
           feeSummary.processingFee = 5
         }
@@ -199,6 +207,9 @@ export default defineComponent({
     watch(() => props.setFeeType, (val: FeeSummaryTypes) => {
       localState.feeType = val
     })
+    watch(() => props.setFeeQuantity, (val: number) => {
+      console.log(val)
+    })
     watch(() => props.setRegistrationType, (val: UIRegistrationTypes) => {
       localState.registrationType = val
     })
@@ -227,7 +238,9 @@ header {
 }
 
 .fee-list {
-  padding-left: 30px !important;
+  li {
+    padding-left: 30px !important;
+  }
 }
 
 .fee-list__hint {

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -30,7 +30,9 @@
           :class="[$style['fee-container'], $style['fee-list__hint'], 'pb-4', 'mt-n3']"
           :key="setFeeQuantity"
         >
-          <div class="fee-list__hint">{{ setFeeQuantity }} @ ${{ feeSummary.feeAmount.toFixed(2) }} each</div>
+          <div id="quantity-label" class="fee-list__hint">
+            {{ setFeeQuantity }} @ ${{ feeSummary.feeAmount.toFixed(2) }} each
+          </div>
         </li>
         <template v-if="additionalFees">
           <li
@@ -55,7 +57,7 @@
             :class="[$style['fee-container'], $style['fee-list__hint'], 'pb-4', 'mt-n3']"
             :key="`Additional Fee: ${additionalFeeSummary.quantity}`"
           >
-            <div class="fee-list__hint">
+            <div id="additional-quantity-label" class="fee-list__hint">
               {{ additionalFeeSummary.quantity }} @ ${{ additionalFeeSummary.feeAmount.toFixed(2) }} each
             </div>
           </li>

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -6,6 +6,7 @@
     <v-slide-y-transition group tag="ul" :class="[$style['fee-list'], 'px-0']">
       <template>
         <li
+          v-if="setFeeQuantity > 0"
           :class="[$style['fee-container'], $style['fee-list__item'], { 'pb-4': !hintFee }, 'pr-4', 'pt-5']"
           :key="feeLabel"
         >
@@ -13,7 +14,7 @@
             {{ feeLabel }}
           </div>
           <div
-            v-if="feeSummary && feeSummary.feeAmount === 0"
+            v-if="feeSummary.feeAmount === 0"
             :class="$style['fee-list__item-value']"
           >
             No Fee
@@ -229,7 +230,8 @@ export default defineComponent({
         return hint
       }),
       isComplete: computed((): boolean => {
-        return localState.feeSummary.quantity > 0 && localState.isValid
+        return localState.isValid &&
+          (localState.feeSummary?.quantity > 0 || localState.additionalFeeSummary?.quantity > 0) && localState.isValid
       }),
       totalAmount: computed((): number => {
         if (localState.isValid) {

--- a/ppr-ui/src/composables/fees/enums/feeSummaryDefaults.ts
+++ b/ppr-ui/src/composables/fees/enums/feeSummaryDefaults.ts
@@ -5,5 +5,7 @@ export enum FeeSummaryDefaults {
   DEFAULT_10 = 'feeDefault10',
   DEFAULT_500 = 'feeDefault500',
   SELECT_5 = 'feeSelect5',
-  SEARCH_5 = 'feeSearch5'
+  SEARCH_5 = 'feeSearch5',
+  SEARCH_8 = 'feeSearch8',
+  SEARCH_12 = 'feeSearch12'
 }

--- a/ppr-ui/src/composables/fees/enums/feeSummaryTypes.ts
+++ b/ppr-ui/src/composables/fees/enums/feeSummaryTypes.ts
@@ -3,5 +3,6 @@ export enum FeeSummaryTypes {
   DISCHARGE = 'discharge',
   NEW = 'new',
   RENEW = 'renew',
-  MHSEARCH = 'manufactured_home_search'
+  MHSEARCH = 'manufactured_home_search',
+  MHR_COMBINED_SEARCH = 'combined_home_'
 }

--- a/ppr-ui/src/composables/fees/enums/feeSummaryTypes.ts
+++ b/ppr-ui/src/composables/fees/enums/feeSummaryTypes.ts
@@ -4,5 +4,5 @@ export enum FeeSummaryTypes {
   NEW = 'new',
   RENEW = 'renew',
   MHSEARCH = 'manufactured_home_search',
-  MHR_COMBINED_SEARCH = 'combined_home_'
+  MHR_COMBINED_SEARCH = 'combined_home_search'
 }

--- a/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
+++ b/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
@@ -77,6 +77,9 @@ export function getFeeSummary (
   if (feeType === FeeSummaryTypes.MHSEARCH) {
     return { ...defaultFeeSummaries[FeeSummaryDefaults.SEARCH_8] }
   }
+  if (feeType === FeeSummaryTypes.MHR_COMBINED_SEARCH) {
+    return { ...defaultFeeSummaries[FeeSummaryDefaults.SEARCH_12] }
+  }
   if (feeType === FeeSummaryTypes.DISCHARGE) {
     return { ...defaultFeeSummaries[FeeSummaryDefaults.NO_FEE] }
   }

--- a/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
+++ b/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
@@ -75,7 +75,7 @@ export function getFeeSummary (
   registrationLength: RegistrationLengthI
 ): FeeSummaryI {
   if (feeType === FeeSummaryTypes.MHSEARCH) {
-    return { ...defaultFeeSummaries[FeeSummaryDefaults.SEARCH_5] }
+    return { ...defaultFeeSummaries[FeeSummaryDefaults.SEARCH_8] }
   }
   if (feeType === FeeSummaryTypes.DISCHARGE) {
     return { ...defaultFeeSummaries[FeeSummaryDefaults.NO_FEE] }

--- a/ppr-ui/src/composables/fees/interfaces/combined-search-fee-interface.ts
+++ b/ppr-ui/src/composables/fees/interfaces/combined-search-fee-interface.ts
@@ -1,0 +1,11 @@
+import { FeeSummaryTypes } from '@/composables/fees/enums'
+import { UIRegistrationTypes } from '@/enums'
+import { RegistrationLengthI } from '@/composables/fees/interfaces/registration-length'
+
+// Defines the additional search data required for the Fee Summary when there is multiple fees to display
+export interface AdditionalSearchFeeIF {
+  feeType: FeeSummaryTypes,
+  quantity: number,
+  registrationType?: UIRegistrationTypes
+  registrationLength?: RegistrationLengthI
+}

--- a/ppr-ui/src/composables/fees/interfaces/index.ts
+++ b/ppr-ui/src/composables/fees/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './combined-search-fee-interface'
 export * from './fee'
 export * from './fee-summary'
 export * from './registration-length'

--- a/ppr-ui/src/composables/fees/resources/feeSummaries.ts
+++ b/ppr-ui/src/composables/fees/resources/feeSummaries.ts
@@ -43,5 +43,17 @@ export const defaultFeeSummaries = {
     processingFee: 0,
     quantity: 1,
     serviceFee: 0
+  } as FeeSummaryI,
+  [FeeSummaryDefaults.SEARCH_8]: {
+    feeAmount: 8,
+    processingFee: 0,
+    quantity: 1,
+    serviceFee: 1
+  } as FeeSummaryI,
+  [FeeSummaryDefaults.SEARCH_12]: {
+    feeAmount: 12,
+    processingFee: 0,
+    quantity: 1,
+    serviceFee: 1
   } as FeeSummaryI
 }

--- a/ppr-ui/src/composables/fees/resources/feeSummaries.ts
+++ b/ppr-ui/src/composables/fees/resources/feeSummaries.ts
@@ -47,13 +47,13 @@ export const defaultFeeSummaries = {
   [FeeSummaryDefaults.SEARCH_8]: {
     feeAmount: 8,
     processingFee: 0,
-    quantity: 1,
+    quantity: 0,
     serviceFee: 1
   } as FeeSummaryI,
   [FeeSummaryDefaults.SEARCH_12]: {
     feeAmount: 12,
     processingFee: 0,
-    quantity: 1,
+    quantity: 0,
     serviceFee: 1
   } as FeeSummaryI
 }

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
@@ -10,5 +10,7 @@ export interface ManufacturedHomeSearchResultIF {
   year?: number | '' // Optional
   make?: string // Optional
   model?: string // Optional
-  homeLocation?: string
+  homeLocation?: string // Optional
+  selected?: boolean // Optional
+  lienSelected?: boolean // Optional
 }

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
@@ -10,7 +10,5 @@ export interface ManufacturedHomeSearchResultIF {
   year?: number | '' // Optional
   make?: string // Optional
   model?: string // Optional
-  homeLocation?: string // Optional
-  selected?: boolean // Optional - for submissions
-  lienSelected?: boolean // Optional - for submissions
+  homeLocation?: string
 }

--- a/ppr-ui/src/store/getters/state-getters.ts
+++ b/ppr-ui/src/store/getters/state-getters.ts
@@ -211,7 +211,7 @@ export const hasPprRole = (state: StateIF): boolean => {
 }
 
 export const hasMhrRole = (state: StateIF): boolean => {
-  return true // state.stateModel.authorization?.authRoles.includes('mhr')
+  return state.stateModel.authorization?.authRoles.includes('mhr')
 }
 
 /** The current user's service fee (applicable for non billable users). */

--- a/ppr-ui/src/store/getters/state-getters.ts
+++ b/ppr-ui/src/store/getters/state-getters.ts
@@ -211,7 +211,7 @@ export const hasPprRole = (state: StateIF): boolean => {
 }
 
 export const hasMhrRole = (state: StateIF): boolean => {
-  return state.stateModel.authorization?.authRoles.includes('mhr')
+  return true // state.stateModel.authorization?.authRoles.includes('mhr')
 }
 
 /** The current user's service fee (applicable for non billable users). */

--- a/ppr-ui/src/views/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/ConfirmMHRSearch.vue
@@ -52,10 +52,12 @@
                 :setShowButtons="true"
                 :setShowFeeSummary="true"
                 :setFeeType="feeType"
+                :setFeeQuantity="feeQuantity"
                 :setBackBtn="'Back'"
                 :setCancelBtn="'Cancel'"
                 :setSubmitBtn="'Pay and Download Result'"
                 :setDisableSubmitBtn="isRoleStaffBcol"
+                :setAdditionalFees="combinedSearchFees"
                 @back="goToSearchResult()"
                 @cancel="showDialog()"
                 @submit="submitSearch()"
@@ -88,11 +90,12 @@ import {
   ActionBindingIF, // eslint-disable-line no-unused-vars
   ErrorIF, // eslint-disable-line no-unused-vars
   StateModelIF, // eslint-disable-line no-unused-vars
-  DialogOptionsIF // eslint-disable-line no-unused-vars
+  DialogOptionsIF, ManufacturedHomeSearchResultIF // eslint-disable-line no-unused-vars
 } from '@/interfaces'
 import { notCompleteDialog } from '@/resources/dialogOptions'
 import { getFeatureFlag } from '@/utils'
 import { SearchedResultMhr } from '@/components/tables'
+import { AdditionalSearchFeeIF } from '@/composables/fees/interfaces' // eslint-disable-line no-unused-vars
 
 @Component({
   components: {
@@ -105,6 +108,7 @@ import { SearchedResultMhr } from '@/components/tables'
 export default class ConfirmDischarge extends Vue {
   @Getter getStateModel: StateModelIF
   @Getter isRoleStaffBcol: boolean
+  @Getter getSelectedManufacturedHomes!: ManufacturedHomeSearchResultIF[]
 
   @Action setUnsavedChanges: ActionBindingIF
 
@@ -134,6 +138,20 @@ export default class ConfirmDischarge extends Vue {
       return '< Please complete required information'
     }
     return ''
+  }
+
+  private get combinedSearchFees (): AdditionalSearchFeeIF {
+    const searchQuantity = this.getSelectedManufacturedHomes?.filter(item => item.lienSelected === true).length
+    return searchQuantity > 0
+      ? {
+        feeType: FeeSummaryTypes.MHR_COMBINED_SEARCH,
+        quantity: searchQuantity
+      }
+      : null
+  }
+
+  private get feeQuantity (): number {
+    return this.getSelectedManufacturedHomes.length
   }
 
   private async loadSearchResult (): Promise<void> {

--- a/ppr-ui/src/views/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/ConfirmMHRSearch.vue
@@ -154,7 +154,8 @@ export default class ConfirmDischarge extends Vue {
   }
 
   private get feeQuantity (): number {
-    return this.getSelectedManufacturedHomes.length
+    // Return selected quantity that is not a combination search
+    return this.getSelectedManufacturedHomes.filter(result => result.selected && !result.lienSelected).length
   }
 
   private async loadSearchResult (): Promise<void> {

--- a/ppr-ui/src/views/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/ConfirmMHRSearch.vue
@@ -83,19 +83,22 @@ import {
 } from '@/components/common'
 import { BaseDialog } from '@/components/dialogs'
 // local helpers/enums/interfaces/resources
-import { RouteNames } from '@/enums' // eslint-disable-line no-unused-vars
+/* eslint-disable no-unused-vars */
+import { RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { Throttle } from '@/decorators'
 import {
-  ActionBindingIF, // eslint-disable-line no-unused-vars
-  ErrorIF, // eslint-disable-line no-unused-vars
-  StateModelIF, // eslint-disable-line no-unused-vars
-  DialogOptionsIF, ManufacturedHomeSearchResultIF // eslint-disable-line no-unused-vars
+  ActionBindingIF,
+  ErrorIF,
+  StateModelIF,
+  DialogOptionsIF,
+  ManufacturedHomeSearchResultIF
 } from '@/interfaces'
 import { notCompleteDialog } from '@/resources/dialogOptions'
 import { getFeatureFlag } from '@/utils'
 import { SearchedResultMhr } from '@/components/tables'
-import { AdditionalSearchFeeIF } from '@/composables/fees/interfaces' // eslint-disable-line no-unused-vars
+import { AdditionalSearchFeeIF } from '@/composables/fees/interfaces'
+/* eslint-enable no-unused-vars */
 
 @Component({
   components: {

--- a/ppr-ui/tests/unit/FeeSummary.spec.ts
+++ b/ppr-ui/tests/unit/FeeSummary.spec.ts
@@ -549,4 +549,88 @@ describe('FeeSummary component tests', () => {
       expect(wrapper.vm.$data.hintFee).toBe('')
     }
   })
+
+  it('renders with correct values for a MHR Search', async () => {
+    expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
+    await wrapper.setProps({
+      setFeeType: FeeSummaryTypes.MHSEARCH,
+      setRegistrationLength: null,
+      setRegistrationType: null
+    })
+    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.MHSEARCH)
+    expect(wrapper.vm.$data.registrationType).toBe(null)
+    expect(wrapper.vm.$data.feeLabel).toBe('Manufactured Home search')
+    expect(wrapper.vm.$data.feeSummary.feeAmount).toBe(8)
+    expect(wrapper.vm.$data.feeSummary.quantity).toBe(1)
+    expect(wrapper.vm.$data.feeSummary.serviceFee).toBe(1)
+    expect(wrapper.vm.$data.totalFees).toBe(8)
+    expect(wrapper.vm.$data.totalAmount).toBe(9)
+    expect(wrapper.vm.$data.isComplete).toBe(true)
+    expect(wrapper.vm.$data.hintFee).toBe('')
+  })
+
+  it('renders with correct values for a MHR Search and Combined Search', async () => {
+    expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
+    await wrapper.setProps({
+      setFeeType: FeeSummaryTypes.MHSEARCH,
+      setRegistrationLength: null,
+      setRegistrationType: null,
+      additionalFees: {
+        feeType: FeeSummaryTypes.MHR_COMBINED_SEARCH,
+        quantity: 1
+      }
+    })
+    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.MHSEARCH)
+    expect(wrapper.vm.$data.registrationType).toBe(null)
+    expect(wrapper.vm.$data.feeLabel).toBe('Manufactured Home search')
+    expect(wrapper.vm.$data.feeSummary.feeAmount).toBe(8)
+    expect(wrapper.vm.$data.feeSummary.quantity).toBe(1)
+    expect(wrapper.vm.$data.feeSummary.serviceFee).toBe(1)
+
+    expect(wrapper.vm.$data.additionalFeeLabel).toBe('Combined Home and Lien search')
+    expect(wrapper.vm.$data.additionalFeeSummary.feeAmount).toBe(12)
+    expect(wrapper.vm.$data.additionalFeeSummary.quantity).toBe(1)
+    expect(wrapper.vm.$data.additionalFeeSummary.serviceFee).toBe(1)
+
+    expect(wrapper.vm.$data.totalFees).toBe(8)
+    expect(wrapper.vm.$data.totalAdditionalFees).toBe(12)
+
+    expect(wrapper.vm.$data.totalAmount).toBe(21)
+    expect(wrapper.vm.$data.isComplete).toBe(true)
+    expect(wrapper.vm.$data.hintFee).toBe('')
+  })
+
+  it('renders with correct values for a MHR Search and Combined Search with multiples', async () => {
+    expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
+    await wrapper.setProps({
+      setFeeType: FeeSummaryTypes.MHSEARCH,
+      setFeeQuantity: 2,
+      setRegistrationLength: null,
+      setRegistrationType: null,
+      additionalFees: {
+        feeType: FeeSummaryTypes.MHR_COMBINED_SEARCH,
+        quantity: 3
+      }
+    })
+    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.MHSEARCH)
+    expect(wrapper.vm.$data.registrationType).toBe(null)
+    expect(wrapper.vm.$data.feeLabel).toBe('Manufactured Home search')
+    expect(wrapper.find('#quantity-label').text()).toBe('2 @ $8.00 each')
+    expect(wrapper.vm.$data.feeSummary.feeAmount).toBe(8)
+    expect(wrapper.vm.$data.feeSummary.quantity).toBe(2)
+    expect(wrapper.vm.$data.feeSummary.serviceFee).toBe(1)
+
+    expect(wrapper.vm.$data.additionalFeeLabel).toBe('Combined Home and Lien search')
+    expect(wrapper.find('#additional-quantity-label').text()).toBe('3 @ $12.00 each')
+    expect(wrapper.vm.$data.additionalFeeSummary.feeAmount).toBe(12)
+    expect(wrapper.vm.$data.additionalFeeSummary.quantity).toBe(3)
+    expect(wrapper.vm.$data.additionalFeeSummary.serviceFee).toBe(1)
+
+    expect(wrapper.vm.$data.totalFees).toBe(16)
+    expect(wrapper.vm.$data.totalAdditionalFees).toBe(36)
+
+    expect(wrapper.vm.$data.totalAmount).toBe(53)
+    expect(wrapper.vm.$data.isComplete).toBe(true)
+    expect(wrapper.vm.$data.hintFee).toBe('')
+  })
 })

--- a/ppr-ui/tests/unit/FeeSummary.spec.ts
+++ b/ppr-ui/tests/unit/FeeSummary.spec.ts
@@ -554,6 +554,7 @@ describe('FeeSummary component tests', () => {
     expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
     await wrapper.setProps({
       setFeeType: FeeSummaryTypes.MHSEARCH,
+      setFeeQuantity: 1,
       setRegistrationLength: null,
       setRegistrationType: null
     })
@@ -573,6 +574,7 @@ describe('FeeSummary component tests', () => {
     expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
     await wrapper.setProps({
       setFeeType: FeeSummaryTypes.MHSEARCH,
+      setFeeQuantity: 1,
       setRegistrationLength: null,
       setRegistrationType: null,
       additionalFees: {

--- a/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
+++ b/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
@@ -165,6 +165,7 @@ describe('Owner name debtor results', () => {
 
   beforeEach(async () => {
     await store.dispatch('setManufacturedHomeSearchResults', testResults)
+    await store.dispatch('setSelectedManufacturedHomes', [])
     wrapper = createComponent()
   })
   afterEach(() => {
@@ -247,6 +248,7 @@ describe('Business debtor results', () => {
 
   beforeEach(async () => {
     await store.dispatch('setManufacturedHomeSearchResults', testResults)
+    await store.dispatch('setSelectedManufacturedHomes', [])
     wrapper = createComponent()
   })
   afterEach(() => {
@@ -325,6 +327,7 @@ describe('Manufactured home results', () => {
 
   beforeEach(async () => {
     await store.dispatch('setManufacturedHomeSearchResults', testResults)
+    await store.dispatch('setSelectedManufacturedHomes', [])
     wrapper = createComponent()
   })
   afterEach(() => {

--- a/ppr-ui/tests/unit/StickyContainer.spec.ts
+++ b/ppr-ui/tests/unit/StickyContainer.spec.ts
@@ -101,7 +101,7 @@ describe('Sticky Container component tests', () => {
 
     expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
     expect(wrapper.findComponent(ButtonsStacked).exists()).toBe(false)
-    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.NEW)
+    expect(wrapper.props().setFeeType).toBe(FeeSummaryTypes.NEW)
     expect(wrapper.findComponent(FeeSummary).vm.$props.setFeeType).toBe(FeeSummaryTypes.NEW)
     expect(wrapper.vm.$data.registrationLength).toEqual(registrationLength)
     expect(wrapper.findComponent(FeeSummary).vm.$props.setRegistrationLength).toEqual(registrationLength)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12010

*Description of changes:*
* Updated Fee Summary to support additional Fee Charges
* Includes sub text for multiple charges and combined totals when additional fees are applied
* Applies Combined searches based off Lien selections
* Misc local data refactors to provide the FeeSummary reactivity to the props

* Updated Results/Review selections to preserve selections when navigating back for further edits

* Updated Unit testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
