### PR TITLE
Dockerfile updates for mainframe DB2 license install.

### DIFF
--- a/mhr_api/Dockerfile
+++ b/mhr_api/Dockerfile
@@ -30,6 +30,11 @@ RUN pip install .
 
 # Install the license file from the DB2 image
 COPY --from=DB2_license ./db2consv_ee.lic /usr/local/lib/python3.10/site-packages/clidriver/license/.
+# Add db2dump to prevent CLI log errors.
+RUN mkdir /usr/local/lib/python3.10/site-packages/clidriver/db2dump
+# Update file permissions for license install and logging to work.
+RUN chmod -R 777 /usr/local/lib/python3.10/site-packages/clidriver/license
+RUN chmod 777 /usr/local/lib/python3.10/site-packages/clidriver/db2dump
 
 USER 1001
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
Dockerfile updates to install DB2 client license.
- Also update to eliminate DB2 CLI driver logging errors. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
