### PR TITLE
mhr search report no PPR content

### DIFF
--- a/mhr_api/report-templates/searchResult.html
+++ b/mhr_api/report-templates/searchResult.html
@@ -64,7 +64,7 @@
               {% if searchQuery.clientReferenceId is defined and searchQuery.clientReferenceId != "" %}
                 {{searchQuery.clientReferenceId}}
               {% else %}
-                NA
+                N/A
               {% endif %}
             </div>
 
@@ -96,6 +96,7 @@
               0 Registrations
             {% endif %}  
           </td>
+          <td></td>
           <td>Total Search Report Pages:
             {% if totalResultsSize > 0 %}
               <span id="pagesCounter"></span>
@@ -117,38 +118,12 @@
 
   </article>
 
-{#
     {% if totalResultsSize > 0 %}
       {% for detail in details %}
         <p style="page-break-before: always" ></p>
-        [[search-result/financingStatement.html]]
-
-        {% if detail.financingStatement.changes is defined %}
-          <p style="page-break-before: always" ></p>
-          <div class="separator-header mt-4"></div>
-          <div class="section-title-centre mt-2">HISTORY</div>
-          <div class="section-statement mt-0">(Showing most recent first)</div>
-          <div class="separator-header mt-2"></div>
-
-          <div class="container pt-4">
-            {% for change in detail.financingStatement.changes %}
-              {% if change.statementType == 'RENEWAL_STATEMENT' %}
-                [[search-result/renewalStatement.html]]
-              {% elif change.statementType == 'AMENDMENT_STATEMENT' %}
-                [[search-result/amendmentStatement.html]]
-              {% elif change.statementType == 'CHANGE_STATEMENT' %}
-                [[search-result/changeStatement.html]]
-              {% elif change.statementType == 'DISCHARGE_STATEMENT' %}
-                [[search-result/dischargeStatement.html]]
-              {% endif %}
-            {% endfor %}
-          </div>
-
-        {% endif %} 
+        [[search-result/registration.html]]
       {% endfor %}
-
     {% endif %}
-#}
 
   </body>
 </html>

--- a/mhr_api/report-templates/template-parts/search-result/details.html
+++ b/mhr_api/report-templates/template-parts/search-result/details.html
@@ -1,0 +1,66 @@
+<div class="no-page-break">
+    {% if detail.description is defined %}
+        <div class="separator mt-5"></div>
+        <div class="section-title mt-3">Manufactured Home Details</div>
+        <table class="no-page-break section-data details-table mt-4" role="presentation">
+            <tr>
+                <td class="section-sub-title">Year:</td>
+                <td>{{detail.description.baseInformation.year}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Manufacturer:</td>
+                <td>{{detail.description.manufacturer}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Make/Model:</td>
+                <td>{{ detail.description.baseInformation.make }}
+                    {% if detail.description.baseInformation.model is defined and detail.description.baseInformation.model != '' %} 
+                    / {{detail.description.baseInformation.model}}
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">CSA Number:</td>
+                <td>
+                    {% if detail.description.csaNumber is defined and detail.description.csaNumber != '' %}
+                        {{detail.description.csaNumber}}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">CSA Standard:</td>
+                <td>
+                    {% if detail.description.csaStandard is defined and detail.description.csaStandard != '' %}
+                        {{detail.description.csaStandard}}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Engineer Name:</td>
+                <td>
+                    {% if detail.description.engineerName is defined and detail.description.engineerName != '' %}
+                        {{detail.description.engineerName}}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Date of Engineer Report:</td>
+                <td>
+                    {% if detail.description.engineerDate is defined and detail.description.engineerDate != '' %}
+                        {{detail.description.engineerDate}}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            </tr>
+        </table>
+   {% endif %}
+
+</div>
+ 

--- a/mhr_api/report-templates/template-parts/search-result/location.html
+++ b/mhr_api/report-templates/template-parts/search-result/location.html
@@ -1,0 +1,32 @@
+{% if detail.location is defined %}
+<div class="no-page-break">
+    <div class="separator mt-5"></div>
+    <div class="section-title mt-3">Registered Location</div>
+    <table class="section-data section-data-table mt-4" role="presentation">
+        <tr class="no-page-break">
+            <td class="col-33">
+                <div class="section-sub-title">{{ detail.location.parkName }}</div>
+            </td>
+            <td class="col-33">
+                <div class="section-sub-title">Address</div>
+                <div class="pt-2">{{ detail.location.address.street }}</div>
+                <div>{{ detail.location.address.streetAdditional }}</div>
+                <div>{{ detail.location.address.city }} 
+                     {{ detail.location.address.region }}</div>
+                <div>{{ detail.location.address.postalCode }} 
+                     {{ detail.location.address.country }}</div>
+            </td>
+            <td class="col-33">
+                <div class="section-sub-title">Pad Number</div>
+                <div class="pt-2">
+                    {% if detail.location.pad is defined and detail.location.pad != '' %}
+                        {{ detail.location.pad }}
+                    {% else %}
+                        N/A
+                    {% endif %} 
+                </div>
+            </td>
+         </tr>
+    </table>
+</div>
+{% endif %}

--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -1,0 +1,47 @@
+{% if detail.notes is defined and detail.notes|length > 0  %}
+    {% for note in detail.notes %}
+        <div class="separator mt-5"></div>
+        <div class="section-title mt-3">{{note.documentDescription}}</div>
+        <table class="no-page-break section-data details-table mt-4" role="presentation">
+            <tr>
+                <td class="section-sub-title">MHR Number:</td>
+                <td>{{detail.mhrNumber}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Document Number:</td>
+                <td>{{note.documentId}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Registration Date and Time:</td>
+                <td>{{note.createDateTime}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Expired Date and Time:</td>
+                <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
+                        {{note.expiryDate}}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="section-sub-title">Remarks:</td>
+                <td>{{note.remarks}}</td>
+            </tr>
+            <tr>
+                <td class="section-sub-title pt-2">Contact:</td>
+                <td class="pt-2">
+                    <div>{{note.contactName}}</div>
+                    {% if note.contactAddress is defined %}
+                        <div>{{ note.contactAddress.street }}</div>
+                        <div>{{ note.contactAddress.streetAdditional }}</div>
+                        <div>{{ note.contactAddress.city }} {{ note.contactAddress.region }}</div>
+                        <div>{{ note.contactAddress.postalCode }} {{ note.contactAddress.country }}</div>
+                    {% endif %}
+                </td>
+            </tr>
+       </table>
+    {% endfor %}
+{% else %}
+    <div class="section-data">None</div>
+{% endif %}

--- a/mhr_api/report-templates/template-parts/search-result/owners.html
+++ b/mhr_api/report-templates/template-parts/search-result/owners.html
@@ -1,0 +1,29 @@
+<div class="section-title mt-3">Registered Owner(s) Information</div>
+{% if detail.owners is defined %}
+    <table class="section-data section-data-table mt-4" role="presentation">
+    {% for party in detail.owners %}
+        <tr class="no-page-break">
+            <td class="col-33">
+                <div class="section-sub-title">
+                    {% if party.organizationName is defined %}
+                        {{ party.organizationName }}
+                    {% elif party.individualName is defined %}
+                        {{ party.individualName.last }},
+                        {{ party.individualName.first }}
+                        {% if party.individualName.middle is defined %}&nbsp;{{ party.individualName.middle }}{% endif %}
+                    {% endif %}
+                </div>
+            </td>
+            <td class="col-33">
+                <div class="section-sub-title">Address</div>
+                <div class="pt-2">{{ party.address.street }}</div>
+                <div>{{ party.address.streetAdditional }}</div>
+                <div>{{ party.address.city }} {{ party.address.region }}</div>
+                <div>{{ party.address.postalCode }} {{ party.address.country }}</div>
+            </td>
+            <td class="col-33">
+           </td>
+         </tr>
+    {% endfor %}
+    </table>
+{% endif %}

--- a/mhr_api/report-templates/template-parts/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/search-result/registration.html
@@ -1,0 +1,78 @@
+
+
+<div class="business-details-container">
+  <table class="registration-header-table" id="{{ detail.mhrNumber }}"  role="presentation">
+    <tr>
+      <td>MHR Registration Number: {{ detail.mhrNumber }}</td>
+      <td></td>
+    </tr>
+  </table>
+  <table class="business-details-table-grey" role="presentation">
+    <tr>
+      <td>Registration Type:</td>
+      <td>Manufactured Home Act</td>
+    </tr>
+    <tr>
+      <td>Registration Date and Time:</td>
+      <td>
+        {% if detail.createDateTime is defined and detail.createDateTime != '' %}
+          {{detail.createDateTime}} 
+        {% else %}
+          N/A
+        {% endif %}
+      </td>
+    </tr>
+      <tr>
+      <td>Current Status:</td>
+      <td>
+        {% if detail.status == 'C' %}
+          Cancelled
+        {% elif detail.status == 'D' %}
+          Deleted
+        {% elif detail.status == 'E' %}
+          Expired
+        {% else %}
+          Registered
+        {% endif %}
+      </td>
+    </tr>
+    <tr>
+      <td>Declared Value:</td>
+      <td>
+        {% if detail.declaredValue is defined and detail.declaredValue != '' %}
+          {{detail.declaredValue}} 
+          {% if detail.declaredDateTime is defined and detail.declaredDateTime != '' %} as of {{detail.declaredDateTime}}{% endif %}
+        {% else %}
+          N/A
+        {% endif %}
+      </td>
+    </tr>    
+  </table>
+</div>
+
+<div class="no-page-break">
+  <div class="separator-header mt-6"></div>
+  <div class="section-title-centre mt-2">CURRENT REGISTRATION INFORMATION</div>
+  <div class="section-statement mt-0">(as of {{searchDateTime}})</div>
+  <div class="separator-header mt-2"></div>
+</div>
+
+<div class="container pt-4">
+  [[search-result/owners.html]]
+  [[search-result/location.html]]
+  [[search-result/details.html]]
+  [[search-result/sections.html]]
+  <div class="no-page-break">
+    <div class="separator-header mt-6"></div>
+    <div class="section-title-centre mt-2">UNIT NOTES</div>
+    <div class="section-statement mt-0">(Showing most recent first)</div>
+    <div class="separator-header mt-2"></div>
+  </div>
+  [[search-result/notes.html]]
+  
+  {#
+    {% if detail.pprRegistrations is defined and detail.pprRegistrations|length > 0 %}
+      [[search-result/pprRegistrations.html]]
+    {% endif %}
+  #}
+</div>

--- a/mhr_api/report-templates/template-parts/search-result/sections.html
+++ b/mhr_api/report-templates/template-parts/search-result/sections.html
@@ -1,0 +1,25 @@
+<div class="no-page-break">
+{% if detail.description is defined and detail.description.sections is defined %}
+   <div class="separator mt-5"></div>
+   <div class="section-title mt-3">Manufactured Home Sections</div>
+   <div class="section-data pt-3"><span class="sections-table-header">Number of Sections:</span> {{ detail.description.sections|length }}</div>
+   <table class="sections-table mt-4" role="presentation">         
+      <tr class="sections-table-header no-page-break">
+         <td class="top-align">Section</td>
+         <td class="top-align">Serial Number</td>
+         <td class="top-align">Length</td>
+         <td class="top-align">Width</td>
+      </tr>
+      {% for section in detail.description.sections %}
+         <tr class="no-page-break">
+            <td>{{loop.index}}</td>
+            <td>{{section.serialNumber}}</td>
+            <td>{{section.lengthFeet}} feet {{section.lengthInches}} inches</td>
+            <td>{{section.widthFeet}} feet {{section.widthInches}} inches</td>
+         </tr>
+      {% endfor %}
+   </table>
+{% else %}
+   <div class="section-data">None</div>
+{% endif %}
+</div>

--- a/mhr_api/report-templates/template-parts/search-result/selected.html
+++ b/mhr_api/report-templates/template-parts/search-result/selected.html
@@ -1,5 +1,5 @@
 <div class="container pt-4">
-    {% if searchQuery.type in ('OWNER_NAME', 'MHR_NUMBER') %}
+    {% if searchQuery.type == 'OWNER_NAME' %}
     <table class="selected-mhr-table mt-4" role="presentation">
         <tr class="solid-row-separator selected-mhr-table-header no-page-break">
             <td class="top-align"></td>
@@ -19,8 +19,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {{result.mhrNumber}}
-                    {#    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a> #}
+                    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a>
                 </td>
                 <td>
                     {{result.ownerName.last}}
@@ -40,7 +39,61 @@
                 </td>
                 <td>{{result.homeLocation}}</td>
                 <td class="right-align">
-                    {#<a href="#{{result.mhrNumber}}" class="tocpagenr"></a>#}
+                    <a href="#{{result.mhrNumber}}" class="tocpagenr"></a>
+                </td>
+                </tr>
+                <tr class="solid-row-separator no-page-break">
+                    <td colspan="4" style="height:1px"/>
+                </tr>
+        {% endfor %}
+    </table>  
+    {% elif searchQuery.type == 'MHR_NUMBER' %}
+    <table class="selected-mhr-table mt-4" role="presentation">
+        <tr class="solid-row-separator selected-mhr-table-header no-page-break">
+            <td class="top-align"></td>
+            <td class="top-align">MHR Number</td>
+            <td class="top-align">
+                {% if selected[0].organizationName is defined %}Organization{% else %}Owner{% endif %} Name
+            </td>
+            <td class="top-align">Status</td>
+            <td class="top-align">Year</td>
+            <td class="top-align">Make/Model</td>
+            <td class="top-align">Location</td>
+            <td class="top-align">Page</td>
+        </tr>
+        {% for result in selected %}
+            <tr class="no-page-break">
+                <td>
+                    {% if result.index is defined %}
+                        {{result.index}}
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a>
+                </td>
+                <td>
+                    {% if result.organizationName is defined %}
+                        {{result.organizationName}}
+                    {% else %}
+                        {{result.ownerName.last}}
+                        {% if result.ownerName.first %}
+                            ,{{result.ownerName.first}}
+                            {% if result.ownerName.middle %}{{result.ownerName.middle}}{% endif %}
+                        {% endif %}
+                    {% endif %}
+                </td>
+                <td>
+                    {{result.status}}
+                </td>
+                <td>{{result.baseInformation.year}}</td>
+                <td>{{result.baseInformation.make}} 
+                    {% if result.baseInformation.model is defined and result.baseInformation.model != '' %} 
+                        / {{result.baseInformation.model}}
+                    {% endif %}
+                </td>
+                <td>{{result.homeLocation}}</td>
+                <td class="right-align">
+                    <a href="#{{result.mhrNumber}}" class="tocpagenr"></a>
                 </td>
                 </tr>
                 <tr class="solid-row-separator no-page-break">
@@ -68,8 +121,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {{result.mhrNumber}}
-                    {#    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a> #}
+                    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a>
                 </td>
                 <td>
                     {{result.serialNumber}}
@@ -85,7 +137,7 @@
                 </td>
                 <td>{{result.homeLocation}}</td>
                 <td class="right-align">
-                    {#<a href="#{{result.mhrNumber}}" class="tocpagenr"></a>#}
+                    <a href="#{{result.mhrNumber}}" class="tocpagenr"></a>
                 </td>
                 </tr>
                 <tr class="solid-row-separator no-page-break">
@@ -113,8 +165,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {{result.mhrNumber}}
-                    {#    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a> #}
+                    <a href="#{{result.mhrNumber}}">{{result.mhrNumber}}</a>
                 </td>
                 <td>
                     {{result.organizationName}}
@@ -130,7 +181,7 @@
                 </td>
                 <td>{{result.homeLocation}}</td>
                 <td class="right-align">
-                    {#<a href="#{{result.mhrNumber}}" class="tocpagenr"></a>#}
+                    <a href="#{{result.mhrNumber}}" class="tocpagenr"></a>
                 </td>
                 </tr>
                 <tr class="solid-row-separator no-page-break">

--- a/mhr_api/report-templates/template-parts/style.html
+++ b/mhr_api/report-templates/template-parts/style.html
@@ -293,15 +293,15 @@
 		vertical-align: middle;
 	}
 	.header-table-toc td:nth-child(1) {
-		width: 35%;
+		width: 48%;
 		text-align: right;
 	}
 	.header-table-toc td:nth-child(2) {
-		width: 30%;
+		width: 4%;
 		text-align: center;
 	}
 	.header-table-toc td:nth-child(3) {
-		width: 35%;
+		width: 48%;
 		text-align: left;
 	}
 
@@ -351,6 +351,26 @@
 		width: 75%;
 	}
 
+	.details-table {
+		width: 100%;
+		table-layout: fixed;
+		border-collapse: collapse;
+	}
+
+	.details-table td {
+		vertical-align: top;
+		overflow-wrap: break-word;
+  		word-wrap: break-word;
+	}
+
+	.details-table td:nth-child(1) {
+		padding-right: 25px;
+		width: 33%;
+	}
+
+	.details-table td:nth-child(2) {
+		width: 67%;
+	}
 
 	.statement-table {
 		width: 100%;
@@ -1046,6 +1066,52 @@
 	.selected-reg-num-table td:nth-child(5) {
 		width: 5%;
 	}
+
+	.sections-table-header {
+		font-family: 'BCSans-Bold', sans-serif !important;
+		color: #313132;
+		font-size: 10pt;
+		font-weight: bold;
+		line-height: 15px;
+		border-collapse: collapse;
+	}
+
+	.sections-table {
+		width: 100%;
+		font-size: 10pt;
+		line-height: 15px;
+		font-family: 'BCSans-Regular', sans-serif !important;
+		border-collapse: collapse;
+	}
+
+	.sections-table tr {
+		border-bottom: solid 0.5px #BCBEC5;
+	}
+	.sections-table tr:last-child {
+		border-bottom: none;
+	}
+
+	.sections-table td {
+		height: 40px;
+		vertical-align: middle;
+	}
+
+	.sections-table td:nth-child(1) {
+		width: 25%;
+	}
+
+	.sections-table td:nth-child(2) {
+		width: 25%;
+	}
+
+	.sections-table td:nth-child(3) {
+		width: 25%;
+	}
+
+	.sections-table td:nth-child(4) {
+		width: 25%;
+	}
+
 
 
 	#pagesCounter::after {

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -147,7 +147,7 @@ class Db2Manuhome(db.Model):
         declared_ts: str = None
         if self.reg_documents:
             for doc in self.reg_documents:
-                if self.reg_document_id and self.reg_document_id == doc.id:    
+                if self.reg_document_id and self.reg_document_id == doc.id:
                     doc_json = doc.registration_json
                     man_home['createDateTime'] = doc_json.get('createDateTime', '')
                     man_home['clientReferenceId'] = doc_json.get('attentionReference', '')
@@ -162,7 +162,7 @@ class Db2Manuhome(db.Model):
         man_home['declaredValue'] = declared_value
         if declared_ts:
             man_home['declaredDateTime'] = model_utils.format_ts(declared_ts)
-            
+
         if self.reg_owners:
             owners = []
             for owner in self.reg_owners:

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -261,6 +261,10 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
     def search(self):
         """Execute a search with the previously set search type and criteria."""
         use_legacy_db: bool = current_app.config.get('USE_LEGACY_DB', True)
+        if self.search_type == self.SearchTypes.MANUFACTURED_HOME_NUM:
+            # Format before searching
+            search_utils.format_mhr_number(self.request_json)
+
         if use_legacy_db:
             self.search_db2()
         else:

--- a/mhr_api/src/mhr_api/models/search_utils.py
+++ b/mhr_api/src/mhr_api/models/search_utils.py
@@ -112,3 +112,10 @@ SELECT DISTINCT fs.id
    AND sc.mhr_number = (SELECT searchkey_mhr(:query_value))
 ORDER BY fs.id ASC
 """
+
+
+def format_mhr_number(request_json):
+    """Trim and pad with zeroes search query mhr number query."""
+    mhr_num: str = request_json['criteria']['value']
+    mhr_num = mhr_num.strip().rjust(6, '0')
+    request_json['criteria']['value'] = mhr_num

--- a/mhr_api/src/mhr_api/reports/report.py
+++ b/mhr_api/src/mhr_api/reports/report.py
@@ -34,22 +34,22 @@ TO_SEARCH_DESCRIPTION = {
     'SERIAL_NUMBER': 'Serial Number'
 }
 TO_NOTE_DESCRIPTION = {
-'101': 'Register New Unit',
-'102': 'Decal Replacement',
-'103': 'Transport Permit',
-'103E': 'Extend Tran Permit',
-'CAU': 'Caution',
-'CAUC': 'Continue Caution',
-'CAUE': 'Extend Caution',
-'EXNR': 'Non-Res. Exemption',
-'EXRS': 'Res. Exemption',
-'FZE': 'Registrars Freeze',
-'NCON': 'Confidential Note',
-'NPUB': 'Public Note',
-'REGC': 'Reg. Correction',
-'REST': 'Restraining Order',
-'STAT': 'Dec./Illegal Move',
-'TAXN': 'Tax Sale Notice'
+    '101': 'Register New Unit',
+    '102': 'Decal Replacement',
+    '103': 'Transport Permit',
+    '103E': 'Extend Tran Permit',
+    'CAU': 'Caution',
+    'CAUC': 'Continue Caution',
+    'CAUE': 'Extend Caution',
+    'EXNR': 'Non-Res. Exemption',
+    'EXRS': 'Res. Exemption',
+    'FZE': 'Registrars Freeze',
+    'NCON': 'Confidential Note',
+    'NPUB': 'Public Note',
+    'REGC': 'Reg. Correction',
+    'REST': 'Restraining Order',
+    'STAT': 'Dec./Illegal Move',
+    'TAXN': 'Tax Sale Notice'
 }
 
 
@@ -273,7 +273,6 @@ class Report:  # pylint: disable=too-few-public-methods
                     for note in detail['notes']:
                         if note.get('contactAddress'):
                             Report._format_address(note['contactAddress'])
-                
 
     def _set_date_times(self):
         """Replace API ISO UTC strings with local report format strings."""
@@ -288,12 +287,12 @@ class Report:  # pylint: disable=too-few-public-methods
                     if declared_value.isnumeric() and declared_value != '0':
                         detail['declaredValue'] = '$' + '{:0,.2f}'.format(float(declared_value))
                     else:
-                        detail['declaredValue']  = ''
+                        detail['declaredValue'] = ''
                     if detail.get('description') and 'engineerDate' in detail['description']:
                         if detail['description']['engineerDate'] == '0001-01-01':
                             detail['description']['engineerDate'] = ''
                         else:
-                           detail['description']['engineerDate'] = \
+                            detail['description']['engineerDate'] = \
                                 Report._to_report_datetime(detail['description']['engineerDate'], False)
 
     def _set_selected(self):

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -114,6 +114,23 @@ def test_find_by_mhr_number(session, http_status, id, mhr_num, status, doc_id):
         assert request_err.value.status_code == http_status
 
 
+def test_notes_sort_order(session):
+    """Assert that manufauctured home notes sort order is as expected."""
+    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('053341')
+    report_json = manuhome.registration_json
+    assert len(report_json['notes']) == 2
+    assert report_json['notes'][0]['documentId'] == '90001986'
+    assert report_json['notes'][1]['documentId'] == '43405528'
+
+
+def test_declared_value(session):
+    """Assert that manufauctured home declared value is as expected."""
+    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('077344')
+    report_json = manuhome.registration_json
+    assert report_json['declaredValue'] == 28200
+    assert str(report_json['declaredDateTime']).startswith('2010-11-09')
+
+
 def test_manuhome_json(session):
     """Assert that the manufactured home info renders to a json format correctly."""
     manuhome = Db2Manuhome(mhr_number='022911',

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -1,0 +1,275 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the Search Model.
+
+Test-Suite to ensure that the Search Model is working as expected.
+"""
+from http import HTTPStatus
+import copy
+
+from flask import current_app
+
+import pytest
+
+from mhr_api.models import SearchRequest, utils as model_utils, search_utils
+from mhr_api.exceptions import BusinessException
+
+
+MHR_NUMBER_JSON = {
+    'type': 'MHR_NUMBER',
+    'criteria': {
+        'value': '022911'
+    },
+    'clientReferenceId': 'T-SQ-MH-1'
+}
+MH_INVALID_JSON = {
+    'type': 'MHR_NUMBER',
+    'criteria': {
+        'ownerName': {
+            'first': 'JAMES',
+            'last': 'BROWN'
+        }
+    }
+}
+# Test valid criteria with no results.
+MH_NONE_JSON = {
+    'type': 'MHR_NUMBER',
+    'criteria': {
+        'value': '999999'
+    },
+    'clientReferenceId': 'T-SQ-MH-4'
+}
+ORG_NAME_JSON = {
+    'type': 'ORGANIZATION_NAME',
+    'criteria': {
+        'value': 'GUTHRIE HOLDINGS LTD.'
+    },
+    'clientReferenceId': 'T-SQ-MO-1'
+}
+MO_INVALID_JSON = {
+    'type': 'ORGANIZATION_NAME',
+    'criteria': {
+        'ownerName': {
+            'first': 'JAMES',
+            'last': 'BROWN'
+        }
+    }
+}
+# Test valid criteria with no results.
+MO_NONE_JSON = {
+    'type': 'ORGANIZATION_NAME',
+    'criteria': {
+        'value': 'XXXXXXXXXXXZZZZZ'
+    },
+    'clientReferenceId': 'T-SQ-MH-4'
+}
+OWNER_NAME_JSON = {
+    'type': 'OWNER_NAME',
+    'criteria': {
+        'ownerName': {
+            'first': 'David',
+            'last': 'Hamm'
+        }
+    },
+    'clientReferenceId': 'T-SQ-MI-1'
+}
+OWNER_NAME_JSON2 = {
+    'type': 'OWNER_NAME',
+    'criteria': {
+        'ownerName': {
+            'first': 'DWAYNE',
+            'middle': 'LARRY',
+            'last': 'MANKE'
+        }
+    },
+    'clientReferenceId': 'T-SQ-MI-1'
+}
+MI_INVALID_JSON = {
+    'type': 'OWNER_NAME',
+    'criteria': {
+        'value': 'GUTHRIE HOLDINGS LTD.'
+    }
+}
+# Test valid criteria with no results.
+MI_NONE_JSON = {
+    'type': 'OWNER_NAME',
+    'criteria': {
+        'ownerName': {
+            'first': 'ZZZZYYYYY',
+            'last': 'XXXXXXXXOO'
+        }
+    },
+    'clientReferenceId': 'T-SQ-MI-4'
+}
+SERIAL_NUMBER_JSON = {
+    'type': 'SERIAL_NUMBER',
+    'criteria': {
+        'value': '4551'
+    },
+    'clientReferenceId': 'T-SQ-MS-1'
+}
+MS_INVALID_JSON = {
+    'type': 'SERIAL_NUMBER',
+    'criteria': {
+        'ownerName': {
+            'first': 'JAMES',
+            'last': 'BROWN'
+        }
+    }
+}
+# Test valid criteria with no results.
+MS_NONE_JSON = {
+    'type': 'SERIAL_NUMBER',
+    'criteria': {
+        'value': 'XXXXXXXXX'
+    },
+    'clientReferenceId': 'T-SQ-MS-4'
+}
+
+# testdata pattern is ({search type}, {JSON data})
+TEST_VALID_DATA = [
+    ('MM', MHR_NUMBER_JSON),
+    ('MO', ORG_NAME_JSON),
+    ('MI', OWNER_NAME_JSON),
+    ('MI', OWNER_NAME_JSON2),
+    ('MS', SERIAL_NUMBER_JSON),
+]
+# testdata pattern is ({search type}, {JSON data})
+TEST_NONE_DATA = [
+    ('MM', MH_NONE_JSON),
+    ('MO', MO_NONE_JSON),
+    ('MI', MO_NONE_JSON),
+    ('MS', MS_NONE_JSON)
+]
+# testdata pattern is ({search type}, {JSON data})
+TEST_INVALID_DATA = [
+    ('MM', MH_INVALID_JSON),
+    ('MO', MO_INVALID_JSON),
+    ('MI', MI_INVALID_JSON),
+    ('MS', MS_INVALID_JSON)
+]
+# testdata pattern is ({mhr_number}, {expected_num})
+TEST_MHR_NUMBER_DATA = [
+    ('001232', '001232'),
+    (' 1232 ', '001232'),
+    ('1232', '001232'),
+    ('01232', '001232')
+]
+
+
+def test_search_no_account(session):
+    """Assert that a search query with no account id returns the expected result."""
+    json_data = copy.deepcopy(MHR_NUMBER_JSON)
+    query = SearchRequest.create_from_json(json_data, None)
+    query.search()
+
+    assert query.id
+    assert query.search_response
+
+
+@pytest.mark.parametrize('search_type,json_data', TEST_VALID_DATA)
+def test_search_valid(session, search_type, json_data):
+    """Assert that a valid search returns the expected search type result."""
+    test_data = copy.deepcopy(json_data)
+    test_data['type'] = model_utils.TO_DB_SEARCH_TYPE[json_data['type']]
+    SearchRequest.validate_query(test_data)
+
+    query: SearchRequest = SearchRequest.create_from_json(json_data, 'PS12345', 'UNIT_TEST')
+    query.search()
+    assert not query.updated_selection
+    result = query.json
+    current_app.logger.debug(result)
+    assert query.id
+    assert query.search_response
+    assert query.account_id == 'PS12345'
+    assert query.user_id == 'UNIT_TEST'
+    assert result['searchId']
+    assert result['searchQuery']
+    assert result['searchDateTime']
+    assert result['totalResultsSize']
+    assert result['maxResultsSize']
+    assert result['returnedResultsSize']
+    assert len(result['results']) >= 1
+    for match in result['results']:
+        assert match['mhrNumber']
+        assert match['status']
+        assert match['createDateTime']
+        assert match['homeLocation']
+        assert match['serialNumber']
+        assert match['baseInformation']
+        assert match['baseInformation']['year']
+        assert match['baseInformation']['make']
+        assert match['baseInformation']['model'] is not None
+        assert 'organizationName' in match or 'ownerName' in match
+        if match.get('ownerName'):
+            assert match['ownerName']['first']
+            assert match['ownerName']['last']
+
+
+@pytest.mark.parametrize('search_type,json_data', TEST_NONE_DATA)
+def test_search_no_results(session, search_type, json_data):
+    """Assert that a search query with no results returns the expected result."""
+    query: SearchRequest = SearchRequest.create_from_json(json_data, None)
+    query.search()
+
+    assert query.id
+    assert not query.search_response
+    assert query.returned_results_size == 0
+
+
+def test_create_from_json(session):
+    """Assert that the search_client creates from a json format correctly."""
+    json_data = copy.deepcopy(MHR_NUMBER_JSON)
+    search_client = SearchRequest.create_from_json(json_data, 'PS12345', 'USERID')
+
+    assert search_client.account_id == 'PS12345'
+    assert search_client.search_type == 'MM'
+    assert search_client.client_reference_id == 'T-SQ-MH-1'
+    assert search_client.search_ts
+    assert search_client.search_criteria
+    assert search_client.user_id == 'USERID'
+
+
+@pytest.mark.parametrize('search_type,json_data', TEST_INVALID_DATA)
+def test_search_invalid_criteria_400(session, client, jwt, search_type, json_data):
+    """Assert that validation of a search request with invalid criteria throws a BusinessException."""
+    test_data = copy.deepcopy(json_data)
+    test_data['type'] = model_utils.TO_DB_SEARCH_TYPE[json_data['type']]
+    # test
+    with pytest.raises(BusinessException) as bad_request_err:
+        SearchRequest.validate_query(test_data)
+
+    # check
+    assert bad_request_err
+    assert bad_request_err.value.status_code == HTTPStatus.BAD_REQUEST
+    # print(bad_request_err.value.error)
+
+
+@pytest.mark.parametrize('mhr_number,expected_number', TEST_MHR_NUMBER_DATA)
+def test_search_mhr_number(session, mhr_number, expected_number):
+    """Assert that an mhr number search works with different values."""
+    test_data = copy.deepcopy(MHR_NUMBER_JSON)
+    test_data['criteria']['value'] = mhr_number
+
+    format_test = copy.deepcopy(test_data)
+    search_utils.format_mhr_number(format_test)
+    assert format_test['criteria']['value'] == expected_number
+
+    query: SearchRequest = SearchRequest.create_from_json(test_data, 'PS12345', 'UNIT_TEST')
+    query.search()
+    result = query.json
+    # current_app.logger.debug(result)
+    assert len(result['results']) >= 1
+    assert result['results'][0]['mhrNumber'] == expected_number


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12177

*Description of changes:*
- Initial implementation of the MHR search results report with no PPR (combination search) content.
- TOC and footer tracked separately.
- 12279 mhr api format search query mhr number: trim, pad with zeroes.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
