### PR TITLE
Fix for MH vehicle collateral schema: allow MHR and serial numbers.

### DIFF
--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -57,4 +57,4 @@ strict-rfc3339==0.7
 typing-inspect==0.7.1
 typing_extensions==4.0.1
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.5.5#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.5.6#egg=registry_schemas

--- a/ppr-api/requirements/bcregistry-libraries.txt
+++ b/ppr-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.5.5#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.5.6#egg=registry_schemas


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
- Fix to recent PPR vehicle collateral MH type schema change: allow both MHR number and serial number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
