### PR TITLE
"Include lien info for all" state kept when navigating back from Summary page

### DIFF
--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -220,12 +220,23 @@ export default defineComponent({
       getManufacturedHomeSearchResults,
       getFolioOrReferenceNumber,
       getSearchedType,
-      getSelectedManufacturedHomes
+      getSelectedManufacturedHomes,
+      getMhrSearchResultSelectAllLien
     } = useGetters<any>([
-      'getManufacturedHomeSearchResults', 'getFolioOrReferenceNumber', 'getSearchedType', 'getSelectedManufacturedHomes'
+      'getManufacturedHomeSearchResults',
+      'getFolioOrReferenceNumber',
+      'getSearchedType',
+      'getSelectedManufacturedHomes',
+      'getMhrSearchResultSelectAllLien'
     ])
-    const { setSelectedManufacturedHomes, setFolioOrReferenceNumber } = useActions<any>([
-      'setSelectedManufacturedHomes', 'setFolioOrReferenceNumber'
+    const {
+      setSelectedManufacturedHomes,
+      setFolioOrReferenceNumber,
+      setMhrSearchResultSelectAllLien
+    } = useActions<any>([
+      'setSelectedManufacturedHomes',
+      'setFolioOrReferenceNumber',
+      'setMhrSearchResultSelectAllLien'
     ])
     const router = context.root.$router
 
@@ -340,6 +351,7 @@ export default defineComponent({
         // includeLienInfo needs to be initialized or something weird will happen
         return result.includeLienInfo !== true ? { ...result, includeLienInfo: false } : result
       })
+      localState.selectAllLien = getMhrSearchResultSelectAllLien.value
       localState.totalResultsLength = resp.totalResultsSize
       const date = new Date(resp.searchDateTime)
       localState.searchTime = pacificDate(date)
@@ -385,7 +397,14 @@ export default defineComponent({
           result.includeLienInfo = localState.selectAllLien
         }
       }
+      setMhrSearchResultSelectAllLien(localState.selectAllLien)
     }
+
+    watch(() => localState.selectedLiensLength, (): void => {
+      if (localState.selectedLiensLength < localState.selectedMatchesLength) {
+        localState.selectAllLien = false
+      }
+    })
 
     return {
       reviewAndConfirm,

--- a/ppr-ui/src/interfaces/store-interfaces/state-model-interface.ts
+++ b/ppr-ui/src/interfaces/store-interfaces/state-model-interface.ts
@@ -57,4 +57,5 @@ export interface StateModelIF {
   unsavedChanges: Boolean // used for cancel flows
   userInfo: UserInfoIF
   mhrValidationState?: MhrValidationStateIF
+  mhrSearchResultSelectAllLien: boolean
 }

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -337,3 +337,7 @@ export const setMhrRegistrationHomeOwnerGroups: ActionIF = (
   commit('mutateMhrHomeOwnerGroups', groups)
   commit('mutateUnsavedChanges', true)
 }
+
+export const setMhrSearchResultSelectAllLien: ActionIF = ({ commit }, value): void => {
+  commit('mutateMhrSearchResultSelectAllLien', value)
+}

--- a/ppr-ui/src/store/getters/state-getters.ts
+++ b/ppr-ui/src/store/getters/state-getters.ts
@@ -682,3 +682,7 @@ export const getMhrRegistrationHomeOwnerGroups = (state: StateIF): MhrRegistrati
 export const getMhrRegistrationValidationModel = (state: StateIF): MhrValidationStateIF => {
   return state.stateModel.mhrValidationState
 }
+
+export const getMhrSearchResultSelectAllLien = (state: StateIF): boolean => {
+  return state.stateModel.mhrSearchResultSelectAllLien
+}

--- a/ppr-ui/src/store/mutations/mutations-model.ts
+++ b/ppr-ui/src/store/mutations/mutations-model.ts
@@ -394,3 +394,7 @@ export const mutateMhrHomeOwnerGroups = (
 ) => {
   state.stateModel.mhrRegistration.ownerGroups = groups
 }
+
+export const mutateMhrSearchResultSelectAllLien = (state: StateIF, value: boolean) => {
+  state.stateModel.mhrSearchResultSelectAllLien = value
+}

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -248,5 +248,6 @@ export const stateModel: StateModelIF = {
       validateSteps: false,
       validateApp: false
     }
-  }
+  },
+  mhrSearchResultSelectAllLien: false
 }

--- a/ppr-ui/tests/unit/test-data/mock-registration-amendment.ts
+++ b/ppr-ui/tests/unit/test-data/mock-registration-amendment.ts
@@ -541,7 +541,8 @@ export const mockedModelAmendmdmentAdd: StateModelIF = {
   folioOrReferenceNumber: 'UT-AM-001-ADD',
   unsavedChanges: false,
   selectedManufacturedHomes: null,
-  isStaffClientPayment: null
+  isStaffClientPayment: null,
+  mhrSearchResultSelectAllLien: false
 }
 
 export const mockedModelAmendmdmentDelete: StateModelIF = {
@@ -652,7 +653,8 @@ export const mockedModelAmendmdmentDelete: StateModelIF = {
   folioOrReferenceNumber: 'UT-AM-002-DELETE',
   unsavedChanges: false,
   selectedManufacturedHomes: null,
-  isStaffClientPayment: null
+  isStaffClientPayment: null,
+  mhrSearchResultSelectAllLien: false
 }
 
 export const mockedModelAmendmdmentEdit: StateModelIF = {
@@ -764,7 +766,8 @@ export const mockedModelAmendmdmentEdit: StateModelIF = {
   folioOrReferenceNumber: 'UT-AM-003-EDIT',
   unsavedChanges: false,
   selectedManufacturedHomes: null,
-  isStaffClientPayment: null
+  isStaffClientPayment: null,
+  mhrSearchResultSelectAllLien: false
 }
 
 export const mockedModelAmendmdmentCourtOrder: StateModelIF = {
@@ -875,5 +878,6 @@ export const mockedModelAmendmdmentCourtOrder: StateModelIF = {
   folioOrReferenceNumber: 'UT-AM-004-COURT-ORDER',
   unsavedChanges: false,
   selectedManufacturedHomes: null,
-  isStaffClientPayment: null
+  isStaffClientPayment: null,
+  mhrSearchResultSelectAllLien: false
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13383

*Description of changes:*
update checkbox behavior, add state to state model

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
