### PR TITLE
Add ownerStatus to MHR api search summary response.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -179,7 +179,7 @@ class Db2Owner(db.Model):
         if self.owngroup:
             owner['type'] = self.owngroup.tenancy_type
             if self.owngroup.status == '3':
-                owner['status'] = 'ACTVIE'
+                owner['status'] = 'ACTIVE'
             elif self.owngroup.status == '4':
                 owner['status'] = 'EXEMPT'
             else:

--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -178,6 +178,13 @@ class Db2Owner(db.Model):
         owner['address'] = model_utils.get_address_from_db2(self.legacy_address, self.postal_code)
         if self.owngroup:
             owner['type'] = self.owngroup.tenancy_type
+            if self.owngroup.status == '3':
+                owner['status'] = 'ACTVIE'
+            elif self.owngroup.status == '4':
+                owner['status'] = 'EXEMPT'
+            else:
+                owner['status'] = 'PREVIOUS'
+
         return owner
 
     @staticmethod

--- a/mhr_api/src/mhr_api/models/db2/search_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/search_utils.py
@@ -40,7 +40,7 @@ RESULTS_SIZE_LIMIT_CLAUSE = 'FETCH FIRST :max_results_size ROWS ONLY'
 
 MHR_NUM_QUERY = """
 SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1, de.yearmade,
-       de.makemodl, mh.manhomid
+       de.makemodl, mh.manhomid, '3'
   FROM manuhome mh, document d, owner o, location l, descript de
  WHERE mh.mhregnum = :query_value
    AND mh.mhregnum = d.mhregnum
@@ -63,7 +63,7 @@ SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname
 #        WHERE o2.manhomid = mh.manhomid) as owner_names, 
 SERIAL_NUM_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
-       (SELECT o.ownrtype || o.ownrname
+       (SELECT o.ownrtype || og.status || o.ownrname
           FROM owner o, owngroup og
          WHERE mh.manhomid = o.manhomid
            AND mh.manhomid = og.manhomid
@@ -86,7 +86,7 @@ ORDER BY d.regidate ASC
 
 OWNER_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
-       de.yearmade, de.makemodl, mh.manhomid
+       de.yearmade, de.makemodl, mh.manhomid, og.status
   FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
@@ -105,7 +105,7 @@ ORDER BY o.ownrname ASC, d.regidate ASC
 
 ORG_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
-       de.yearmade, de.makemodl, mh.manhomid
+       de.yearmade, de.makemodl, mh.manhomid, og.status
   FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -35,6 +35,12 @@ from .db import db
 REPORT_STATUS_PENDING = 'PENDING'
 CHARACTER_SET_UNSUPPORTED = 'The search name {} charcter set is not supported.\n'
 
+LEGACY_TO_OWNER_STATUS = {
+    '3': 'ACTIVE',
+    '4': 'EXEMPT',
+    '5': 'PREVIOUS'
+}
+
 
 class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
     """This class maintains search query (search step 1) information."""
@@ -154,6 +160,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
             result_json['organizationName'] = owner_name
         else:
             result_json['ownerName'] = model_utils.get_ind_name_from_db2(owner_name)
+        result_json['ownerStatus'] = LEGACY_TO_OWNER_STATUS[str(row[11])]
         return result_json
 
     @classmethod
@@ -188,11 +195,13 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         # current_app.logger.info(result_json)
         owner_info = str(row[4])
         owner_type = owner_info[0:1]
-        owner_name = owner_info[1:].strip()
+        owner_status = owner_info[1:2]
+        owner_name = owner_info[2:].strip()
         if owner_type != 'I':
             result_json['organizationName'] = owner_name
         else:
             result_json['ownerName'] = model_utils.get_ind_name_from_db2(owner_name)
+        result_json['ownerStatus'] = LEGACY_TO_OWNER_STATUS[owner_status]
         serial_index = int(row[10])
         if serial_index == 2:
             result_json['serialNumber'] = str(row[11]).strip()

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -67,6 +67,7 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, owner_id, type):
                 assert reg_json['address']['region']
                 assert reg_json['address']['country']
                 assert reg_json.get('type')
+                assert reg_json.get('status')
     else:
         assert not owners
 

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -67,7 +67,7 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, owner_id, type):
                 assert reg_json['address']['region']
                 assert reg_json['address']['country']
                 assert reg_json.get('type')
-                assert reg_json.get('status')
+                assert reg_json.get('status') in ('ACTIVE', 'EXEMPT', 'PREVIOUS')
     else:
         assert not owners
 

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -220,6 +220,7 @@ def test_search_valid(session, search_type, json_data):
         if match.get('ownerName'):
             assert match['ownerName']['first']
             assert match['ownerName']['last']
+        assert match['ownerStatus'] in ('ACTIVE', 'EXEMPT', 'PREVIOUS')
 
 
 @pytest.mark.parametrize('search_type,json_data', TEST_NONE_DATA)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12830

*Description of changes:*
- Add ownerStatus to MHR api search summary response.
- Add status to owner information in search registration data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
