### PR TITLE
Add endpoint to get account registrations.

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_extra_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_extra_registration.py
@@ -54,7 +54,7 @@ class MhrExtraRegistration(db.Model):
 
     @classmethod
     def find_by_account_id(cls, account_id: str):
-        """Return an list of user extra registration matching the account id."""
+        """Return a list of user extra registrations matching the account id."""
         if account_id:
             return db.session.query(MhrExtraRegistration).\
                                     filter(MhrExtraRegistration.account_id == account_id).all()
@@ -62,7 +62,7 @@ class MhrExtraRegistration(db.Model):
 
     @classmethod
     def find_mhr_numbers_by_account_id(cls, account_id: str):
-        """Return an list of user extra registration MHR numbers matching the account id."""
+        """Return a list of user extra registration MHR numbers matching the account id."""
         mhr_numbers = []
         if account_id:
             registrations = db.session.query(MhrExtraRegistration).\

--- a/mhr_api/src/mhr_api/models/mhr_extra_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_extra_registration.py
@@ -53,6 +53,27 @@ class MhrExtraRegistration(db.Model):
         return None
 
     @classmethod
+    def find_by_account_id(cls, account_id: str):
+        """Return an list of user extra registration matching the account id."""
+        if account_id:
+            return db.session.query(MhrExtraRegistration).\
+                                    filter(MhrExtraRegistration.account_id == account_id).all()
+        return None
+
+    @classmethod
+    def find_mhr_numbers_by_account_id(cls, account_id: str):
+        """Return an list of user extra registration MHR numbers matching the account id."""
+        mhr_numbers = []
+        if account_id:
+            registrations = db.session.query(MhrExtraRegistration).\
+                                             filter(MhrExtraRegistration.account_id == account_id).all()
+            if registrations:
+                for reg in registrations:
+                    mhr = {'mhr_number': reg.mhr_number}
+                    mhr_numbers.append(mhr)
+        return mhr_numbers
+
+    @classmethod
     def delete(cls, mhr_number: str, account_id: str):
         """Delete a user extra registation record by account ID and MHR number."""
         registration = None

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -264,6 +264,7 @@ DB2_PROVINCE_MAPPING = {
 COUNTRY_CA = 'CA'
 COUNTRY_US = 'US'
 PROVINCE_BC = 'BC'
+REGISTRATION_PATH = '/mhr/api/v1/registrations/'
 
 
 def get_max_registrations_size():

--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -22,6 +22,7 @@ from .meta import bp as meta_bp
 from .ops import bp as ops_bp
 from .other_registrations import bp as other_registrations_bp
 from .registration_report_callback import bp as registration_report_callback_bp
+from .registrations import bp as registrations_bp
 from .search_history import bp as search_history_bp
 from .search_report_callback import bp as search_report_callback_bp
 from .search_results import bp as search_result_bp
@@ -46,6 +47,7 @@ class V1Endpoint:
         self.app.register_blueprint(meta_bp)
         self.app.register_blueprint(ops_bp)
         self.app.register_blueprint(other_registrations_bp)
+        self.app.register_blueprint(registrations_bp)
         self.app.register_blueprint(searches_bp)
         self.app.register_blueprint(search_history_bp)
         self.app.register_blueprint(search_result_bp)

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""API endpoints for requests to view registrations created by another account."""
-
-# pylint: disable=too-many-return-statements
+"""API endpoints for requests to maintain MH registrations."""
 
 from http import HTTPStatus
 

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -1,0 +1,59 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for requests to view registrations created by another account."""
+
+# pylint: disable=too-many-return-statements
+
+from http import HTTPStatus
+
+from flask import Blueprint
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+from mhr_api.utils.auth import jwt
+from mhr_api.exceptions import DatabaseException
+from mhr_api.services.authz import authorized
+from mhr_api.models import Registration
+from mhr_api.resources import utils as resource_utils
+
+
+bp = Blueprint('REGISTRATIONS1',  # pylint: disable=invalid-name
+               __name__, url_prefix='/api/v1/registrations')
+
+
+@bp.route('', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_account_registrations():
+    """Get account registrations summary list."""
+    account_id = ''
+    try:
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        # current_app.logger.debug(f'get_account_registrations account={account_id}.')
+        # Try to fetch account registrations.
+        statement_list = Registration.find_all_by_account_id(account_id)
+        return jsonify(statement_list), HTTPStatus.OK
+
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id,
+                                                    'GET account registrations id=' + account_id)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -632,7 +632,53 @@
 			"name": "registrations",
 			"item": [
 				{
-					"name": "Get other account registration",
+					"name": "Get account registrations",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/registrations",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"registrations"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
+				},
+				{
+					"name": "Get other account registration Copy",
 					"protocolProfileBehavior": {
 						"disabledSystemHeaders": {
 							"accept": true

--- a/mhr_api/tests/unit/api/test_other_registrations.py
+++ b/mhr_api/tests/unit/api/test_other_registrations.py
@@ -22,11 +22,9 @@ from http import HTTPStatus
 import pytest
 from flask import current_app
 
-from mhr_api.models import SearchResult, SearchRequest
-from mhr_api.resources.v1.search_results import get_payment_details
-from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE, BCOL_HELP, GOV_ACCOUNT_ROLE
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
 
-from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
+from tests.unit.services.utils import create_header, create_header_account
 
 
 # testdata pattern is ({desc}, {roles}, {status}, {has_account}, {mhr_number})

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests to verify the account extra/other registrations endpoint.
+"""Tests to verify the endpoints for maintaining MH registrations.
 
-Test-Suite to ensure that the /other-registrations/{mhr_number} endpoint is working as expected.
+Test-Suite to ensure that the /registrations endpoint is working as expected.
 """
 import copy
 from http import HTTPStatus

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -1,0 +1,68 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the account extra/other registrations endpoint.
+
+Test-Suite to ensure that the /other-registrations/{mhr_number} endpoint is working as expected.
+"""
+import copy
+from http import HTTPStatus
+
+import pytest
+from flask import current_app
+
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
+
+from tests.unit.services.utils import create_header, create_header_account
+
+
+# testdata pattern is ({desc}, {roles}, {status}, {has_account}, {results_size})
+TEST_GET_ACCOUNT_DATA = [
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, 0),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 0),
+    ('Valid request', [MHR_ROLE], HTTPStatus.OK, True, 1),
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, 0)
+]
+
+
+@pytest.mark.parametrize('desc,roles,status,has_account,results_size', TEST_GET_ACCOUNT_DATA)
+def test_get_account_registrations(session, client, jwt, desc, roles, status, has_account, results_size):
+    """Assert that a get account registrations summary list endpoint works as expected."""
+    headers = None
+    # setup
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
+    # test
+    rv = client.get('/api/v1/registrations',
+                    headers=headers)
+
+    # check
+    # print(rv.json)
+    assert rv.status_code == status
+    if rv.status_code == HTTPStatus.OK:
+        assert rv.json
+        assert len(rv.json) >= results_size
+        for registration in rv.json:
+            assert registration['mhrNumber']
+            assert registration['registrationDescription']
+            assert registration['statusType'] is not None
+            assert registration['createDateTime'] is not None
+            assert registration['username'] is not None
+            assert registration['submittingParty'] is not None
+            assert registration['clientReferenceId'] is not None
+            assert registration['ownerNames'] is not None
+            assert registration['path'] is not None
+            assert registration['inUserList'] is not None

--- a/mhr_api/tests/unit/models/test_mhr_extra_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_extra_registration.py
@@ -18,6 +18,15 @@ Test-Suite to ensure that the MHR Extra Registrations Model is working as expect
 """
 from mhr_api.models import MhrExtraRegistration
 
+import pytest
+
+
+# testdata pattern is ({account_id}, {count})
+TEST_ACCOUNT_REG_DATA = [
+    ('PS12345', 2),
+    ('TESTXX', 0)
+]
+
 
 def test_find_by_id(session):
     """Assert that find user extra validation by ID contains all expected elements."""
@@ -81,3 +90,31 @@ def test_find_by_mhr_number_invalid_account(session):
     """Assert that find user extra registration by non-existent account id returns the expected result."""
     registration = MhrExtraRegistration.find_by_mhr_number('TEST01', 'XXXXXX')
     assert not registration
+
+
+@pytest.mark.parametrize('account_id, count', TEST_ACCOUNT_REG_DATA)
+def test_find_by_account_id(session, account_id, count):
+    """Assert that finding account extra registrations works as expected."""
+    extra_reg_list = MhrExtraRegistration.find_by_account_id(account_id)
+    if count > 0:
+        assert extra_reg_list
+        assert len(extra_reg_list) >= count
+        for reg in extra_reg_list:
+            assert reg.id > 0
+            assert reg.account_id
+            assert reg.mhr_number
+    else:
+        assert not extra_reg_list
+
+
+@pytest.mark.parametrize('account_id, count', TEST_ACCOUNT_REG_DATA)
+def test_find_mhr_numbers_by_account_id(session, account_id, count):
+    """Assert that finding account extra registration mhr numbers works as expected."""
+    mhr_list = MhrExtraRegistration.find_mhr_numbers_by_account_id(account_id)
+    if count > 0:
+        assert mhr_list
+        assert len(mhr_list) >= count
+        for mhr in mhr_list:
+            assert mhr['mhr_number']
+    else:
+        assert not mhr_list

--- a/mhr_api/tests/unit/models/test_registration.py
+++ b/mhr_api/tests/unit/models/test_registration.py
@@ -23,18 +23,23 @@ import pytest
 from mhr_api.models import Registration
 
 
-# testdata pattern is ({mhr_num}, {exists}, {reg_description}, {in_list})
+# testdata pattern is ({account_id}, {mhr_num}, {exists}, {reg_description}, {in_list})
 TEST_SUMMARY_REG_DATA = [
-    ('077741', True, 'Manufactured Home Registration', False),
-    ('TESTXX', False, None, False),
-    ('045349', True, 'Manufactured Home Registration', True)
+    ('PS12345', '077741', True, 'Manufactured Home Registration', False),
+    ('PS12345', 'TESTXX', False, None, False),
+    ('PS12345', '045349', True, 'Manufactured Home Registration', True)
+]
+# testdata pattern is ({account_id}, {has_results})
+TEST_ACCOUNT_REG_DATA = [
+    ('PS12345', True),
+    ('999999', False)
 ]
 
 
-@pytest.mark.parametrize('mhr_num,exists,reg_desc,in_list', TEST_SUMMARY_REG_DATA)
-def test_find_summary_by_mhr_number(session, mhr_num, exists, reg_desc, in_list):
+@pytest.mark.parametrize('account_id,mhr_num,exists,reg_desc,in_list', TEST_SUMMARY_REG_DATA)
+def test_find_summary_by_mhr_number(session, account_id, mhr_num, exists, reg_desc, in_list):
     """Assert that finding summary MHR registration information works as expected."""
-    registration = Registration.find_summary_by_mhr_number('PS12345', mhr_num)
+    registration = Registration.find_summary_by_mhr_number(account_id, mhr_num)
     if exists:
         current_app.logger.info(registration)
         assert registration['mhrNumber'] == mhr_num
@@ -49,3 +54,23 @@ def test_find_summary_by_mhr_number(session, mhr_num, exists, reg_desc, in_list)
         assert registration['inUserList'] == in_list
     else:
         assert not registration
+
+
+@pytest.mark.parametrize('account_id, has_results', TEST_ACCOUNT_REG_DATA)
+def test_find_account_registrations(session, account_id, has_results):
+    """Assert that finding account summary MHR registration information works as expected."""
+    reg_list = Registration.find_all_by_account_id(account_id)
+    if has_results:
+        for registration in reg_list:
+            assert registration['mhrNumber']
+            assert registration['registrationDescription']
+            assert registration['statusType'] is not None
+            assert registration['createDateTime'] is not None
+            assert registration['username'] is not None
+            assert registration['submittingParty'] is not None
+            assert registration['clientReferenceId'] is not None
+            assert registration['ownerNames'] is not None
+            assert registration['path'] is not None
+            assert registration['inUserList'] is not None
+    else:
+        assert not reg_list


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13110

*Description of changes:*
Add new mhr api endpoint to get account registrations summary info list to populate the UI mhr registrations table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
