### PR TITLE
Update serial number search query, key generation.

### DIFF
--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -18,6 +18,7 @@ from .db import db
 from .address import Address
 from .client_code import ClientCode
 from .court_order import CourtOrder
+from .db2.cmpserno import Db2Cmpserno
 from .db2.descript import Db2Descript
 from .db2.docdes import Db2Docdes
 from .db2.document import Db2Document
@@ -49,7 +50,7 @@ from .vehicle_collateral import VehicleCollateral
 
 __all__ = ('db',
            'Address', 'ClientCode', 'CountryType', 'CourtOrder',
-           'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manuhome', 'Db2Mhomnote',
+           'Db2Cmpserno', 'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manuhome', 'Db2Mhomnote',
            'Db2Owner', 'Db2Owngroup',
            'EventTracking', 'EventTrackingType', 'FinancingStatement', 'GeneralCollateral', 'Party',
            'PartyType', 'ProvinceType', 'Registration', 'RegistrationType',

--- a/mhr_api/src/mhr_api/models/db2/cmpserno.py
+++ b/mhr_api/src/mhr_api/models/db2/cmpserno.py
@@ -1,0 +1,83 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for legacy DB2 compressed serial number information."""
+from flask import current_app
+
+from mhr_api.exceptions import DatabaseException
+from mhr_api.models import db
+
+
+class Db2Cmpserno(db.Model):
+    """This class manages all of the legacy DB2 MHR compressed serial number information."""
+
+    __bind_key__ = 'db2'
+    __tablename__ = 'cmpserno'
+
+    manuhome_id = db.Column('MANHOMID', db.Integer, primary_key=True)
+    compressed_id = db.Column('CMPSERID', db.Integer, primary_key=True)
+    compressed_key = db.Column('SERIALNO', db.String(3), nullable=False)
+
+    # parent keys
+
+    # Relationships
+
+    def save(self):
+        """Save the object to the database immediately. Only used for unit testing."""
+        try:
+            db.session.add(self)
+            db.session.commit()
+            # current_app.logger.debug(f'Saved {self.json}')
+        except Exception as db_exception:   # noqa: B902; return nicer error
+            # current_app.logger.error('DB2Cmpserno.save exception: ' + str(db_exception))
+            raise DatabaseException(db_exception)
+
+    @classmethod
+    def find_by_manuhome_id(cls, manuhome_id: int):
+        """Return the compressed keys matching the manuhome id."""
+        serial_keys = None
+        if manuhome_id and manuhome_id > 0:
+            try:
+                serial_keys = cls.query.filter(Db2Cmpserno.manuhome_id == manuhome_id).all()
+            except Exception as db_exception:   # noqa: B902; return nicer error
+                current_app.logger.error('DB2Cmpserno.find_by_manuhome_id exception: ' + str(db_exception))
+                raise DatabaseException(db_exception)
+        return serial_keys
+
+    @property
+    def json(self):
+        """Return a dict of this object, with keys in JSON format."""
+        key = {
+            'compressedKeyId': self.compressed_id,
+            'compressedKey': self.compressed_key
+        }
+        return key
+
+    @property
+    def registration_json(self):
+        """Return a search registration dict of this object, with keys in JSON format."""
+        # Response legacy data: allow for any column to be null.
+        return self.json
+
+    @staticmethod
+    def create_from_dict(new_info: dict):
+        """Create a compressed serial number key object from dict/json."""
+        key = Db2Cmpserno(compressed_id=new_info.get('compressedKeyId', ''),
+                          compressed_key=new_info.get('compressedKey', ''))
+        return key
+
+    @staticmethod
+    def create_from_json(json_data):
+        """Create a a compressed serial number key object from a json document schema object: map json to db."""
+        key = Db2Cmpserno.create_from_dict(json_data)
+        return key

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -129,6 +129,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
             else:
                 status = 'HISTORIC'
         timestamp = row[3]
+        value: str = str(row[8])
+        year = int(value) if value.isnumeric() else 0
         result_json = {
             'mhrNumber': str(row[0]),
             'status': status,
@@ -136,7 +138,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
             'homeLocation': str(row[6]).strip(),
             'serialNumber': str(row[7]).strip(),
             'baseInformation': {
-                'year': int(row[8]),
+                'year': year,
                 'make': str(row[9]).strip(),
                 'model': ''
             }
@@ -224,6 +226,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         if rows is not None:
             results_json = []
             for row in rows:
+                # result = SearchRequest.__build_search_result(row)
+                # current_app.logger.debug(result)
                 results_json.append(SearchRequest.__build_search_result(row))
             self.returned_results_size = len(results_json)
             self.total_results_size = self.returned_results_size

--- a/mhr_api/tests/unit/models/db2/test_cmpserno.py
+++ b/mhr_api/tests/unit/models/db2/test_cmpserno.py
@@ -1,0 +1,55 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the legacy DB2 Cmpserno Model.
+
+Test-Suite to ensure that the legacy DB2 Cmpserno Model is working as expected.
+"""
+import pytest
+
+from flask import current_app
+
+from mhr_api.models import Db2Cmpserno, utils as model_utils
+
+
+# testdata pattern is ({exists}, {manuhome_id}, {compressed_id})
+TEST_DATA = [
+    (True, 1, 1),
+    (False, 0, 0)
+]
+
+
+@pytest.mark.parametrize('exists,manuhome_id,compressed_id', TEST_DATA)
+def test_find_by_manuhome_id(session, exists, manuhome_id, compressed_id):
+    """Assert that find compressed serial number key by manuhome id contains all expected elements."""
+    cmpserno = Db2Cmpserno.find_by_manuhome_id(manuhome_id)
+    if exists:
+        assert cmpserno
+        for key in cmpserno:
+            assert key.manuhome_id == manuhome_id
+            assert key.compressed_id == compressed_id
+            assert key.compressed_key
+            current_app.logger.debug(f'Compressed key=${key.compressed_key}$')
+    else:
+        assert not cmpserno
+
+
+def test_compressed_key(session):
+    """Assert that setting a compressed serial number key by manuhome id works as expected."""
+    keys = Db2Cmpserno.find_by_manuhome_id(47715)
+    if keys:
+        cmpserno: Db2Cmpserno = keys[0]
+        cmpserno.compressed_key =  model_utils.get_serial_number_key('123')
+        current_app.logger.debug(f'Updated key for {cmpserno.json}')
+        cmpserno.save()

--- a/mhr_api/tests/unit/models/db2/test_db2_search_request.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_search_request.py
@@ -55,7 +55,7 @@ MH_NONE_JSON = {
 ORG_NAME_JSON = {
     'type': 'ORGANIZATION_NAME',
     'criteria': {
-        'value': 'GUTHRIE HOLDINGS LTD.'
+        'value': 'JANDEL HOMES LTD.'
     },
     'clientReferenceId': 'T-SQ-MO-1'
 }
@@ -90,9 +90,9 @@ OWNER_NAME_JSON2 = {
     'type': 'OWNER_NAME',
     'criteria': {
         'ownerName': {
-            'first': 'DWAYNE',
-            'middle': 'LARRY',
-            'last': 'MANKE'
+            'first': 'ROSE',
+            'middle': 'CHERYL',
+            'last': 'LESLIE'
         }
     },
     'clientReferenceId': 'T-SQ-MI-1'
@@ -117,7 +117,7 @@ MI_NONE_JSON = {
 SERIAL_NUMBER_JSON = {
     'type': 'SERIAL_NUMBER',
     'criteria': {
-        'value': '4551'
+        'value': 'XF1048'
     },
     'clientReferenceId': 'T-SQ-MS-1'
 }
@@ -134,7 +134,7 @@ MS_INVALID_JSON = {
 MS_NONE_JSON = {
     'type': 'SERIAL_NUMBER',
     'criteria': {
-        'value': 'XXXXXXXXX'
+        'value': 'XXX999999999'
     },
     'clientReferenceId': 'T-SQ-MS-4'
 }
@@ -147,6 +147,7 @@ TEST_VALID_DATA = [
     ('MI', OWNER_NAME_JSON2),
     ('MS', SERIAL_NUMBER_JSON),
 ]
+
 # testdata pattern is ({search type}, {JSON data})
 TEST_NONE_DATA = [
     ('MM', MH_NONE_JSON),
@@ -184,7 +185,7 @@ def test_search_valid(session, search_type, json_data):
     query.search_db2()
     assert not query.updated_selection
     result = query.json
-    current_app.logger.debug(result)
+    current_app.logger.debug('Results size:' + str(result['totalResultsSize']))
     assert query.id
     assert query.search_response
     assert query.account_id == 'PS12345'
@@ -203,8 +204,8 @@ def test_search_valid(session, search_type, json_data):
         assert match['homeLocation']
         assert match['serialNumber']
         assert match['baseInformation']
-        assert match['baseInformation']['year']
-        assert match['baseInformation']['make']
+        assert 'year' in match['baseInformation']
+        assert 'make' in match['baseInformation']
         assert match['baseInformation']['model'] is not None
         assert 'organizationName' in match or 'ownerName' in match
         if match.get('ownerName'):

--- a/mhr_api/tests/unit/models/test_registration.py
+++ b/mhr_api/tests/unit/models/test_registration.py
@@ -22,7 +22,6 @@ import pytest
 
 from mhr_api.exceptions import BusinessException
 from mhr_api.models import Registration, GeneralCollateral
-from mhr_api.models import registration_utils as registration_utils
 # from mhr_api.services.authz import STAFF_ROLE, BCOL_HELP, GOV_ACCOUNT_ROLE
 
 
@@ -162,7 +161,7 @@ def test_find_by_id_cs_su(session):
 def test_find_by_registration_number(session, desc, reg_number, account_id, status, staff, base_reg_number):
     """Assert that a fetch financing statement by registration number works as expected."""
     if status == HTTPStatus.OK:
-        registration = Registration.find_by_registration_number(reg_number, account_id, staff, base_reg_number)
+        registration = Registration.find_by_registration_number(reg_number, account_id)
         assert registration.id >= 200000000
         assert registration.registration_num == reg_number
         assert registration.base_registration_num
@@ -173,7 +172,7 @@ def test_find_by_registration_number(session, desc, reg_number, account_id, stat
         # assert registration.client_reference_id
     else:
         with pytest.raises(BusinessException) as request_err:
-            Registration.find_by_registration_number(reg_number, account_id, staff, base_reg_number)
+            Registration.find_by_registration_number(reg_number, account_id)
 
         # check
         assert request_err
@@ -183,7 +182,7 @@ def test_find_by_registration_number(session, desc, reg_number, account_id, stat
 
 def test_find_by_registration_num_fs(session):
     """Assert that find a financing statement by registration number contains all expected elements."""
-    registration = Registration.find_by_registration_number('TEST0001', 'PS12345', False)
+    registration = Registration.find_by_registration_number('TEST0001', 'PS12345')
     assert registration
     assert registration.id == 200000000
     assert registration.registration_num == 'TEST0001'
@@ -195,7 +194,7 @@ def test_find_by_registration_num_fs(session):
 
 def test_find_by_registration_num_ds(session):
     """Assert that find a discharge statement by registration number contains all expected elements."""
-    registration = Registration.find_by_registration_number('TEST00D4', 'PS12345', True)
+    registration = Registration.find_by_registration_number('TEST00D4', 'PS12345')
     assert registration
     assert registration.id == 200000004
     assert registration.registration_num == 'TEST00D4'
@@ -215,7 +214,7 @@ def test_find_by_registration_num_ds(session):
 
 def test_find_by_registration_num_gc(session):
     """Assert that find an amendment with general collateral changes contains all expected elements."""
-    registration = Registration.find_by_registration_number('TEST0018A3', 'PS12345', True)
+    registration = Registration.find_by_registration_number('TEST0018A3', 'PS12345')
     assert registration
     assert registration.registration_num == 'TEST0018A3'
     assert registration.registration_type == 'AM'
@@ -246,7 +245,7 @@ def test_find_by_id_invalid(session):
 @pytest.mark.parametrize('base_reg_num,reg_num,reg_num_name', TEST_VERIFICATION_DATA)
 def test_verification_json(session, base_reg_num, reg_num, reg_num_name):
     """Assert that generating verification statement json works as expected."""
-    registration = Registration.find_by_registration_number(reg_num, 'PS12345', True)
+    registration = Registration.find_by_registration_number(reg_num, 'PS12345')
     json_data = registration.verification_json(reg_num_name)
     assert json_data[reg_num_name] == reg_num
     assert json_data['baseRegistrationNumber'] == base_reg_num

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -54,7 +54,7 @@ MH_NONE_JSON = {
 ORG_NAME_JSON = {
     'type': 'ORGANIZATION_NAME',
     'criteria': {
-        'value': 'GUTHRIE HOLDINGS LTD.'
+        'value': 'JANDEL HOMES LTD.'
     },
     'clientReferenceId': 'T-SQ-MO-1'
 }
@@ -89,9 +89,9 @@ OWNER_NAME_JSON2 = {
     'type': 'OWNER_NAME',
     'criteria': {
         'ownerName': {
-            'first': 'DWAYNE',
-            'middle': 'LARRY',
-            'last': 'MANKE'
+            'first': 'ROSE',
+            'middle': 'CHERYL',
+            'last': 'LESLIE'
         }
     },
     'clientReferenceId': 'T-SQ-MI-1'
@@ -116,7 +116,7 @@ MI_NONE_JSON = {
 SERIAL_NUMBER_JSON = {
     'type': 'SERIAL_NUMBER',
     'criteria': {
-        'value': '4551'
+        'value': 'XF1048'
     },
     'clientReferenceId': 'T-SQ-MS-1'
 }
@@ -133,7 +133,7 @@ MS_INVALID_JSON = {
 MS_NONE_JSON = {
     'type': 'SERIAL_NUMBER',
     'criteria': {
-        'value': 'XXXXXXXXX'
+        'value': 'XXX999999999'
     },
     'clientReferenceId': 'T-SQ-MS-4'
 }
@@ -190,7 +190,7 @@ def test_search_valid(session, search_type, json_data):
     query.search()
     assert not query.updated_selection
     result = query.json
-    current_app.logger.debug(result)
+    current_app.logger.debug('Results size:' + str(result['totalResultsSize']))
     assert query.id
     assert query.search_response
     assert query.account_id == 'PS12345'
@@ -209,8 +209,8 @@ def test_search_valid(session, search_type, json_data):
         assert match['homeLocation']
         assert match['serialNumber']
         assert match['baseInformation']
-        assert match['baseInformation']['year']
-        assert match['baseInformation']['make']
+        assert 'year' in match['baseInformation']
+        assert 'make' in match['baseInformation']
         assert match['baseInformation']['model'] is not None
         assert 'organizationName' in match or 'ownerName' in match
         if match.get('ownerName'):

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -14,6 +14,8 @@
 """Test Suite to ensure the model utility functions are working as expected."""
 import pytest
 
+from flask import current_app
+
 from mhr_api.models import utils as model_utils
 
 
@@ -57,6 +59,16 @@ TEST_DB2_ADDRESS = [
     ('18215 105TH AVENUE', None, 'EDMONTON', 'AB', '18215 105TH AVENUE                                                                                                      EDMONTON, AB'),
     ('MADELINE HILL, SALES ASSISTANT', 'P.O. BOX 845                            NO. 200 HIGHWAY #18 WEST', 'ESTEVAN', 'SK', 'MADELINE HILL, SALES ASSISTANT          P.O. BOX 845                            NO. 200 HIGHWAY #18 WEST                ESTEVAN SASKATCHEWAN')
 ]
+# testdata pattern is ({serial_num}, {hex_value})
+TEST_DATA_SERIAL_KEY = [
+    ('WIN14569401627', '0620db'),
+    ('A4492', '00118c'),
+    ('3E3947', '04a34b'),
+    ('6436252B10FK', '03db8a'),
+    ('I1724B', '002dcc'),
+    ('2427', '00097b'),
+    ('123', '00007b')
+]
 
 
 @pytest.mark.parametrize('name, key_value', TEST_DATA_ORG_KEY)
@@ -71,6 +83,15 @@ def test_search_key_owner(name, key_value):
     """Assert that computing an owner name search key works as expected."""
     value = model_utils.get_compressed_key(name)
     assert value == key_value
+
+
+@pytest.mark.parametrize('serial_num, hex_value', TEST_DATA_SERIAL_KEY)
+def test_search_key_serial(session, serial_num, hex_value):
+    """Assert that computing a serial number search key works as expected."""
+    value = model_utils.get_serial_number_key(serial_num)
+    # current_app.logger.info(f'Key={value}')
+    assert len(value) == 3
+    assert value.hex() == hex_value
 
 
 @pytest.mark.parametrize('street1, street2, city, region, address', TEST_DB2_ADDRESS)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12141

*Description of changes:*
- Follow the algorithm provided from legacy code to generate a serial number key.
- Use the key to match on serial number searches.
- Note: DEV db requires key regeneration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
