### PR TITLE
Remove hint message for MHR Owner Name search

### DIFF
--- a/ppr-ui/src/resources/searchTypes.ts
+++ b/ppr-ui/src/resources/searchTypes.ts
@@ -138,7 +138,7 @@ export const MHRSearchTypes: Array<SearchTypeIF> = [
     searchTypeAPI: APIMHRMapSearchTypes.MHROWNER_NAME,
     textLabel: '',
     hints: {
-      searchValueFirst: 'Owner names normally contain letters and numbers only'
+      searchValueFirst: ''
     },
     group: 2
   },

--- a/ppr-ui/tests/unit/SearchBar.spec.ts
+++ b/ppr-ui/tests/unit/SearchBar.spec.ts
@@ -556,7 +556,7 @@ describe('Mhr Owner name search', () => {
     wrapper.find(searchButtonSelector).trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.validations).toBeNull()
-    expect(wrapper.find('.v-messages__message').exists()).toBe(true)
+    expect(wrapper.find('.v-messages__message').exists()).toBe(false)
     await Vue.nextTick()
     await Vue.nextTick()
 
@@ -589,7 +589,7 @@ describe('Mhr Owner name search', () => {
     wrapper.find(searchButtonSelector).trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.validations).toBeNull()
-    expect(wrapper.find('.v-messages__message').exists()).toBe(true)
+    expect(wrapper.find('.v-messages__message').exists()).toBe(false)
     await Vue.nextTick()
     await Vue.nextTick()
 
@@ -620,7 +620,7 @@ describe('Mhr Owner name search', () => {
     wrapper.find(searchButtonSelector).trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.validations).toBeNull()
-    expect(wrapper.find('.v-messages__message').exists()).toBe(true)
+    expect(wrapper.find('.v-messages__message').exists()).toBe(false)
     await Vue.nextTick()
     await Vue.nextTick()
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12553

*Description of changes:*

As per Tracy/Scott, we don't need a hint message under the Owner Name search fields. 

- Remove hint message
- Update unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
