### PR TITLE
Add endpoint to get manufacturer info.

### DIFF
--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -15,6 +15,7 @@
 """This exports all of the models and schemas used by the application."""
 # flake8: noqa I001
 from .db import db
+from .account_bcol_id import AccountBcolId
 from .address import Address
 from .client_code import ClientCode
 from .court_order import CourtOrder
@@ -23,6 +24,7 @@ from .db2.descript import Db2Descript
 from .db2.docdes import Db2Docdes
 from .db2.document import Db2Document
 from .db2.location import Db2Location
+from .db2.manufact import Db2Manufact
 from .db2.manuhome import Db2Manuhome
 from .db2.mhomnote import Db2Mhomnote
 from .db2.owner import Db2Owner
@@ -49,9 +51,9 @@ from .type_tables import (
 from .vehicle_collateral import VehicleCollateral
 
 __all__ = ('db',
-           'Address', 'ClientCode', 'CountryType', 'CourtOrder',
-           'Db2Cmpserno', 'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manuhome', 'Db2Mhomnote',
-           'Db2Owner', 'Db2Owngroup',
+           'AccountBcolId', 'Address', 'ClientCode', 'CountryType', 'CourtOrder',
+           'Db2Cmpserno', 'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manufact', 'Db2Manuhome',
+           'Db2Mhomnote', 'Db2Owner', 'Db2Owngroup',
            'EventTracking', 'EventTrackingType', 'FinancingStatement', 'GeneralCollateral', 'Party',
            'PartyType', 'ProvinceType', 'Registration', 'RegistrationType',
            'RegistrationTypeClass', 'SearchRequest', 'SearchResult', 'SearchType', 'StateType', 'SerialType',

--- a/mhr_api/src/mhr_api/models/account_bcol_id.py
+++ b/mhr_api/src/mhr_api/models/account_bcol_id.py
@@ -1,0 +1,85 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This table manages a the mapping of BCRS account ID's to BCOL numbers.
+
+Link an account id to a legacy BCOL number to associate the account with a client party code.
+All crown charge accounts must have at least one record.
+"""
+
+from .db import db
+
+
+class AccountBcolId(db.Model):
+    """Map a user account ID to one or more BCOL account numbers."""
+
+    __versioned__ = {}
+    __tablename__ = 'account_bcol_ids'
+    CROWN_CHARGE_YES = 'Y'
+
+    id = db.Column('id', db.Integer, db.Sequence('account_bcol_id_seq'), primary_key=True)
+    account_id = db.Column('account_id', db.String(20), nullable=False, index=True)
+    bconline_account = db.Column('bconline_account', db.Integer, nullable=False)
+    # Only set when account is a crown charge account.
+    crown_charge_ind = db.Column('crown_charge_ind', db.String(1), nullable=True)
+
+    def save(self):
+        """Store the User into the local cache."""
+        db.session.add(self)
+        db.session.commit()
+
+    @classmethod
+    def find_by_id(cls, account_bcol_id: int):
+        """Return the mapping record matching the id."""
+        return db.session.query(AccountBcolId).\
+            filter(AccountBcolId.id == account_bcol_id).one_or_none()
+
+    @classmethod
+    def find_by_account_id(cls, account_id: str):
+        """Return the account bcol numbers matching the account id."""
+        if account_id:
+            return db.session.query(AccountBcolId).\
+                                    filter(AccountBcolId.account_id == account_id).all()
+        return None
+
+    @classmethod
+    def find_by_account_id_bcol_number(cls, account_id: str, bconline_account: int):
+        """Return the account bcol numbers matching the account id and bcol number."""
+        if account_id:
+            return db.session.query(AccountBcolId).\
+                                    filter(AccountBcolId.account_id == account_id,
+                                           AccountBcolId.bconline_account == bconline_account).one_or_none()
+        return None
+
+    @classmethod
+    def delete(cls, account_id: str, bconline_account: int):
+        """Future maintenance: delete an account bcol number mapping record by account ID and bcol number."""
+        account_mapping = None
+        if bconline_account and account_id:
+            account_mapping = cls.find_by_account_id_bcol_number(account_id, bconline_account)
+
+        if account_mapping:
+            db.session.delete(account_mapping)
+            db.session.commit()
+
+        return account_mapping
+
+    @staticmethod
+    def crown_charge_account(account_id: str) -> bool:
+        """Check if an account is configured for crown charge request types."""
+        account_mappings = db.session.query(AccountBcolId).\
+            filter(AccountBcolId.account_id == account_id,
+                   AccountBcolId.crown_charge_ind == AccountBcolId.CROWN_CHARGE_YES).all()
+        if account_mappings:
+            return True
+        return False

--- a/mhr_api/src/mhr_api/models/account_bcol_id.py
+++ b/mhr_api/src/mhr_api/models/account_bcol_id.py
@@ -23,7 +23,6 @@ from .db import db
 class AccountBcolId(db.Model):
     """Map a user account ID to one or more BCOL account numbers."""
 
-    __versioned__ = {}
     __tablename__ = 'account_bcol_ids'
     CROWN_CHARGE_YES = 'Y'
 

--- a/mhr_api/src/mhr_api/models/db2/manufact.py
+++ b/mhr_api/src/mhr_api/models/db2/manufact.py
@@ -1,0 +1,156 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for legacy DB2 MHR manufacturer information."""
+from flask import current_app
+
+from mhr_api.exceptions import DatabaseException
+from mhr_api.models import db, utils as model_utils
+
+
+class Db2Manufact(db.Model):
+    """This class manages all of the legacy DB2 MHR location information."""
+
+    __bind_key__ = 'db2'
+    __tablename__ = 'manufact'
+
+    id = db.Column('MANUFAID', db.Integer, primary_key=True)
+    bcol_account_number = db.Column('BCOLACCT', db.String(6), nullable=False)
+    dealer_name = db.Column('MHDEALER', db.String(60), nullable=False)
+    submitting_party_name = db.Column('SUBPNAME', db.String(40), nullable=False)
+    submitting_party_phone = db.Column('SUBPFONE', db.String(10), nullable=False)
+    submitting_party_address = db.Column('SUBPADDR', db.String(160), nullable=False)
+    owner_name = db.Column('OWNRNAME', db.String(70), nullable=False)
+    owner_phone_number = db.Column('OWNRFONE', db.String(10), nullable=False)
+    owner_address = db.Column('OWNRADDR', db.String(160), nullable=False)
+    owner_postal_code = db.Column('OWNRPOCO', db.String(10), nullable=False)
+    street_number = db.Column('STNUMBER', db.String(6), nullable=False)
+    street_name = db.Column('STNAME', db.String(25), nullable=False)
+    town_city = db.Column('TOWNCITY', db.String(20), nullable=False)
+    province = db.Column('PROVINCE', db.String(2), nullable=False)
+    manufacturer_name = db.Column('MANUNAME', db.String(65), nullable=False)
+
+    # parent keys
+
+    # Relationships
+
+    def save(self):
+        """Save the object to the database immediately. Only used for unit testing."""
+        try:
+            db.session.add(self)
+            db.session.commit()
+        except Exception as db_exception:   # noqa: B902; return nicer error
+            current_app.logger.error('DB2 manufact.save exception: ' + str(db_exception))
+            raise DatabaseException(db_exception)
+
+    def strip(self):
+        """Strip all string properties."""
+        self.bcol_account_number = self.bcol_account_number.strip()
+        self.dealer_name = self.dealer_name.strip()
+        self.submitting_party_name = self.submitting_party_name.strip()
+        self.submitting_party_phone = self.submitting_party_phone.strip()
+        self.submitting_party_address = self.submitting_party_address.strip()
+        self.owner_name = self.owner_name.strip()
+        self.owner_phone_number = self.owner_phone_number.strip()
+        self.owner_address = self.owner_address.strip()
+        self.owner_postal_code = self.owner_postal_code.strip()
+        self.street_number = self.street_number.strip()
+        self.street_name = self.street_name.strip()
+        self.town_city = self.town_city.strip()
+        self.manufacturer_name = self.manufacturer_name.strip()
+
+    @classmethod
+    def find_by_id(cls, id: int):
+        """Return the manufacturer matching the manufacturer id."""
+        manfacturer = None
+        if id and id > 0:
+            try:
+                manfacturer = cls.query.get(id)
+            except Exception as db_exception:   # noqa: B902; return nicer error
+                current_app.logger.error('DB2 manufact.find_by_id exception: ' + str(db_exception))
+                raise DatabaseException(db_exception)
+        if manfacturer:
+            manfacturer.strip()
+        return manfacturer
+
+    @classmethod
+    def find_by_bcol_account(cls, bcol_account_num: str):
+        """Return the manufacturers matching the BCOL account number."""
+        manufacturers = None
+        if bcol_account_num:
+            try:
+                manufacturers = cls.query.filter(Db2Manufact.bcol_account_number == bcol_account_num).all()
+            except Exception as db_exception:   # noqa: B902; return nicer error
+                current_app.logger.error('DB2 manufact.find_by_bcol_account exception: ' + str(db_exception))
+                raise DatabaseException(db_exception)
+        if manufacturers:
+            for manufacturer in manufacturers:
+                manufacturer.strip()
+        return manufacturers
+
+    @property
+    def json(self):
+        """Return a dict of this object, with keys in JSON format."""
+        manufacturer = {
+            'bcolAccountNumber': self.bcol_account_number,
+            'dealerName': self.dealer_name,
+            'submittingParty': {
+                'businessName': self.submitting_party_name,
+                'phoneNumber': self.submitting_party_phone,
+                'address': model_utils.get_address_from_db2_manufact(self.submitting_party_address)
+            },
+            'owner': {
+                'businessName': self.owner_name,
+                'phoneNumber': self.owner_phone_number,
+                'address': {
+                    'street': self.street_number + ' ' + self.street_name,
+                    'city': self.town_city,
+                    'region': self.province,
+                    'country': model_utils.get_country_from_province(self.province),
+                    'postalCode': self.owner_postal_code
+                }
+            },
+            'manufacturerName': self.manufacturer_name
+        }
+        if not self.owner_postal_code:
+            pos = len(self.owner_address) - 9
+            p_code = self.owner_address[pos:].strip()
+            if p_code[1:2] == ' ':
+                p_code = p_code[2:]
+            manufacturer['owner']['address']['postalCode'] = p_code
+        return manufacturer
+
+    @staticmethod
+    def create_from_dict(new_info: dict):
+        """Create a manufacturer object from dict/json."""
+        manufacturer = Db2Manufact(bcol_account_number=new_info.get('bcolAccountNumber', ''),
+                                   dealer_name=new_info.get('dealerName', ''),
+                                   submitting_party_name=new_info.get('submittingPartyName', ''),
+                                   submitting_party_phone=new_info.get('submittingPartyPhone', ''),
+                                   submitting_party_address=new_info.get('submittingPartyAddress', ''),
+                                   owner_name=new_info.get('ownerName', ''),
+                                   owner_phone_number=new_info.get('ownerPhoneNumber', ''),
+                                   owner_address=new_info.get('ownerAddress', ''),
+                                   owner_postal_code=new_info.get('ownerPostalCode', ''),
+                                   street_number=new_info.get('streetNumber', ''),
+                                   street_name=new_info.get('streetName', ''),
+                                   town_city=new_info.get('townCity', ''),
+                                   province=new_info.get('province', ''),
+                                   manufacturer_name=new_info.get('manufacturerName', ''))
+        return manufacturer
+
+    @staticmethod
+    def create_from_json(json_data):
+        """Create a manufacturer object from a json manufacturer schema object: map json to db."""
+        manufacturer = Db2Manufact.create_from_dict(json_data)
+        return manufacturer

--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from flask import Flask
 
+from .manufacturer import bp as manufacturers_bp
 from .meta import bp as meta_bp
 from .ops import bp as ops_bp
 from .registration_report_callback import bp as registration_report_callback_bp
@@ -40,6 +41,7 @@ class V1Endpoint:
 
         self.app = app
 
+        self.app.register_blueprint(manufacturers_bp)
         self.app.register_blueprint(meta_bp)
         self.app.register_blueprint(ops_bp)
         self.app.register_blueprint(searches_bp)

--- a/mhr_api/src/mhr_api/resources/v1/manufacturer.py
+++ b/mhr_api/src/mhr_api/resources/v1/manufacturer.py
@@ -1,0 +1,76 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for executing PPR search history requests."""
+
+# pylint: disable=too-many-return-statements
+
+from http import HTTPStatus
+
+from flask import Blueprint
+from flask import request, jsonify, current_app
+from flask_cors import cross_origin
+
+from mhr_api.utils.auth import jwt
+from mhr_api.exceptions import BusinessException, DatabaseException
+from mhr_api.services.authz import authorized
+from mhr_api.models import AccountBcolId, Db2Manufact
+from mhr_api.resources import utils as resource_utils
+
+
+bp = Blueprint('MANUFACTURER1', __name__, url_prefix='/api/v1/manufacturers')  # pylint: disable=invalid-name
+
+
+@bp.route('/parties', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_manufacturer_parties():
+    """Get account manufacturer party information."""
+    try:
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        # Try to get bcol account from account ID: from business an account should have at most 1 bcol number.
+        current_app.logger.info(f'Fetching BCOL account number for {account_id}.')
+        bcol_accounts = AccountBcolId.find_by_account_id(account_id)
+        ids = []
+        if bcol_accounts:
+            for account in bcol_accounts:
+                ids.append(str(account.bconline_account))
+        else:
+            current_app.logger.info(f'No BCOL account number found for {account_id}.')
+            return jsonify([]), HTTPStatus.OK
+
+        # Try to fetch search history by account id.
+        # No results returns an empty array.
+        bcol_account = ids[0]
+        current_app.logger.info(f'Fetching account manufacturers for {account_id}, BCOL account {bcol_account}.')
+        manufacturers = Db2Manufact.find_by_bcol_account(bcol_account)
+        if not manufacturers:
+            return jsonify([]), HTTPStatus.OK
+        results = []
+        for result in manufacturers:
+            results.append(result.json)
+        return jsonify(results), HTTPStatus.OK
+
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id, 'GET manufacturer parties')
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -3,7 +3,8 @@
 		"_postman_id": "53809702-5212-459e-a0cb-92524c3c8867",
 		"name": "MHR API Unit Tests",
 		"description": "Requests to demonstrate the Manufactured Home Registry API. The requests use a test consumer API key and account ID.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "10405485"
 	},
 	"item": [
 		{
@@ -568,6 +569,64 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "manufacturers",
+			"item": [
+				{
+					"name": "Get account manufacturer information",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"description": "Prism only local mock server header.",
+								"key": "Prefer",
+								"type": "text",
+								"value": "example=/api/v1/searches/1294376/put"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/manufacturers/parties",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"manufacturers",
+								"parties"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"auth": {
@@ -626,6 +685,11 @@
 		{
 			"key": "jwt",
 			"value": "PROVIDE",
+			"type": "string"
+		},
+		{
+			"key": "base_url_local",
+			"value": "http://localhost:5000",
 			"type": "string"
 		}
 	]

--- a/mhr_api/tests/unit/api/test_manufacturers.py
+++ b/mhr_api/tests/unit/api/test_manufacturers.py
@@ -1,0 +1,74 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the manufacturers endpoints.
+
+Test-Suite to ensure that the /manufacturers/* endpoints are working as expected.
+"""
+
+from http import HTTPStatus
+
+import pytest
+
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
+from tests.unit.services.utils import create_header_account, create_header
+
+
+# testdata pattern is ({desc}, {roles}, {account_id}, {status}, {size})
+TEST_ACCOUNT_PARTIES_DATA = [
+    ('Valid', [MHR_ROLE], '2523', HTTPStatus.OK, 1),
+    ('Valid no results', [MHR_ROLE], '1234', HTTPStatus.OK, 0),
+    ('Non-staff no account', [MHR_ROLE], None, HTTPStatus.BAD_REQUEST, 0),
+    ('Staff no account', [MHR_ROLE, STAFF_ROLE], None, HTTPStatus.BAD_REQUEST, 0),
+    ('Unauthorized', [COLIN_ROLE], '1234', HTTPStatus.UNAUTHORIZED, 0)
+]
+
+
+@pytest.mark.parametrize('desc,roles,account_id,status,size', TEST_ACCOUNT_PARTIES_DATA)
+def test_manufacturer_parties(session, client, jwt, desc, roles, account_id, status, size):
+    """Assert that the manufacturer parties endpoint behaves as expected."""
+    # setup
+    headers = create_header_account(jwt, roles, 'test-user', account_id) if account_id else create_header(jwt, roles)
+
+    # test
+    rv = client.get('/api/v1/manufacturers/parties', headers=headers)
+
+    # check
+    assert rv.status_code == status
+    if status == HTTPStatus.OK:
+        results = rv.json
+        assert len(results) == size
+        if size > 0:
+            for result in results:
+                assert result.get('bcolAccountNumber') is not None
+                assert result.get('dealerName') is not None
+                assert result['submittingParty']
+                assert result['submittingParty']['businessName']
+                assert result['submittingParty']['phoneNumber']
+                assert result['submittingParty']['address']
+                assert result['submittingParty']['address']['street']
+                assert result['submittingParty']['address']['city']
+                assert result['submittingParty']['address']['region']
+                assert result['submittingParty']['address']['country']
+                assert result['submittingParty']['address']['postalCode']
+                assert result['owner']
+                assert result['owner']['businessName']
+                assert result['owner']['phoneNumber']
+                assert result['owner']['address']
+                assert result['owner']['address']['street']
+                assert result['owner']['address']['city']
+                assert result['owner']['address']['region']
+                assert result['owner']['address']['country']
+                assert result['owner']['address']['postalCode']
+                assert result.get('manufacturerName') is not None

--- a/mhr_api/tests/unit/models/db2/test_manufact.py
+++ b/mhr_api/tests/unit/models/db2/test_manufact.py
@@ -1,0 +1,173 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the legacy DB2 Manufacturer Model.
+
+Test-Suite to ensure that the legacy DB2 Manufacturer Model is working as expected.
+"""
+
+import pytest
+
+from flask import current_app
+
+from mhr_api.models import Db2Manufact, utils as model_utils
+
+
+# testdata pattern is ({exists}, {id}, {park_name}, {pad}, {street_num}, {street}, {city}. {count})
+TEST_DATA = [
+    (True, 3, '', '', '4004', 'POPLAR AVENUE', 'FORT NELSON', 1),
+    (False, 0, None, None, None, None, None, 0)
+]
+TEST_BCOL_DATA = [
+    (True, '251256', '', '', '4004', 'POPLAR AVENUE', 'FORT NELSON', 1),
+    (False, 0, None, None, None, None, None, 0)
+]
+
+
+@pytest.mark.parametrize('exists,id,park_name,pad,street_num,street,city,count', TEST_DATA)
+def test_find_by_id(session, exists, id, park_name, pad, street_num, street, city, count):
+    """Assert that find manufacturer by id contains all expected elements."""
+    manufacturer: Db2Manufact = Db2Manufact.find_by_id(id)
+    if exists:
+        assert manufacturer
+        assert manufacturer.id == id
+        assert manufacturer.bcol_account_number
+        assert manufacturer.dealer_name
+        assert manufacturer.submitting_party_name
+        assert manufacturer.submitting_party_phone
+        assert manufacturer.submitting_party_address
+        assert manufacturer.owner_name
+        assert manufacturer.owner_phone_number
+        assert manufacturer.street_number
+        assert manufacturer.owner_address
+        assert manufacturer.street_name
+        assert manufacturer.town_city
+        assert manufacturer.province
+        assert manufacturer.manufacturer_name
+        reg_json = manufacturer.json
+        current_app.logger.debug(reg_json)
+        assert reg_json.get('bcolAccountNumber') is not None
+        assert reg_json.get('dealerName') is not None
+        assert reg_json['submittingParty']
+        assert reg_json['submittingParty']['businessName']
+        assert reg_json['submittingParty']['phoneNumber']
+        assert reg_json['submittingParty']['address']
+        assert reg_json['submittingParty']['address']['street']
+        assert reg_json['submittingParty']['address']['city']
+        assert reg_json['submittingParty']['address']['region']
+        assert reg_json['submittingParty']['address']['country']
+        assert reg_json['submittingParty']['address']['postalCode']
+        assert reg_json['owner']
+        assert reg_json['owner']['businessName']
+        assert reg_json['owner']['phoneNumber']
+        assert reg_json['owner']['address']
+        assert reg_json['owner']['address']['street']
+        assert reg_json['owner']['address']['city']
+        assert reg_json['owner']['address']['region']
+        assert reg_json['owner']['address']['country']
+        assert reg_json['owner']['address']['postalCode']
+        assert reg_json.get('manufacturerName') is not None
+    else:
+        assert not manufacturer
+
+
+@pytest.mark.parametrize('exists,bcol_num,park_name,pad,street_num,street,city,count', TEST_BCOL_DATA)
+def test_find_by_bcol_account(session, exists, bcol_num, park_name, pad, street_num, street, city, count):
+    """Assert that find manufacturer by BCOL account number contains all expected elements."""
+    manufacturers = Db2Manufact.find_by_bcol_account(bcol_num)
+    if exists:
+        assert manufacturers
+        assert len(manufacturers) == count
+        for manufacturer in manufacturers:
+            assert manufacturer.id
+            assert manufacturer.bcol_account_number == bcol_num
+            assert manufacturer.dealer_name
+            assert manufacturer.submitting_party_name
+            assert manufacturer.submitting_party_phone
+            assert manufacturer.submitting_party_address
+            assert manufacturer.owner_name
+            assert manufacturer.owner_phone_number
+            assert manufacturer.street_number
+            assert manufacturer.owner_address
+            assert manufacturer.street_name
+            assert manufacturer.town_city
+            assert manufacturer.province
+            assert manufacturer.manufacturer_name
+            reg_json = manufacturer.json
+            current_app.logger.debug(reg_json)
+            assert reg_json.get('bcolAccountNumber') is not None
+            assert reg_json.get('dealerName') is not None
+            assert reg_json['submittingParty']
+            assert reg_json['submittingParty']['businessName']
+            assert reg_json['submittingParty']['phoneNumber']
+            assert reg_json['submittingParty']['address']
+            assert reg_json['submittingParty']['address']['street']
+            assert reg_json['submittingParty']['address']['city']
+            assert reg_json['submittingParty']['address']['region']
+            assert reg_json['submittingParty']['address']['country']
+            assert reg_json['submittingParty']['address']['postalCode']
+            assert reg_json['owner']
+            assert reg_json['owner']['businessName']
+            assert reg_json['owner']['phoneNumber']
+            assert reg_json['owner']['address']
+            assert reg_json['owner']['address']['street']
+            assert reg_json['owner']['address']['city']
+            assert reg_json['owner']['address']['region']
+            assert reg_json['owner']['address']['country']
+            assert reg_json['owner']['address']['postalCode']
+            assert reg_json.get('manufacturerName') is not None
+
+    else:
+        assert not manufacturers
+
+
+def test_manufact_json(session):
+    """Assert that the manufacturer renders to a json format correctly."""
+    manufacturer = Db2Manufact(bcol_account_number='123456',
+                               dealer_name='dealerName',
+                               submitting_party_name='submittingPartyName',
+                               submitting_party_phone='6041234567',
+                               submitting_party_address='106 1704 GOVERNMENT STREET              PENTICTON, BC V2A 6K3',
+                               owner_name='ownerName',
+                               owner_phone_number='2501234567',
+                               owner_address='ownerAddress',
+                               owner_postal_code='ownerCode',
+                               street_number='1234',
+                               street_name='streetName',
+                               town_city='townCity',
+                               province='BC',
+                               manufacturer_name='manufacturerName')
+
+    test_json = {
+        'bcolAccountNumber': manufacturer.bcol_account_number,
+        'dealerName': manufacturer.dealer_name,
+        'submittingParty': {
+            'businessName': manufacturer.submitting_party_name,
+            'phoneNumber': manufacturer.submitting_party_phone,
+            'address': model_utils.get_address_from_db2_manufact(manufacturer.submitting_party_address)
+        },
+        'owner': {
+            'businessName': manufacturer.owner_name,
+            'phoneNumber': manufacturer.owner_phone_number,
+            'address': {
+                'street': manufacturer.street_number + ' ' + manufacturer.street_name,
+                'city': manufacturer.town_city,
+                'region': manufacturer.province,
+                'country': 'CA',
+                'postalCode': manufacturer.owner_postal_code
+            }
+        },
+        'manufacturerName': manufacturer.manufacturer_name
+    }
+    assert manufacturer.json == test_json

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -71,6 +71,18 @@ TEST_DATA_SERIAL_KEY = [
     ('12345', '003039'),
     ('999999', '0F423F')
 ]
+#3737 PALM HARBOR DRIVE                  MILLERSBURG,OR  97321   
+# testdata pattern is ({street1}, {city}, {region}, {country}, {postal_code}, {address})
+TEST_DB2_ADDRESS_MANUFACT = [
+    ('PO BOX 190 STATION MAIN', 'PENTICTON', 'BC', 'CA', 'V2A 6J9',
+     'PO BOX 190 STATION MAIN                 PENTICTON, BC V2A 6J9'),
+    ('3737 PALM HARBOR DRIVE', 'MILLERSBURG', 'OR', 'US', '97321',
+     '3737 PALM HARBOR DRIVE                  MILLERSBURG,OR  97321'),
+    ('PO BOX 188', 'SHERIDAN', 'OR', 'US', 'USA 97378',
+     'PO BOX 188                              SHERIDAN OR USA 97378'),
+    ('RR1, S2,C23', 'OKANAGAN FALLS', 'BC', 'CA', 'V0H1RO',
+     'RR1, S2,C23                             OKANAGAN FALLS B.C. V0H1RO')
+]
 
 
 @pytest.mark.parametrize('name, key_value', TEST_DATA_ORG_KEY)
@@ -107,3 +119,15 @@ def test_db2_address(session, street1, street2, city, region, address):
         assert 'streetAdditional' not in test_address
     else:
         assert test_address['streetAdditional'] == street2
+
+
+@pytest.mark.parametrize('street1, city, region, country, postal_code, address', TEST_DB2_ADDRESS_MANUFACT)
+def test_db2_address_manufact(session, street1, city, region, country, postal_code, address):
+    """Assert that parsing a legacy db2 manufact table address works as expected."""
+    test_address = model_utils.get_address_from_db2_manufact(address)
+    current_app.logger.info(test_address)
+    assert test_address['street'] == street1
+    assert test_address['city'] == city
+    assert test_address['region'] == region
+    assert test_address['country'] == country
+    assert test_address['postalCode'] == postal_code

--- a/mhr_api/tests/unit/services/test_payment.py
+++ b/mhr_api/tests/unit/services/test_payment.py
@@ -154,12 +154,17 @@ def test_payment_data_staff_search(client, jwt, selection, routing_slip, bcol_nu
     data = SBCPaymentClient.create_payment_staff_search_data(selection, transaction_info, 'TEST', 'UT-PAY-0001')
     # check
     assert data
-    assert len(data['filingInfo']['filingTypes']) == 1
     if waive_fees:
         assert data['filingInfo']['filingTypes'][0]['waiveFees']
     else:
         assert 'waiveFees' not in data['filingInfo']['filingTypes'][0]
-
+    assert not data['filingInfo']['filingTypes'][0]['priority']
+    if priority:
+        assert len(data['filingInfo']['filingTypes']) == 2
+        assert data['filingInfo']['filingTypes'][1]['filingTypeCode'] == 'PRIMH'
+        assert data['filingInfo']['filingTypes'][1]['priority']
+    else:
+        assert len(data['filingInfo']['filingTypes']) == 1
     if not routing_slip and not bcol_number:
         assert 'accountInfo' not in data
     elif routing_slip:
@@ -168,10 +173,6 @@ def test_payment_data_staff_search(client, jwt, selection, routing_slip, bcol_nu
         assert 'accountInfo' in data and data['accountInfo']['bcolAccountNumber'] == bcol_number
         if dat_number:
             assert data['accountInfo']['datNumber'] == dat_number
-    if priority:
-        assert data['filingInfo']['filingTypes'][0]['priority']
-    else:
-        assert not data['filingInfo']['filingTypes'][0]['priority']
 
 
 @pytest.mark.parametrize('filing_type,selection,staff', TEST_PAY_TYPE_FILING_TYPE_SEARCH)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12642

*Description of changes:*
- Add new endpoint to get manufacturer information by account id (including submitting party).
- 12928 MHR staff search fee charges use CSRCS, MSRCS codes. For priority charge an additional PRIMH code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
