### PR TITLE
Staff payment UI fix, don't show the error until user starts typing

### DIFF
--- a/ppr-ui/src/components/dialogs/StaffPaymentDialog.vue
+++ b/ppr-ui/src/components/dialogs/StaffPaymentDialog.vue
@@ -7,7 +7,7 @@
     <template v-slot:content>
       <staff-payment-component
         :staffPaymentData="staffPaymentData"
-        :validate="true"
+        :validate="validating"
         :displaySideLabel="false"
         :displayPriorityCheckbox="false"
         @update:staffPaymentData="onStaffPaymentDataUpdate($event)"
@@ -81,6 +81,7 @@ export default defineComponent({
     const localState = reactive({
       certify: false,
       valid: false,
+      validating: false,
       paymentOption: StaffPaymentOptions.NONE,
       display: computed(() => {
         return props.setDisplay
@@ -137,6 +138,15 @@ export default defineComponent({
     const onStaffPaymentDataUpdate = (val: StaffPaymentIF) => {
       let staffPaymentData: StaffPaymentIF = {
         ...val
+      }
+
+      if (staffPaymentData.routingSlipNumber || staffPaymentData.bcolAccountNumber || staffPaymentData.datNumber) {
+        localState.validating = true
+      } else {
+        if (localState.paymentOption !== staffPaymentData.option) {
+          localState.validating = false
+          localState.paymentOption = staffPaymentData.option
+        }
       }
 
       // disable validation

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -165,7 +165,7 @@ export default class ConfirmMHRSearch extends Vue {
   private validFolio = true
   private staffPaymentValid = false
   private validating = false
-  private curOption = StaffPaymentOptions.NONE
+  private paymentOption = StaffPaymentOptions.NONE
 
   private get isAuthenticated (): boolean {
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
@@ -286,9 +286,9 @@ export default class ConfirmMHRSearch extends Vue {
     if (staffPaymentData.routingSlipNumber || staffPaymentData.bcolAccountNumber || staffPaymentData.datNumber) {
       this.validating = true
     } else {
-      if (staffPaymentData.option !== this.curOption) {
+      if (staffPaymentData.option !== this.paymentOption) {
         this.validating = false
-        this.curOption = staffPaymentData.option
+        this.paymentOption = staffPaymentData.option
       }
     }
 

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -56,7 +56,7 @@
               <staff-payment-component
                 id="staff-payment-dialog"
                 :staffPaymentData="staffPaymentData"
-                :validate="true"
+                :validate="validating||showErrors"
                 :displaySideLabel="true"
                 :displayPriorityCheckbox="true"
                 :invalidSection="showErrorAlert"
@@ -164,6 +164,8 @@ export default class ConfirmMHRSearch extends Vue {
   private submitting = false
   private validFolio = true
   private staffPaymentValid = false
+  private validating = false
+  private curOption = StaffPaymentOptions.NONE
 
   private get isAuthenticated (): boolean {
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
@@ -236,6 +238,8 @@ export default class ConfirmMHRSearch extends Vue {
   }
 
   private async submit (): Promise<void> {
+    this.validating = true
+    await Vue.nextTick()
     if (!this.validFolio || (this.getIsStaffClientPayment && !this.staffPaymentValid)) {
       this.showErrors = true
       document.getElementById('staff-payment-dialog').scrollIntoView({ behavior: 'smooth' })
@@ -274,9 +278,18 @@ export default class ConfirmMHRSearch extends Vue {
   }
 
   /** Called when component's staff payment data has been updated. */
-  private onStaffPaymentDataUpdate = (val: StaffPaymentIF) => {
+  private onStaffPaymentDataUpdate (val: StaffPaymentIF) {
     let staffPaymentData: StaffPaymentIF = {
       ...val
+    }
+
+    if (staffPaymentData.routingSlipNumber || staffPaymentData.bcolAccountNumber || staffPaymentData.datNumber) {
+      this.validating = true
+    } else {
+      if (staffPaymentData.option !== this.curOption) {
+        this.validating = false
+        this.curOption = staffPaymentData.option
+      }
     }
 
     // disable validation


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11757

*Description of changes:*
UI fix, don't show the error until user starts typing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
