### PR TITLE
MHR api pub/sub setup for search, registration reports.

### DIFF
--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -23,13 +23,16 @@ from .db2.manuhome import Db2Manuhome
 from .db2.mhomnote import Db2Mhomnote
 from .db2.owner import Db2Owner
 from .db2.owngroup import Db2Owngroup
+from .event_tracking import EventTracking
 from .search_request import SearchRequest
 from .search_result import SearchResult
 from .type_tables import (
+    EventTrackingType,
     SearchType
 )
 
 __all__ = ('db',
            'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manuhome', 'Db2Mhomnote',
            'Db2Owner', 'Db2Owngroup',
+           'EventTracking', 'EventTrackingType',
            'SearchRequest', 'SearchResult', 'SearchType')

--- a/mhr_api/src/mhr_api/models/event_tracking.py
+++ b/mhr_api/src/mhr_api/models/event_tracking.py
@@ -1,0 +1,117 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for ppr queue event tracking."""
+from __future__ import annotations
+
+from mhr_api.models import utils as model_utils
+from mhr_api.utils.base import BaseEnum
+
+from .db import db
+
+
+class EventTracking(db.Model):  # pylint: disable=too-many-instance-attributes
+    """This class manages all of the event tracking information."""
+
+    class EventTrackingTypes(BaseEnum):
+        """Render an Enum of the event tracking types."""
+
+        SEARCH_REPORT = 'SEARCH_REPORT'
+        API_NOTIFICATION = 'API_NOTIFICATION'
+        EMAIL = 'EMAIL'
+        SURFACE_MAIL = 'SURFACE_MAIL'
+        EMAIL_REPORT = 'EMAIL_REPORT'
+        REGISTRATION_REPORT = 'REGISTRATION_REPORT'
+
+    __tablename__ = 'event_tracking'
+
+    id = db.Column('id', db.Integer, db.Sequence('event_tracking_id_seq'), primary_key=True)
+    key_id = db.Column('key_id', db.Integer, nullable=False, index=True)
+    event_ts = db.Column('event_ts', db.DateTime, nullable=False, index=True)
+    event_tracking_type = db.Column('event_tracking_type', db.String(20),
+                                    db.ForeignKey('event_tracking_types.event_tracking_type'),
+                                    nullable=False, index=True)
+    status = db.Column('status', db.Integer, nullable=True)
+    message = db.Column('message', db.String(2000), nullable=True)
+    email_id = db.Column('email_address', db.String(250), nullable=True)
+
+    # Relationships - SerialType
+    tracking_type = db.relationship('EventTrackingType', foreign_keys=[event_tracking_type],
+                                    back_populates='event_tracking', cascade='all, delete', uselist=False)
+
+    def save(self):
+        """Save the object to the database immediately."""
+        db.session.add(self)
+        db.session.commit()
+
+    @property
+    def json(self) -> dict:
+        """Return the event tracking record as a json object."""
+        event_tracking = {
+            'eventTrackingId': self.id,
+            'keyId': self.key_id,
+            'type': self.event_tracking_type,
+            'createDateTime': model_utils.format_ts(self.event_ts)
+        }
+        if self.status:
+            event_tracking['status'] = self.status
+        if self.message:
+            event_tracking['message'] = self.message
+        if self.email_id:
+            event_tracking['emailAddress'] = self.email_id
+
+        return event_tracking
+
+    @classmethod
+    def find_by_id(cls, event_id: int):
+        """Return a tracking object by ID."""
+        if event_id:
+            return cls.query.get(event_id)
+
+        return None
+
+    @classmethod
+    def find_by_key_id(cls, key_id: int):
+        """Return a list of event tracking objects by key id."""
+        event_tracking = None
+        if key_id:
+            event_tracking = cls.query.filter(EventTracking.key_id == key_id) \
+                                      .order_by(EventTracking.id).all()
+
+        return event_tracking
+
+    @classmethod
+    def find_by_key_id_type(cls, key_id: int, event_tracking_type: str, extra_key: str = None):
+        """Return a list of event tracking objects by key id and event tracking type."""
+        event_tracking = None
+        if key_id and event_tracking_type:
+            event_tracking = cls.query.filter(EventTracking.key_id == key_id,
+                                              EventTracking.event_tracking_type == event_tracking_type) \
+                                      .order_by(EventTracking.id).all()
+
+            if event_tracking is not None and extra_key:
+                events = []
+                for event in event_tracking:
+                    if event.message and event.message.find(extra_key) > 0:
+                        events.append(event)
+                return events
+        return event_tracking
+
+    @staticmethod
+    def create(key_id: int, event_type: str, status: int = None, message: str = None):
+        """Create an EventTracking record."""
+        event_tracking = EventTracking(key_id=key_id, event_tracking_type=event_type, status=status, message=message)
+        event_tracking.event_ts = model_utils.now_ts()
+        event_tracking.save()
+
+        return event_tracking

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -18,6 +18,20 @@ from __future__ import annotations
 from .db import db
 
 
+class EventTrackingType(db.Model):  # pylint: disable=too-few-public-methods
+    """This class defines the model for the event_tracking_types table."""
+
+    __tablename__ = 'event_tracking_types'
+
+    event_tracking_type = db.Column('event_tracking_type', db.String(20), primary_key=True)
+    event_tracking_desc = db.Column('event_tracking_desc', db.String(100), nullable=False)
+
+    # parent keys
+
+    # Relationships - EventTracking
+    event_tracking = db.relationship('EventTracking', back_populates='tracking_type')
+
+
 class SearchType(db.Model):  # pylint: disable=too-few-public-methods
     """This class defines the model for the search_type table."""
 

--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -19,7 +19,9 @@ from flask import Flask
 
 from .meta import bp as meta_bp
 from .ops import bp as ops_bp
+from .registration_report_callback import bp as registration_report_callback_bp
 from .search_history import bp as search_history_bp
+from .search_report_callback import bp as search_report_callback_bp
 from .search_results import bp as search_result_bp
 from .searches import bp as searches_bp
 
@@ -43,6 +45,8 @@ class V1Endpoint:
         self.app.register_blueprint(searches_bp)
         self.app.register_blueprint(search_history_bp)
         self.app.register_blueprint(search_result_bp)
+        self.app.register_blueprint(search_report_callback_bp)
+        self.app.register_blueprint(registration_report_callback_bp)
 
 
 v1_endpoint = V1Endpoint()  # pylint: disable=invalid-name

--- a/mhr_api/src/mhr_api/resources/v1/registration_report_callback.py
+++ b/mhr_api/src/mhr_api/resources/v1/registration_report_callback.py
@@ -1,0 +1,177 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API callback endpoint to generate and store MHR search reports after completting search step 2."""
+
+from http import HTTPStatus
+
+# import requests
+from flask import Blueprint, current_app  # , jsonify, request
+from flask_cors import cross_origin
+
+from mhr_api.exceptions import DatabaseException
+from mhr_api.services.queue_service import GoogleQueueService
+from mhr_api.models import EventTracking
+from mhr_api.resources import utils as resource_utils
+
+
+# from mhr_api.reports import ReportTypes, get_callback_pdf
+from mhr_api.services.utils.exceptions import ReportException, ReportDataException, StorageException
+# from mhr_api.services.document_storage.storage_service import GoogleStorageService
+
+
+bp = Blueprint('REGISTRATION_REPORT1', __name__,  # pylint: disable=invalid-name
+               url_prefix='/api/v1/registration-report-callback')
+
+CALLBACK_MESSAGES = {
+    resource_utils.CallbackExceptionCodes.UNKNOWN_ID: '01: no registration data found for id={key_id}.',
+    resource_utils.CallbackExceptionCodes.MAX_RETRIES: '02: maximum retries reached for id={key_id}.',
+    resource_utils.CallbackExceptionCodes.INVALID_ID: '03: no registration found for id={key_id}.',
+    resource_utils.CallbackExceptionCodes.DEFAULT: '04: default error for id={key_id}.',
+    resource_utils. CallbackExceptionCodes.REPORT_DATA_ERR: '05: report data error for id={key_id}.',
+    resource_utils. CallbackExceptionCodes.REPORT_ERR: '06: generate report failed for id={key_id}.',
+    resource_utils.CallbackExceptionCodes.FILE_TRANSFER_ERR: '09: SFTP failed for id={key_id}.',
+    resource_utils.CallbackExceptionCodes.SETUP_ERR: '10: setup failed for id={key_id}.'
+}
+
+
+@bp.route('/<string:registration_id>', methods=['POST', 'OPTIONS'])
+@cross_origin(origin='*')
+def post_registration_report_callback(registration_id: str):
+    """Resource to generate and store a registration report as a callback request."""
+    try:
+        current_app.logger.info(f'Registration report callback starting id={registration_id}.')
+        if registration_id is None:
+            return resource_utils.path_param_error_response('registration ID')
+        # If exceeded max retries we're done.
+        event_count: int = 0
+        events = EventTracking.find_by_key_id_type(registration_id,
+                                                   EventTracking.EventTrackingTypes.REGISTRATION_REPORT)
+        if events:
+            event_count = len(events)
+        if event_count > current_app.config.get('EVENT_MAX_RETRIES'):
+            return registration_callback_error(resource_utils.CallbackExceptionCodes.MAX_RETRIES,
+                                               registration_id,
+                                               HTTPStatus.INTERNAL_SERVER_ERROR,
+                                               'Max retries reached.')
+
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.UNKNOWN_ID,
+                                           registration_id,
+                                           HTTPStatus.NOT_FOUND)
+        # Verify the registration ID and request:
+        # registration: Registration = Registration.find_by_id(registration_id)
+        # if not registration:
+        #    return registration_callback_error(resource_utils.CallbackExceptionCodes.UNKNOWN_ID,
+        #                                       registration_id,
+        #                                       HTTPStatus.NOT_FOUND)
+        # if not registration.verification_report:
+        #    return registration_callback_error(resource_utils.CallbackExceptionCodes.SETUP_ERR,
+        #                                       registration_id,
+        #                                       HTTPStatus.BAD_REQUEST,
+        #                                       'No report data found for the registration.')
+        # return get_registration_callback_report(registration)
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, None, 'POST registration report event')
+    except Exception as default_err:  # noqa: B902; return nicer default error
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.DEFAULT,
+                                           registration_id,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           str(default_err))
+
+
+def enqueue_registration_report(registration_id):
+    """Add the registration verification report request to the registration queue."""
+    try:
+        # if json_data and report_type:
+        # Signal registration report request is pending: record exists but no doc_storage_url.
+        #    verification_report: VerificationReport = VerificationReport(create_ts=registration.registration_ts,
+        #                                                                 registration_id=registration.id,
+        #                                                                 report_data=json_data,
+        #                                                                 report_type=report_type)
+        #    verification_report.save()
+
+        payload = {
+            'registrationId': registration_id
+        }
+        apikey = current_app.config.get('SUBSCRIPTION_API_KEY')
+        if apikey:
+            payload['apikey'] = apikey
+        GoogleQueueService().publish_registration_report(payload)
+        current_app.logger.info(f'Enqueue registration report successful for id={registration_id}.')
+    except DatabaseException as db_err:
+        # Just log, do not return an error response.
+        msg = f'Enqueue registration report db error for id={registration_id}: ' + str(db_err)
+        current_app.logger.error(msg)
+    except Exception as err:  # noqa: B902; do not alter app processing
+        msg = f'Enqueue registration report failed for id={registration_id}: ' + str(err)
+        current_app.logger.error(msg)
+        EventTracking.create(registration_id,
+                             EventTracking.EventTrackingTypes.REGISTRATION_REPORT,
+                             int(HTTPStatus.INTERNAL_SERVER_ERROR),
+                             msg)
+
+
+def registration_callback_error(code: str, registration_id: int, status_code, message: str = None):
+    """Return the registration report event listener callback error response based on the code."""
+    error: str = CALLBACK_MESSAGES[code].format(key_id=registration_id)
+    if message:
+        error += ' ' + message
+    # Track event here.
+    EventTracking.create(registration_id, EventTracking.EventTrackingTypes.REGISTRATION_REPORT, status_code, message)
+    if status_code != HTTPStatus.BAD_REQUEST and code not in (resource_utils.CallbackExceptionCodes.MAX_RETRIES,
+                                                              resource_utils.CallbackExceptionCodes.UNKNOWN_ID,
+                                                              resource_utils.CallbackExceptionCodes.SETUP_ERR):
+        # set up retry
+        enqueue_registration_report(registration_id)
+    return resource_utils.error_response(status_code, error)
+
+
+def get_registration_callback_report(registration):  # pylint: disable=too-many-return-statements
+    """Attempt to generate and store a registration report. Record the status."""
+    registration_id: int = 0
+    try:
+        if registration:
+            registration_id = registration.id
+        # Not yet implemented.
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.REPORT_ERR,
+                                           9999999,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           'Registration report not yet implemented.')
+
+        # Track success event.
+        # EventTracking.create(registration_id,
+        #                     EventTracking.EventTrackingTypes.REGISTRATION_REPORT,
+        #                     int(HTTPStatus.OK))
+        # return response, HTTPStatus.OK
+    except ReportException as report_err:
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.REPORT_ERR,
+                                           registration_id,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           str(report_err))
+    except ReportDataException as report_data_err:
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.REPORT_DATA_ERR,
+                                           registration_id,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           str(report_data_err))
+    except StorageException as storage_err:
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.STORAGE_ERR,
+                                           registration_id,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           str(storage_err))
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, None, 'POST registration report event')
+    except Exception as default_err:  # noqa: B902; return nicer default error
+        return registration_callback_error(resource_utils.CallbackExceptionCodes.DEFAULT,
+                                           registration_id,
+                                           HTTPStatus.INTERNAL_SERVER_ERROR,
+                                           str(default_err))

--- a/mhr_api/src/mhr_api/resources/v1/search_report_callback.py
+++ b/mhr_api/src/mhr_api/resources/v1/search_report_callback.py
@@ -1,0 +1,163 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API callback endpoint to generate and store MHR search reports after completting search step 2."""
+
+from http import HTTPStatus
+
+# import requests
+from flask import Blueprint, current_app  # , jsonify, request
+from flask_cors import cross_origin
+
+from mhr_api.exceptions import DatabaseException
+from mhr_api.services.queue_service import GoogleQueueService
+from mhr_api.models import EventTracking, SearchResult  # , utils as model_utils
+from mhr_api.resources import utils as resource_utils
+
+
+# from mhr_api.reports import ReportTypes, get_pdf
+# from mhr_api.callback.reports.report_service import get_search_report
+from mhr_api.services.utils.exceptions import ReportException, ReportDataException, StorageException
+# from mhr_api.services.document_storage.storage_service import GoogleStorageService
+
+
+bp = Blueprint('SEARCH_REPORT1', __name__, url_prefix='/api/v1/search-report-callback')  # pylint: disable=invalid-name
+
+CALLBACK_MESSAGES = {
+    resource_utils.CallbackExceptionCodes.UNKNOWN_ID: '01: no search result data found for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.MAX_RETRIES: '02: maximum retries reached for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.INVALID_ID: '03: search result report setup not async for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.DEFAULT: '04: default error for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.REPORT_DATA_ERR: '05: report data error for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.REPORT_ERR: '06: generate report failed for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.STORAGE_ERR: '07: document storage save failed for id={search_id}.',
+    resource_utils.CallbackExceptionCodes.NOTIFICATION_ERR: '08: notification failed for id={search_id}.'
+}
+
+
+@bp.route('/<string:search_id>', methods=['POST', 'OPTIONS'])
+@cross_origin(origin='*')
+def post_search_report_callback(  # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements
+        search_id: str
+        ):
+    """Resource to generate and store a search result report as callback request."""
+    try:
+        current_app.logger.info(f'Search report callback starting id={search_id}.')
+        if search_id is None:
+            return resource_utils.path_param_error_response('search ID')
+
+        # If exceeded max retries we're done.
+        event_count: int = 0
+        events = EventTracking.find_by_key_id_type(search_id, EventTracking.EventTrackingTypes.SEARCH_REPORT)
+        if events:
+            event_count = len(events)
+        if event_count > current_app.config.get('EVENT_MAX_RETRIES'):
+            return callback_error(resource_utils.CallbackExceptionCodes.MAX_RETRIES, search_id,
+                                  HTTPStatus.INTERNAL_SERVER_ERROR,
+                                  'Max retries reached.')
+
+        search_detail = SearchResult.find_by_search_id(search_id, False)
+        if not search_detail:
+            return callback_error(resource_utils.CallbackExceptionCodes.UNKNOWN_ID, search_id, HTTPStatus.NOT_FOUND)
+
+        # Check if report already generated.
+        if search_detail.doc_storage_url is not None:
+            doc_ref = search_detail.doc_storage_url
+            current_app.logger.warn(f'Search detail report for {search_id} already exists: {doc_ref}.')
+            return {}, HTTPStatus.OK
+
+        # Generate the report with an API call here
+        current_app.logger.info(f'Generating search detail report for {search_id}.')
+        # raw_data, status_code, headers = get_search_report(search_id)
+        # if not raw_data or not status_code:
+        #    return callback_error(resource_utils.CallbackExceptionCodes.REPORT_DATA_ERR,
+        #                            search_id,
+        #                            HTTPStatus.INTERNAL_SERVER_ERROR,
+        #                            'No data or status code.')
+        # current_app.logger.debug('report api call status=' + str(status_code) + ' headers=' + json.dumps(headers))
+        # if status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
+        #    message = f'Status code={status_code}. Response: ' + raw_data.get_data(as_text=True)
+        #    return callback_error(resource_utils.CallbackExceptionCodes.REPORT_ERR,
+        #                            search_id,
+        #                            HTTPStatus.INTERNAL_SERVER_ERROR,
+        #                            message)
+
+        # doc_name = model_utils.get_search_doc_storage_name(search_detail.search)
+        # current_app.logger.info(f'Saving report output to doc storage: name={doc_name}.')
+        # response = GoogleStorageService.save_document(doc_name, raw_data)
+        # current_app.logger.info('Save document storage response: ' + json.dumps(response))
+        # search_detail.doc_storage_url = doc_name
+        # search_detail.save()
+
+        # Track success event.
+        EventTracking.create(search_id, EventTracking.EventTrackingTypes.SEARCH_REPORT, int(HTTPStatus.OK))
+
+        # return response, HTTPStatus.OK
+        # Replace with above when report implemented.
+        return None, HTTPStatus.OK
+    except ReportException as report_err:
+        return callback_error(resource_utils.CallbackExceptionCodes.REPORT_ERR,
+                              search_id,
+                              HTTPStatus.INTERNAL_SERVER_ERROR,
+                              str(report_err))
+    except ReportDataException as report_data_err:
+        return callback_error(resource_utils.CallbackExceptionCodes.REPORT_DATA_ERR,
+                              search_id,
+                              HTTPStatus.INTERNAL_SERVER_ERROR,
+                              str(report_data_err))
+    except StorageException as storage_err:
+        return callback_error(resource_utils.CallbackExceptionCodes.STORAGE_ERR,
+                              search_id,
+                              HTTPStatus.INTERNAL_SERVER_ERROR,
+                              str(storage_err))
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, None, 'POST large report event')
+    except Exception as default_err:  # noqa: B902; return nicer default error
+        return callback_error(resource_utils.CallbackExceptionCodes.DEFAULT,
+                              search_id,
+                              HTTPStatus.INTERNAL_SERVER_ERROR,
+                              str(default_err))
+
+
+def callback_error(code: str, search_id: str, status_code, message: str = None):
+    """Return to the event listener callback error response based on the code."""
+    error = CALLBACK_MESSAGES[code].format(search_id=search_id)
+    if message:
+        error += ' ' + message
+    current_app.logger.error(error)
+    # Track event here.
+    EventTracking.create(search_id, EventTracking.EventTrackingTypes.SEARCH_REPORT, status_code, message)
+    if status_code != HTTPStatus.BAD_REQUEST and code not in (resource_utils.CallbackExceptionCodes.MAX_RETRIES,
+                                                              resource_utils.CallbackExceptionCodes.UNKNOWN_ID):
+        # set up retry
+        enqueue_search_report(search_id)
+    return resource_utils.error_response(status_code, error)
+
+
+def enqueue_search_report(search_id: str):
+    """Add the search report request to the queue."""
+    try:
+        payload = {
+            'searchId': search_id
+        }
+        apikey = current_app.config.get('SUBSCRIPTION_API_KEY')
+        if apikey:
+            payload['apikey'] = apikey
+        GoogleQueueService().publish_search_report(payload)
+        current_app.logger.info(f'Enqueue search report successful for id={search_id}.')
+    except Exception as err:  # noqa: B902; do not alter app processing
+        current_app.logger.error(f'Enqueue search report failed for id={search_id}: ' + str(err))
+        EventTracking.create(search_id,
+                             EventTracking.EventTrackingTypes.SEARCH_REPORT,
+                             int(HTTPStatus.INTERNAL_SERVER_ERROR),
+                             'Enqueue search report event failed: ' + str(err))

--- a/mhr_api/src/mhr_api/services/payment/client/__init__.py
+++ b/mhr_api/src/mhr_api/services/payment/client/__init__.py
@@ -279,10 +279,6 @@ class SBCPaymentClient(BaseClient):
                 if 'datNumber' in transaction_info:
                     account_info['datNumber'] = transaction_info['datNumber']
                 data['accountInfo'] = account_info
-        if client_reference_id:
-            data['filingInfo']['folioNumber'] = client_reference_id
-        else:
-            del data['filingInfo']['folioNumber']
         return data
 
     @staticmethod
@@ -421,6 +417,7 @@ class SBCPaymentClient(BaseClient):
 
     def create_payment_staff_search(self, selections, transaction_info, mhr_id=None, client_reference_id=None):
         """Submit a staff search payment request for the PPR API transaction."""
+        current_app.logger.debug('Setting up staff search data.')
         data = SBCPaymentClient.create_payment_staff_search_data(selections,
                                                                  transaction_info,
                                                                  mhr_id,

--- a/mhr_api/src/mhr_api/services/queue_service.py
+++ b/mhr_api/src/mhr_api/services/queue_service.py
@@ -1,0 +1,60 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This class enqueues messages for the PPR API asynchronous events."""
+import json
+
+from flask import current_app
+from google.cloud import pubsub_v1
+
+from mhr_api.services.gcp_auth.auth_service import GoogleAuthService
+
+
+class GoogleQueueService():
+    """Google Pub/Sub implementation to publish/enqueue events.
+
+    Publish aync messages for downstream processing.
+    """
+
+    def __init__(self):
+        """Initialize the publisher."""
+        credentials = GoogleAuthService.get_credentials()
+        self.publisher = pubsub_v1.PublisherClient(credentials=credentials)
+        self.project_id = str(current_app.config.get('GCP_PS_PROJECT_ID'))
+        self.search_report_topic = str(current_app.config.get('GCP_PS_SEARCH_REPORT_TOPIC'))
+        self.registration_report_topic = str(current_app.config.get('GCP_PS_REGISTRATION_REPORT_TOPIC'))
+        self.search_report_topic_name = f'projects/{self.project_id}/topics/{self.search_report_topic}'
+        self.registration_report_topic_name = f'projects/{self.project_id}/topics/{self.registration_report_topic}'
+
+    def publish_search_report(self, payload):
+        """Publish the search report request json payload to the Queue Service."""
+        try:
+            self.publish(self.search_report_topic_name, payload)
+        except Exception as err:  # pylint: disable=broad-except # noqa F841;
+            current_app.logger.error('Error publish_search_report: ' + str(err))
+            raise err
+
+    def publish_registration_report(self, payload):
+        """Publish the API registration verification request json payload to the Queue Service."""
+        try:
+            self.publish(self.registration_report_topic_name, payload)
+        except Exception as err:  # pylint: disable=broad-except # noqa F841;
+            current_app.logger.error('Error publish_registration_report: ' + str(err))
+            raise err
+
+    def publish(self, topic_name, payload_json):
+        """Publish the payload to the specified topic."""
+        payload = json.dumps(payload_json).encode('utf-8')
+        current_app.logger.info('Publishing topic=' + topic_name + ', payload=' + json.dumps(payload_json))
+        future = self.publisher.publish(topic_name, payload)
+        future.result()

--- a/mhr_api/tests/unit/api/test_registration_report_callback.py
+++ b/mhr_api/tests/unit/api/test_registration_report_callback.py
@@ -1,0 +1,38 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the callback registration report endpoint.
+
+Test-Suite to ensure that the /registration-report-callback endpoint is working as expected.
+"""
+from http import HTTPStatus
+
+import pytest
+
+
+# testdata pattern is ({desc}, {status}, {registration_id})
+# Add more when report available.
+TEST_CALLBACK_DATA = [
+    ('Invalid id', HTTPStatus.NOT_FOUND, 300000005)
+]
+
+
+@pytest.mark.parametrize('desc,status,registration_id', TEST_CALLBACK_DATA)
+def test_registration_report_callback(session, client, jwt, desc, status, registration_id):
+    """Assert that a callback request returns the expected status."""
+    # test
+    rv = client.post('/api/v1/registration-report-callback/' + str(registration_id),
+                     headers=None)
+    # check
+    assert rv.status_code == status

--- a/mhr_api/tests/unit/api/test_search_report_callback.py
+++ b/mhr_api/tests/unit/api/test_search_report_callback.py
@@ -1,0 +1,38 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the callback search report endpoint.
+
+Test-Suite to ensure that the /search-report-callback endpoint is working as expected.
+"""
+from http import HTTPStatus
+
+import pytest
+
+
+# testdata pattern is ({desc}, {status}, {search_id})
+# Add more when report available.
+TEST_CALLBACK_DATA = [
+    ('Invalid id', HTTPStatus.NOT_FOUND, 300000005)
+]
+
+
+@pytest.mark.parametrize('desc,status,search_id', TEST_CALLBACK_DATA)
+def test_search_report_callback(session, client, jwt, desc, status, search_id):
+    """Assert that a callback request returns the expected status."""
+    # test
+    rv = client.post('/api/v1/search-report-callback/' + str(search_id),
+                     headers=None)
+    # check
+    assert rv.status_code == status

--- a/mhr_api/tests/unit/models/test_event_tracking.py
+++ b/mhr_api/tests/unit/models/test_event_tracking.py
@@ -1,0 +1,146 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the EventTracking Model.
+
+Test-Suite to ensure that the EventTracking Model is working as expected.
+"""
+from http import HTTPStatus
+
+import pytest
+
+from mhr_api.models import EventTracking, utils as model_utils
+
+
+# testdata pattern is ({description}, {exists}, {search_value})
+TEST_DATA_ID = [
+    ('Exists', True, 200000000),
+    ('Does not exist', False, 300000000)
+]
+# testdata pattern is ({description}, {exists}, {search_value})
+TEST_DATA_KEY_ID = [
+    ('Exists', True, 200000008),
+    ('Does not exist', False, 300000000)
+]
+# testdata pattern is ({description}, {results_size}, {key_id}, {type})
+TEST_DATA_KEY_ID_TYPE = [
+    ('No results', 0, 200000000, EventTracking.EventTrackingTypes.SEARCH_REPORT),
+    ('1 result search', 1, 200000009, EventTracking.EventTrackingTypes.SEARCH_REPORT),
+    ('3 results search', 1, 200000010, EventTracking.EventTrackingTypes.SEARCH_REPORT),
+    ('1 result notification', 1, 200000011, EventTracking.EventTrackingTypes.API_NOTIFICATION),
+    ('1 result email', 1, 200000012, EventTracking.EventTrackingTypes.EMAIL),
+    ('1 result surface mail', 1, 200000013, EventTracking.EventTrackingTypes.SURFACE_MAIL),
+    ('1 result email report', 1, 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT)
+]
+# testdata pattern is ({description}, {key_id}, {type}, {status}, {message})
+TEST_DATA_CREATE = [
+    ('Search', 200000010, EventTracking.EventTrackingTypes.SEARCH_REPORT, int(HTTPStatus.OK), 'message'),
+    ('Notification', 200000011, EventTracking.EventTrackingTypes.API_NOTIFICATION, int(HTTPStatus.OK), 'message'),
+    ('Email', 200000012, EventTracking.EventTrackingTypes.EMAIL, int(HTTPStatus.OK), 'message'),
+    ('Surface mail', 200000013, EventTracking.EventTrackingTypes.SURFACE_MAIL, int(HTTPStatus.OK), 'message'),
+    ('Email report', 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT, int(HTTPStatus.OK), 'message')
+]
+# testdata pattern is ({description}, {results_size}, {key_id}, {type}, extra_key)
+TEST_DATA_KEY_ID_TYPE_EXTRA = [
+    ('No results registration id', 0, 200000000, EventTracking.EventTrackingTypes.SURFACE_MAIL, '9999998'),
+    ('No results party id', 0, 200000030, EventTracking.EventTrackingTypes.SURFACE_MAIL, '9999998'),
+    ('4 results party id', 4, 200000030, EventTracking.EventTrackingTypes.SURFACE_MAIL, '9999999')
+]
+
+
+@pytest.mark.parametrize('desc,exists,search_value', TEST_DATA_ID)
+def test_find_by_id(session, desc, exists, search_value):
+    """Assert that find event tracking by id contains all expected elements."""
+    event_tracking = EventTracking.find_by_id(search_value)
+    if exists:
+        assert event_tracking
+        assert event_tracking.id == search_value
+        assert event_tracking.key_id
+        assert event_tracking.event_ts
+        assert event_tracking.event_tracking_type == EventTracking.EventTrackingTypes.SEARCH_REPORT
+    else:
+        assert not event_tracking
+
+
+@pytest.mark.parametrize('desc,exists,search_value', TEST_DATA_KEY_ID)
+def test_find_by_key_id(session, desc, exists, search_value):
+    """Assert that find event tracking by key id contains all expected elements."""
+    events = EventTracking.find_by_key_id(search_value)
+    if exists:
+        assert events
+        assert events[0].id > 0
+        assert events[0].key_id == search_value
+        assert events[0].event_ts
+        assert events[0].event_tracking_type == EventTracking.EventTrackingTypes.SEARCH_REPORT
+    else:
+        assert not events
+
+
+@pytest.mark.parametrize('desc,results_size,key_id,type', TEST_DATA_KEY_ID_TYPE)
+def test_find_by_id_type(session, desc, results_size, key_id, type):
+    """Assert that find event tracking by key id and type contains all expected elements."""
+    events = EventTracking.find_by_key_id_type(key_id, type)
+    if results_size > 0:
+        assert events
+        assert len(events) >= results_size
+    else:
+        assert not events
+
+
+@pytest.mark.parametrize('desc,key_id,type,status,message', TEST_DATA_CREATE)
+def test_create(session, desc, key_id, type, status, message):
+    """Assert that create event tracking works as expected."""
+    event_tracking = EventTracking.create(key_id, type, status, message)
+    assert event_tracking
+    assert event_tracking.id > 0
+    assert event_tracking.event_ts
+    assert event_tracking.event_tracking_type == type
+    assert event_tracking.status == status
+    assert event_tracking.message == message
+
+
+@pytest.mark.parametrize('desc,results_size,key_id,type,extra_key', TEST_DATA_KEY_ID_TYPE_EXTRA)
+def test_find_by_id_type_extra(session, desc, results_size, key_id, type, extra_key):
+    """Assert that find event tracking by key id, extra key, and type contains all expected elements."""
+    events = EventTracking.find_by_key_id_type(key_id, type, extra_key)
+    if results_size > 0:
+        assert events
+        assert len(events) >= results_size
+    else:
+        assert not events
+
+
+def test_event_tracking_json(session):
+    """Assert that the event tracking model renders to a json format correctly."""
+    now_ts = model_utils.now_ts()
+    tracking = EventTracking(
+        id=1000,
+        key_id=1000,
+        event_ts=now_ts,
+        event_tracking_type=EventTracking.EventTrackingTypes.SEARCH_REPORT,
+        status=200,
+        message='message',
+        email_id='test@gmail.com'
+    )
+
+    tracking_json = {
+        'eventTrackingId': tracking.id,
+        'keyId': tracking.key_id,
+        'type': tracking.event_tracking_type,
+        'createDateTime': model_utils.format_ts(tracking.event_ts),
+        'status': tracking.status,
+        'message': tracking.message,
+        'emailAddress': tracking.email_id
+    }
+    assert tracking.json == tracking_json

--- a/mhr_api/tests/unit/services/test_queue_service.py
+++ b/mhr_api/tests/unit/services/test_queue_service.py
@@ -1,0 +1,51 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Google queue service publish tests."""
+import os
+
+from flask import current_app
+
+from mhr_api.services.queue_service import GoogleQueueService
+
+
+SUB_URL = 'https://bcregistry-dev.apigee.net/ppr-sub/api/v1/'
+TEST_PAYLOAD = {
+    'searchId': 999999999
+}
+TEST_PAYLOAD_REGISTRATION = {
+    'registrationId': 9999999,
+    'partyId': 9999999
+}
+
+
+def test_publish_search_report(session):
+    """Assert that enqueuing/publishing a search report event works as expected (no exception thrown)."""
+    current_app.config.update(GCP_PS_PROJECT_ID=os.getenv('GCP_PS_PROJECT_ID'))
+    current_app.config.update(GCP_PS_SEARCH_REPORT_TOPIC=os.getenv('GCP_PS_SEARCH_REPORT_TOPIC'))
+    current_app.config.update(GCP_PS_REGISTRATION_REPORT_TOPIC=os.getenv('GCP_PS_REGISTRATION_REPORT_TOPIC'))
+    current_app.config.update(SUBSCRIPTION_API_KEY=os.getenv('SUBSCRIPTION_API_KEY'))
+    payload = TEST_PAYLOAD
+    apikey = current_app.config.get('SUBSCRIPTION_API_KEY')
+    if apikey:
+        payload['apikey'] = apikey
+    GoogleQueueService().publish_search_report(payload)
+
+
+def test_publish_registration_report(session):
+    """Assert that enqueuing/publishing a registration report event works as expected (no exception thrown)."""
+    payload = TEST_PAYLOAD_REGISTRATION
+    apikey = current_app.config.get('SUBSCRIPTION_API_KEY')
+    if apikey:
+        payload['apikey'] = apikey
+    GoogleQueueService().publish_registration_report(payload)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12063

*Description of changes:*
- Set up mhr api async report generation/storage using the GCP Pub/Sub service.
-  12044 also fix staff mhr search payment error when no/empty string client ref: api was trying to remove pay-api folio number from the payload twice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
