### PR TITLE
Tune DB2 performance, fix search queries from legacy comparison.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -80,22 +80,34 @@ class Db2Manuhome(db.Model):
         manuhome = None
         if id and id > 0:
             try:
+                current_app.logger.debug('Db2Manuhome.find_by_id query.')
                 manuhome = cls.query.get(id)
             except Exception as db_exception:   # noqa: B902; return nicer error
                 current_app.logger.error('Db2Manuhome.find_by_id exception: ' + str(db_exception))
                 raise DatabaseException(db_exception)
         if manuhome:
-            manuhome.reg_documents = Db2Document.find_by_mhr_number(manuhome.mhr_number)
-            manuhome.reg_owners = Db2Owner.find_by_manuhome_id(manuhome.id)
+            current_app.logger.debug('Db2Manuhome.find_by_id Db2Document query.')
+            documents = []
+            doc = Db2Document.find_by_doc_id(manuhome.reg_document_id)
+            if doc:
+                documents.append(doc)
+            manuhome.reg_documents = documents
+            current_app.logger.debug('Db2Manuhome.find_by_id Db2Owner query.')
+            manuhome.reg_owners = Db2Owner.find_by_manuhome_id_registration(manuhome.id)
+            current_app.logger.debug('Db2Manuhome.find_by_id Db2Descript query.')
             manuhome.reg_descript = Db2Descript.find_by_manuhome_id_active(manuhome.id)
+            current_app.logger.debug('Db2Manuhome.find_by_id Db2Location query.')
             manuhome.reg_location = Db2Location.find_by_manuhome_id_active(manuhome.id)
+            current_app.logger.debug('Db2Manuhome.find_by_id Db2Mhomnote query.')
             manuhome.reg_notes = Db2Mhomnote.find_by_manuhome_id_active(manuhome.id)
+            current_app.logger.debug('Db2Manuhome.find_by_id completed.')
         return manuhome
 
     @classmethod
     def find_by_mhr_number(cls, mhr_number: str):
         """Return the MH registration matching the MHR number."""
         manuhome = None
+        current_app.logger.debug(f'Db2Manuhome.find_by_mhr_number {mhr_number}.')
         if mhr_number:
             try:
                 manuhome = cls.query.filter(Db2Manuhome.mhr_number == mhr_number).one_or_none()
@@ -109,11 +121,17 @@ class Db2Manuhome(db.Model):
                                                                         mhr_number=mhr_number),
                 status_code=HTTPStatus.NOT_FOUND
             )
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number Db2Document query.')
         manuhome.reg_documents = Db2Document.find_by_mhr_number(manuhome.mhr_number)
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number Db2Owner query.')
         manuhome.reg_owners = Db2Owner.find_by_manuhome_id(manuhome.id)
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number Db2Descript query.')
         manuhome.reg_descript = Db2Descript.find_by_manuhome_id_active(manuhome.id)
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number Db2Location query.')
         manuhome.reg_location = Db2Location.find_by_manuhome_id_active(manuhome.id)
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number Db2Mhomnote query.')
         manuhome.reg_notes = Db2Mhomnote.find_by_manuhome_id_active(manuhome.id)
+        current_app.logger.debug('Db2Manuhome.find_by_mhr_number completed.')
         return manuhome
 
     @property

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -106,8 +106,9 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         try:
             db.session.add(self)
             db.session.commit()
+            current_app.logger.debug('DB search_request.save completed')
         except Exception as db_exception:
-            current_app.logger.error('DB search_client save exception: ' + repr(db_exception))
+            current_app.logger.error('DB search_request save exception: ' + str(db_exception))
             raise DatabaseException(db_exception)
 
     def update_search_selection(self, search_json):
@@ -128,7 +129,9 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                 status = 'EXEMPT'
             else:
                 status = 'HISTORIC'
+        # current_app.logger.info('Mapping timestamp')
         timestamp = row[3]
+        # current_app.logger.info('Timestamp mapped')
         value: str = str(row[8])
         year = int(value) if value.isnumeric() else 0
         result_json = {
@@ -141,8 +144,10 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                 'year': year,
                 'make': str(row[9]).strip(),
                 'model': ''
-            }
+            },
+            'mhId': int(row[10])
         }
+        # current_app.logger.info(result_json)
         owner_type = str(row[4])
         owner_name = str(row[5]).strip()
         if owner_type != 'I':

--- a/mhr_api/src/mhr_api/resources/v1/search_results.py
+++ b/mhr_api/src/mhr_api/resources/v1/search_results.py
@@ -151,8 +151,10 @@ def post_search_results(search_id: str):  # pylint: disable=too-many-branches, t
         try:
             # Save the search query selection and details that match the selection.
             account_name = resource_utils.get_account_name(jwt.get_token_auth_header(), account_id)
+            current_app.logger.debug('SearchResult.update_selection start')
             search_detail.update_selection(request_json, account_name, callback_url)
             query.save()
+            current_app.logger.debug('SearchResult.update_selection end')
         except Exception as db_exception:   # noqa: B902; handle all db related errors.
             current_app.logger.error(SAVE_ERROR_MESSAGE.format(account_id, str(db_exception)))
             if invoice_id is not None:

--- a/mhr_api/src/mhr_api/resources/v1/searches.py
+++ b/mhr_api/src/mhr_api/resources/v1/searches.py
@@ -58,7 +58,9 @@ def post_searches():
         query: SearchRequest = SearchRequest.create_from_json(request_json, account_id,
                                                               g.jwt_oidc_token_info.get('username', None))
         # Execute the search query: treat no results as a success.
+        current_app.logger.debug('query.search() start')
         query.search()
+        current_app.logger.debug('query.search() end')
 
         # Now save the initial detail results in the search_result table with no
         # search selection criteria (the absence indicates an incomplete search).

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.0'  # pylint: disable=invalid-name
+__version__ = '1.0.1'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_search_result.py
+++ b/mhr_api/tests/unit/models/test_search_result.py
@@ -213,12 +213,14 @@ def test_search_sort(session, client, jwt, mhr1, mhr2, mhr3, mhr4):
 
     # test
     search_result: SearchResult = SearchResult()
+    search_request: SearchRequest = SearchRequest(search_response=select_data)
+    search_result.search = search_request
     search_result.set_search_selection(select_data)
     sorted_data = search_result.search_select
 
     # check
     assert len(sorted_data) == 4
-    assert select_data[0]['mhrNumber'] == '000199'
-    assert select_data[1]['mhrNumber'] == '001999'
-    assert select_data[2]['mhrNumber'] == '002200'
-    assert select_data[3]['mhrNumber'] == '022911'
+    assert sorted_data[0]['mhrNumber'] == '000199'
+    assert sorted_data[1]['mhrNumber'] == '001999'
+    assert sorted_data[2]['mhrNumber'] == '002200'
+    assert sorted_data[3]['mhrNumber'] == '022911'

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -61,13 +61,15 @@ TEST_DB2_ADDRESS = [
 ]
 # testdata pattern is ({serial_num}, {hex_value})
 TEST_DATA_SERIAL_KEY = [
-    ('WIN14569401627', '0620db'),
-    ('A4492', '00118c'),
-    ('3E3947', '04a34b'),
-    ('6436252B10FK', '03db8a'),
-    ('I1724B', '002dcc'),
-    ('2427', '00097b'),
-    ('123', '00007b')
+    ('WIN14569401627', '0620DB'),
+    ('A4492', '00118C'),
+    ('3E3947', '04A34B'),
+    ('6436252B10FK', '03DB8A'),
+    ('I1724B', '002DCC'),
+    ('2427', '00097B'),
+    ('123', '00007B'),
+    ('12345', '003039'),
+    ('999999', '0F423F')
 ]
 
 
@@ -88,10 +90,10 @@ def test_search_key_owner(name, key_value):
 @pytest.mark.parametrize('serial_num, hex_value', TEST_DATA_SERIAL_KEY)
 def test_search_key_serial(session, serial_num, hex_value):
     """Assert that computing a serial number search key works as expected."""
-    value = model_utils.get_serial_number_key(serial_num)
+    value = model_utils.get_serial_number_key_hex(serial_num)
     # current_app.logger.info(f'Key={value}')
-    assert len(value) == 3
-    assert value.hex() == hex_value
+    assert len(value) == 6
+    assert value == hex_value
 
 
 @pytest.mark.parametrize('street1, street2, city, region, address', TEST_DB2_ADDRESS)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12773

*Description of changes:*
- Add log messages to help analyze performance.
- Update DB2 owner/owner group query to improve performance.
- Move loading of registration details to search step 2
- Include historical names in search by org name, search by owner name
- Correct serial number compressed key matching.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
