### PR TITLE
Update search registration owners to exclude previous.

### DIFF
--- a/mhr_api/report-templates/searchResult.html
+++ b/mhr_api/report-templates/searchResult.html
@@ -74,7 +74,7 @@
     </div>
 
     <div class="footer-search-result">
-      {{ footer_content }} <span class="footer-separator">|</span>
+      {{ footer_content }} <span class="footer-separator">|</span> Page 
     </div>
 
     <table class="header-table-toc mt-6" role="presentation">

--- a/mhr_api/report-templates/template-parts/stylePage.html
+++ b/mhr_api/report-templates/template-parts/stylePage.html
@@ -60,7 +60,7 @@
 			font-size: 10px;
 			font-weight: bold;
 			color: #003366;
-			margin-right: 158px;
+			margin-right: 112px; /* 158px; */
 			margin-left: 0px;
 			margin-bottom: 10px;
 			content: element(search_result_footer);
@@ -76,7 +76,7 @@
 			margin-left: 0px;
 			padding-left: 0px;
 			margin-bottom: 10px;
-    		content: "Page " counter(page) " of " counter(pages);
+    		content: counter(page) " of " counter(pages);
 		}
         @bottom-left {
 			margin-bottom: 14px;

--- a/mhr_api/report-templates/template-parts/stylePageDraft.html
+++ b/mhr_api/report-templates/template-parts/stylePageDraft.html
@@ -60,7 +60,7 @@
 			font-size: 10px;
 			font-weight: bold;
 			color: #003366;
-			margin-right: 158px;
+			margin-right: 112px; /* 158px; */
 			margin-left: 0px;
 			margin-bottom: 10px;
 			content: element(search_result_footer);
@@ -76,7 +76,7 @@
 			margin-left: 0px;
 			padding-left: 0px;
 			margin-bottom: 10px;
-    		content: "Page " counter(page) " of " counter(pages);
+    		content: counter(page) " of " counter(pages);
 		}
         @bottom-left {
 			margin-bottom: 14px;

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -105,8 +105,8 @@ class Db2Manuhome(db.Model):
 
         if not manuhome:
             raise BusinessException(
-                error=model_utils.ERR_REGISTRATION_NOT_FOUND.format(code=ResourceErrorCodes.NOT_FOUND_ERR,
-                                                                    mhr_number=mhr_number),
+                error=model_utils.ERR_REGISTRATION_NOT_FOUND_MHR.format(code=ResourceErrorCodes.NOT_FOUND_ERR,
+                                                                        mhr_number=mhr_number),
                 status_code=HTTPStatus.NOT_FOUND
             )
         manuhome.reg_documents = Db2Document.find_by_mhr_number(manuhome.mhr_number)
@@ -166,7 +166,9 @@ class Db2Manuhome(db.Model):
         if self.reg_owners:
             owners = []
             for owner in self.reg_owners:
-                owners.append(owner.registration_json)
+                owner_json = owner.registration_json
+                if owner_json:
+                    owners.append(owner_json)
             man_home['owners'] = owners
         if self.reg_location:
             man_home['location'] = self.reg_location.registration_json

--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -108,6 +108,9 @@ class Db2Owner(db.Model):
         """Return a search registration dict of this object, with keys in JSON format."""
         # Response legacy data: allow for any column to be null.
         owner = {}
+        if self.owngroup and self.owngroup.status == self.owngroup.StatusTypes.PREVIOUS:
+            return owner
+
         if self.owner_type == Db2Owner.OwnerTypes.INDIVIDUAL:
             owner['individualName'] = model_utils.get_ind_name_from_db2(self.name)
         else:

--- a/mhr_api/src/mhr_api/models/db2/owngroup.py
+++ b/mhr_api/src/mhr_api/models/db2/owngroup.py
@@ -30,6 +30,13 @@ class Db2Owngroup(db.Model):
         JOINT = 'JT'
         COMMON = 'TC'
 
+    class StatusTypes(str, Enum):
+        """Render an Enum of the owner group status types."""
+
+        ACTIVE = '3'
+        PREVIOUS = '4'
+        EXEMPT = '5'
+
     __bind_key__ = 'db2'
     __tablename__ = 'owngroup'
 

--- a/mhr_api/src/mhr_api/models/db2/search_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/search_utils.py
@@ -45,13 +45,16 @@ SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname
  WHERE mh.mhregnum = :query_value
    AND mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
-   AND mh.manhomid = o.manhomid
-   AND o.owngrpid = 1
-   AND o.ownerid = 1
    AND mh.manhomid = l.manhomid
    AND l.status = 'A'
    AND mh.manhomid = de.manhomid
    AND de.status = 'A'
+   AND mh.manhomid = o.manhomid
+   AND o.ownerid = 1
+   AND o.owngrpid IN (SELECT MIN(og2.owngrpid)
+                        FROM owngroup og2
+                       WHERE mh.manhomid = og2.manhomid
+                         AND og2.status IN ('3', '5'))
 """
 
 # Equivalent logic as DB view search_by_serial_num_vw, but API determines the where clause.
@@ -63,12 +66,9 @@ SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype,
 --         WHERE o2.manhomid = mh.manhomid) as owner_names, 
        l.towncity, de.sernumb1, de.yearmade,
        de.makemodl
-  FROM amhrtdb.manuhome mh, amhrtdb.document d, amhrtdb.owner o, amhrtdb.location l, amhrtdb.descript de
+  FROM manuhome mh, document d, owner o, location l, descript de
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
-   AND mh.manhomid = o.manhomid
-   AND o.owngrpid = 1
-   AND o.ownerid = 1
    AND (de.sernumb1 LIKE :query_value || '%' OR 
         de.sernumb2 LIKE :query_value || '%' OR 
         de.sernumb3 LIKE :query_value || '%' OR 
@@ -77,38 +77,50 @@ SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype,
    AND l.status = 'A'
    AND mh.manhomid = de.manhomid
    AND de.status = 'A'
+   AND mh.manhomid = o.manhomid
+   AND o.ownerid = 1
+   AND o.owngrpid IN (SELECT MIN(og2.owngrpid)
+                        FROM owngroup og2
+                       WHERE mh.manhomid = og2.manhomid
+                         AND og2.status IN ('3', '5'))
 ORDER BY d.regidate ASC
 """
 
 OWNER_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
        de.yearmade, de.makemodl
-  FROM manuhome mh, document d, owner o, location l, descript de
+  FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
-   AND mh.manhomid = o.manhomid
-   AND o.ownrtype = 'I'
-   AND o.compname LIKE :query_value || '%'
    AND mh.manhomid = l.manhomid
    AND l.status = 'A'
    AND mh.manhomid = de.manhomid
    AND de.status = 'A'
+   AND mh.manhomid = o.manhomid
+   AND o.ownrtype = 'I'
+   AND o.compname LIKE :query_value || '%'
+   AND o.manhomid = og.manhomid
+   AND o.owngrpid = og.owngrpid
+   AND og.status IN ('3', '5')
 ORDER BY o.ownrname ASC, d.regidate ASC
 """
 
 ORG_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
        de.yearmade, de.makemodl
-  FROM manuhome mh, document d, owner o, location l, descript de
+  FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
-   AND mh.manhomid = o.manhomid
-   AND o.ownrtype = 'B'
-   AND o.compname LIKE :query_value || '%'
    AND mh.manhomid = l.manhomid
    AND l.status = 'A'
    AND mh.manhomid = de.manhomid
    AND de.status = 'A'
+   AND mh.manhomid = o.manhomid
+   AND o.ownrtype = 'B'
+   AND o.compname LIKE :query_value || '%'
+   AND o.manhomid = og.manhomid
+   AND o.owngrpid = og.owngrpid
+   AND og.status IN ('3', '5')
 ORDER BY o.ownrname ASC, d.regidate ASC
 """
 

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -195,7 +195,7 @@ REG_TYPE_TO_REG_CLASS = {
 }
 
 # MHR Error messages
-ERR_REGISTRATION_NOT_FOUND = '{code}: no registration found for MHR number {mhr_number}.'
+ERR_REGISTRATION_NOT_FOUND_MHR = '{code}: no registration found for MHR number {mhr_number}.'
 ERR_SEARCH_TOO_OLD = '{code}: search get details search ID {search_id} timestamp too old: must be after {min_ts}.'
 ERR_SEARCH_COMPLETE = '{code}: search select results failed: results already provided for search ID {search_id}.'
 ERR_SEARCH_NOT_FOUND = '{code}: search select results failed: invalid search ID {search_id}.'
@@ -216,6 +216,42 @@ DB2_PROVINCE_MAPPING = {
     ' AB': 'AB',
     ', AB': 'AB',
     'ALBERTA': 'AB',
+    'MB': 'MB',
+    ' MB': 'MB',
+    ', MB': 'MB',
+    'MANITOBA': 'MB',
+    'NB': 'NB',
+    ' NB': 'NB',
+    ', NB': 'NB',
+    'NEW BRUSNWICK': 'NB',
+    'NL': 'NL',
+    ' NL': 'NL',
+    ', NL': 'NL',
+    'NEWFOUNDLAND': 'NL',
+    'NS': 'NS',
+    ' NS': 'NS',
+    ', NS': 'NS',
+    'NOVA SCOTIA': 'NS',
+    'NT': 'NT',
+    ' NT': 'NT',
+    ', NT': 'NT',
+    'NORTHWEST TERRITORIES': 'NT',
+    'NU': 'NU',
+    ' NU': 'NU',
+    ', NU': 'NU',
+    'NUNUVIT': 'NU',
+    'PE': 'PE',
+    ' PE': 'PE',
+    ', PE': 'PE',
+    'PRINCE EDWARD ISLAND': 'PE',
+    'QC': 'QC',
+    ' QC': 'QC',
+    ', QC': 'QC',
+    'QUEBEC': 'QC',
+    'YT': 'YT',
+    ' YT': 'YT',
+    ', YT': 'YT',
+    'YUKON TERRITORIES': 'YT',
     'SK': 'SK',
     ' SK': 'SK',
     ', SK': 'SK',

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -54,7 +54,7 @@ def test_find_by_id(session, exists, id, mhr_num, status, doc_id):
         assert manuhome.update_time is not None
         assert manuhome.accession_number is not None
         assert manuhome.box_number is not None
-        assert manuhome.reg_document
+        assert manuhome.reg_documents
         assert manuhome.reg_owners
         assert manuhome.reg_location
         assert manuhome.reg_descript
@@ -91,7 +91,7 @@ def test_find_by_mhr_number(session, http_status, id, mhr_num, status, doc_id):
         assert manuhome.update_time is not None
         assert manuhome.accession_number is not None
         assert manuhome.box_number is not None
-        assert manuhome.reg_document
+        assert manuhome.reg_documents
         assert manuhome.reg_owners
         assert manuhome.reg_location
         assert manuhome.reg_descript

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -54,17 +54,19 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, owner_id, type):
             assert owner.owngroup
             reg_json = owner.registration_json
             current_app.logger.debug(reg_json)
-            if owner.owner_type == Db2Owner.OwnerTypes.INDIVIDUAL:
-                assert reg_json.get('individualName')
+            if owner.owngroup and owner.owngroup.status == owner.owngroup.StatusTypes.PREVIOUS:
+                assert not reg_json
             else:
-                assert reg_json.get('organizationName')
-            assert reg_json.get('address')
-            assert reg_json['address']['street']
-            assert reg_json['address']['city']
-            assert reg_json['address']['region']
-            assert reg_json['address']['country']
-            assert reg_json.get('type')
-
+                if owner.owner_type == Db2Owner.OwnerTypes.INDIVIDUAL:
+                    assert reg_json.get('individualName')
+                else:
+                    assert reg_json.get('organizationName')
+                assert reg_json.get('address')
+                assert reg_json['address']['street']
+                assert reg_json['address']['city']
+                assert reg_json['address']['region']
+                assert reg_json['address']['country']
+                assert reg_json.get('type')
     else:
         assert not owners
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12379

*Description of changes:*
MHR api:
- Search result MHR registrations exclude previous owners. 
- Update unit tests.
- Revert previous search resort footer page counter spacing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
