### PR TITLE
Search by org/owner include duplicates to match legacy.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/search_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/search_utils.py
@@ -86,7 +86,7 @@ ORDER BY d.regidate ASC
 
 OWNER_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
-       de.yearmade, de.makemodl, mh.manhomid, og.status
+       de.yearmade, de.makemodl, mh.manhomid, og.status, og.owngrpid
   FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
@@ -105,7 +105,7 @@ ORDER BY o.ownrname ASC, d.regidate ASC
 
 ORG_NAME_QUERY = """
 SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, o.ownrtype, o.ownrname, l.towncity, de.sernumb1,
-       de.yearmade, de.makemodl, mh.manhomid, og.status
+       de.yearmade, de.makemodl, mh.manhomid, og.status, og.owngrpid
   FROM manuhome mh, document d, owner o, location l, descript de, owngroup og
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12626

*Description of changes:*
- Include owner group in owner/org search queries to match legacy results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
