### PR TITLE
Fix empty General Collateral on Review page

### DIFF
--- a/ppr-ui/src/components/collateral/Collateral.vue
+++ b/ppr-ui/src/components/collateral/Collateral.vue
@@ -84,7 +84,8 @@ import {
   onMounted,
   reactive,
   toRefs,
-  watch
+  watch,
+  onUnmounted
 } from '@vue/composition-api'
 import { useActions, useGetters } from 'vuex-composition-helpers'
 // local components
@@ -188,6 +189,18 @@ export default defineComponent({
                 'but not restricted to machinery, equipment, furniture, fixtures and receivables.'
             }])
           }
+        }
+      }
+    })
+
+    onUnmounted(() => {
+      // clear general collateral description if there is no valid text left in editor (html tags not included)
+      if (getAddCollateral.value.generalCollateral[0]?.description?.replace(/(<([^>]+)>)/ig, '').length === 0) {
+        setGeneralCollateral([])
+        // clear collateral step check mark if there are no vehicles
+        // (this resets check mark that was set by general collateral description)
+        if (getAddCollateral.value.vehicleCollateral.length === 0) {
+          getAddCollateral.value.valid = false
         }
       }
     })

--- a/ppr-ui/tests/unit/ReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/ReviewConfirm.spec.ts
@@ -26,7 +26,7 @@ import { LengthTrustIF } from '@/interfaces'
 import { RegistrationTypes } from '@/resources'
 // unit test helpers/data
 import mockRouter from './MockRouter'
-import { mockedSelectSecurityAgreement } from './test-data'
+import { mockedSelectSecurityAgreement, mockedGeneralCollateral1 } from './test-data'
 import { getLastEvent } from './utils'
 
 Vue.use(Vuetify)
@@ -186,6 +186,40 @@ describe('Review Confirm new registration component', () => {
       )
       wrapper.destroy()
     }
+  })
+
+  it('show error message in Collateral Summary section when description is empty', async () => {
+    await store.dispatch('setRegistrationType', mockedSelectSecurityAgreement())
+    await store.dispatch('setRegistrationFlowType', RegistrationFlowType.NEW)
+    await store.dispatch('setAddCollateral', { generalCollateral: mockedGeneralCollateral1 } )
+
+    wrapper = createComponent()
+    await flushPromises()
+
+    expect(wrapper.vm.$route.name).toBe(RouteNames.REVIEW_CONFIRM)
+    expect(wrapper.vm.appReady).toBe(true)
+    expect(wrapper.vm.dataLoaded).toBe(true)
+
+    expect(wrapper.findComponent(Collateral).exists()).toBe(true)
+    expect(wrapper.findComponent(Collateral).findAll('.invalid-message').exists()).toBe(false)
+
+    // Go back to Collateral step
+    await wrapper.find('#reg-back-btn').trigger('click')
+    expect(wrapper.vm.$route.name).toBe(RouteNames.ADD_COLLATERAL)
+
+    // Delete text from General Collateral as leave just html styling tag (as per current behavior)
+    await store.dispatch('setAddCollateral', { generalCollateral: 
+      {
+        addedDateTime: '2021-09-16T05:56:20Z',
+        description: '<p></p>'
+      }}
+    )
+
+    // Go Next to Review page and check that Collateral sections has invalid message(s)
+    await wrapper.find('#reg-next-btn').trigger('click')
+    expect(wrapper.vm.stepName).toBe(RouteNames.REVIEW_CONFIRM)
+    expect(wrapper.find(title).text()).toContain('Review and Confirm')
+    expect(wrapper.findComponent(Collateral).findAll('.invalid-message').exists()).toBe(true)
   })
 
   it('emits error', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12430

Deleting all text from General Collateral description (wysiwyg) does not clear HTML styling tags, which in turn displays empty Collateral Summary

*Description of changes:*
- Fix the issue by stripping out HTML from the GC description and checking for valid text
- Add tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
