### PR TITLE
Allow UI requests to regenerate failed verification reports.

### DIFF
--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -196,9 +196,13 @@ def set_path(params: AccountRegistrationParams, result, reg_num: str, base_reg_n
     elif reg_class in (model_utils.REG_CLASS_AMEND, model_utils.REG_CLASS_AMEND_COURT):
         result['path'] = FINANCING_PATH + base_reg_num + '/amendments/' + reg_num
 
-    if pending_count > 0 or not can_access_report(params.account_id, params.account_name, result, params.sbc_staff):
+    if not can_access_report(params.account_id, params.account_name, result, params.sbc_staff):
         result['path'] = ''
-
+    elif pending_count > 0:
+        # Allow report regeneration if pending and > 15 minutes has elapsed.
+        last_ts = model_utils.ts_from_iso_format(result['lastUpdateDateTime'])
+        if not model_utils.report_retry_elapsed(last_ts):
+            result['path'] = ''
     return result
 
 

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.2'  # pylint: disable=invalid-name
+__version__ = '1.0.3'  # pylint: disable=invalid-name


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#12833

*Description of changes:*
- If a verification report request fails, allow a download regeneration in the UI reg table after 15 minutes has elapsed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
