### PR TITLE
11472 tobacco speculation vacancy tax

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/collateral/generalCollateral/factories/useGeneralCollateral.ts
+++ b/ppr-ui/src/components/collateral/generalCollateral/factories/useGeneralCollateral.ts
@@ -36,7 +36,9 @@ export const useGeneralCollateral = () => {
       APIRegistrationTypes.TRANSITION_FINANCING_STATEMENT,
       APIRegistrationTypes.TRANSITION_SALE_OF_GOODS,
       APIRegistrationTypes.TRANSITION_TAX_LIEN,
-      APIRegistrationTypes.TRANSITION_MH
+      APIRegistrationTypes.TRANSITION_MH,
+      APIRegistrationTypes.TOBACCO_TAX,
+      APIRegistrationTypes.SPECULATION_VACANCY_TAX
     ]
     return ghArray.includes(registrationType)
   }
@@ -49,7 +51,9 @@ export const useGeneralCollateral = () => {
       APIRegistrationTypes.PROVINCIAL_SALES_TAX,
       APIRegistrationTypes.INCOME_TAX,
       APIRegistrationTypes.MOTOR_FUEL_TAX,
-      APIRegistrationTypes.EXCISE_TAX
+      APIRegistrationTypes.EXCISE_TAX,
+      APIRegistrationTypes.TOBACCO_TAX,
+      APIRegistrationTypes.SPECULATION_VACANCY_TAX
     ]
     return gcList.includes(registrationType)
   }

--- a/ppr-ui/src/components/collateral/vehicleCollateral/factories/useVehicle.ts
+++ b/ppr-ui/src/components/collateral/vehicleCollateral/factories/useVehicle.ts
@@ -153,7 +153,9 @@ export const useVehicle = (props, context) => {
       APIRegistrationTypes.OTHER,
       APIRegistrationTypes.PROVINCIAL_SALES_TAX,
       APIRegistrationTypes.PETROLEUM_NATURAL_GAS_TAX,
-      APIRegistrationTypes.RURAL_PROPERTY_TAX
+      APIRegistrationTypes.RURAL_PROPERTY_TAX,
+      APIRegistrationTypes.TOBACCO_TAX,
+      APIRegistrationTypes.SPECULATION_VACANCY_TAX
     ]
     return vhArray.includes(registrationType)
   }

--- a/ppr-ui/src/components/registration/length-trust/RegistrationLengthTrust.vue
+++ b/ppr-ui/src/components/registration/length-trust/RegistrationLengthTrust.vue
@@ -233,7 +233,9 @@ export default defineComponent({
         APIRegistrationTypes.OTHER,
         APIRegistrationTypes.MINERAL_LAND_TAX,
         APIRegistrationTypes.PROPERTY_TRANSFER_TAX,
-        APIRegistrationTypes.SCHOOL_ACT
+        APIRegistrationTypes.SCHOOL_ACT,
+        APIRegistrationTypes.TOBACCO_TAX,
+        APIRegistrationTypes.SPECULATION_VACANCY_TAX
       ]
       return ipArray.includes(registrationType)
     }

--- a/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
+++ b/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
@@ -29,7 +29,9 @@ export const hasNoCharge = (val: UIRegistrationTypes): boolean => {
     UIRegistrationTypes.OTHER,
     UIRegistrationTypes.MINERAL_LAND_TAX,
     UIRegistrationTypes.PROPERTY_TRANSFER_TAX,
-    UIRegistrationTypes.SCHOOL_ACT
+    UIRegistrationTypes.SCHOOL_ACT,
+    UIRegistrationTypes.TOBACCO_TAX,
+    UIRegistrationTypes.SPECULATION_VACANCY_TAX
   ]
   // it will not be in the UIRegistrationTypes enum list if 'Other' was selected
   return hfArray.includes(val) || !Object.values(UIRegistrationTypes).includes(val)
@@ -63,7 +65,9 @@ export const hasNoChargeAmendment = (val: UIRegistrationTypes): boolean => {
     UIRegistrationTypes.CROWN_CONSUMPTION_TRANSITION_TAX,
     UIRegistrationTypes.CROWN_HOTEL_ROOM_TAX,
     UIRegistrationTypes.CROWN_SOCIAL_SERVICE_TAX,
-    UIRegistrationTypes.TRANSITION_TAX_LIEN
+    UIRegistrationTypes.TRANSITION_TAX_LIEN,
+    UIRegistrationTypes.TOBACCO_TAX,
+    UIRegistrationTypes.SPECULATION_VACANCY_TAX
   ]
   // it will not be in the UIRegistrationTypes enum list if 'Other' was selected
   return hfArray.includes(val) || !Object.values(UIRegistrationTypes).includes(val)

--- a/ppr-ui/src/enums/registrationTypes.ts
+++ b/ppr-ui/src/enums/registrationTypes.ts
@@ -23,6 +23,8 @@ export enum APIRegistrationTypes {
     PROVINCIAL_SALES_TAX = 'PS',
     RURAL_PROPERTY_TAX = 'RA',
     SCHOOL_ACT = 'SC',
+    SPECULATION_VACANCY_TAX = 'SV',
+    TOBACCO_TAX = 'TO',
     OTHER = 'OT',
     // miscelaneous registration other
     LIEN_UNPAID_WAGES = 'WL',
@@ -71,6 +73,8 @@ export enum UIRegistrationTypes {
     PROVINCIAL_SALES_TAX = 'Crown Charge - Provincial Sales Tax Act',
     RURAL_PROPERTY_TAX = 'Crown Charge - Taxation (Rural Area) Act',
     SCHOOL_ACT = 'Crown Charge - School Act',
+    SPECULATION_VACANCY_TAX = 'Crown Charge - Speculation and Vacancy Tax Act',
+    TOBACCO_TAX = 'Crown Charge - Tobacco Tax Act',
     OTHER = 'Crown Charge - Other',
       // miscelaneous registration other
     LIEN_UNPAID_WAGES = 'Lien for Unpaid Wages',

--- a/ppr-ui/src/resources/registrationTypes.ts
+++ b/ppr-ui/src/resources/registrationTypes.ts
@@ -133,6 +133,24 @@ export const RegistrationTypesMiscellaneousCC: Array<RegistrationTypeIF> = [
     disabled: false,
     divider: false,
     group: 1,
+    registrationTypeUI: UIRegistrationTypes.SPECULATION_VACANCY_TAX,
+    registrationTypeAPI: APIRegistrationTypes.SPECULATION_VACANCY_TAX,
+    text: `${UIRegistrationTypes.SPECULATION_VACANCY_TAX}`
+  },
+  {
+    class: 'registration-list-item',
+    disabled: false,
+    divider: false,
+    group: 1,
+    registrationTypeUI: UIRegistrationTypes.TOBACCO_TAX,
+    registrationTypeAPI: APIRegistrationTypes.TOBACCO_TAX,
+    text: `${UIRegistrationTypes.TOBACCO_TAX}`
+  },
+  {
+    class: 'registration-list-item',
+    disabled: false,
+    divider: false,
+    group: 1,
     registrationTypeUI: UIRegistrationTypes.OTHER,
     registrationTypeAPI: APIRegistrationTypes.OTHER,
     text: `${UIRegistrationTypes.OTHER}`

--- a/ppr-ui/src/utils/validation-helper.ts
+++ b/ppr-ui/src/utils/validation-helper.ts
@@ -306,7 +306,9 @@ export function isSecuredPartyRestrictedList (regType: string): boolean {
     APIRegistrationTypes.CROWN_CONSUMPTION_TRANSITION_TAX,
     APIRegistrationTypes.CROWN_HOTEL_ROOM_TAX,
     APIRegistrationTypes.CROWN_SOCIAL_SERVICE_TAX,
-    APIRegistrationTypes.TRANSITION_TAX_LIEN
+    APIRegistrationTypes.TRANSITION_TAX_LIEN,
+    APIRegistrationTypes.TOBACCO_TAX,
+    APIRegistrationTypes.SPECULATION_VACANCY_TAX
   ]
   // @ts-ignore - it doesn't like the string comparison for some reason
   if (restrictedList.includes(regType)) {

--- a/ppr-ui/src/views/newRegistration/LengthTrust.vue
+++ b/ppr-ui/src/views/newRegistration/LengthTrust.vue
@@ -183,6 +183,8 @@ export default class LengthTrust extends Vue {
       case APIRegistrationTypes.SCHOOL_ACT:
       case APIRegistrationTypes.PROPERTY_TRANSFER_TAX:
       case APIRegistrationTypes.MINERAL_LAND_TAX:
+      case APIRegistrationTypes.TOBACCO_TAX:
+      case APIRegistrationTypes.SPECULATION_VACANCY_TAX:
         return (
           'The registration length for this registration is automatically set to infinite. ' +
           'There is no fee for this registration.'

--- a/ppr-ui/tests/unit/FeeSummary.spec.ts
+++ b/ppr-ui/tests/unit/FeeSummary.spec.ts
@@ -44,6 +44,8 @@ const newRegMisc = [
   UIRegistrationTypes.PROVINCIAL_SALES_TAX,
   UIRegistrationTypes.RURAL_PROPERTY_TAX,
   UIRegistrationTypes.SCHOOL_ACT,
+  UIRegistrationTypes.SPECULATION_VACANCY_TAX,
+  UIRegistrationTypes.TOBACCO_TAX,
   UIRegistrationTypes.OTHER,
   // miscelaneous registration other
   UIRegistrationTypes.LIEN_UNPAID_WAGES,

--- a/ppr-ui/tests/unit/LengthTrust.spec.ts
+++ b/ppr-ui/tests/unit/LengthTrust.spec.ts
@@ -193,7 +193,9 @@ describe('Length and Trust Indenture new registration component', () => {
         APIRegistrationTypes.OTHER,
         APIRegistrationTypes.SCHOOL_ACT,
         APIRegistrationTypes.PROPERTY_TRANSFER_TAX,
-        APIRegistrationTypes.MINERAL_LAND_TAX
+        APIRegistrationTypes.MINERAL_LAND_TAX,
+        APIRegistrationTypes.TOBACCO_TAX,
+        APIRegistrationTypes.SPECULATION_VACANCY_TAX
       ]
       if (RegistrationTypes[i].registrationTypeAPI === APIRegistrationTypes.REPAIRERS_LIEN) {
         expect(wrapper.find(titleInfo).text()).toContain('Enter the amount of the Lien and the date the vehicle')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11472

*Description of changes:*
Add Tobacco Tax Act and Speculation Vacancy Tax Act to Registration, applying rules that were applied to Carbon Tax Act.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
