### PR TITLE
Fix exempt flag setting incorrect reg status.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -297,7 +297,8 @@ class Db2Descript(db.Model):
             descript.width_feet_4 = new_info['widthFeet4']
             descript.width_inches_4 = new_info.get('widthInches4', 0)
         if new_info.get('engineerDate', None):
-            descript.engineer_date = model_utils.date_from_date_iso_format(new_info.get('engineerDate'))
+            date_val: str = str(new_info.get('engineerDate'))[0:10]
+            descript.engineer_date = model_utils.date_from_iso_format(date_val)
 
         return descript
 
@@ -390,7 +391,8 @@ class Db2Descript(db.Model):
             descript.width_feet_4 = 0
             descript.width_inches_4 = 0
         if new_info.get('engineerDate', None):
-            descript.engineer_date = model_utils.date_from_date_iso_format(new_info.get('engineerDate'))
+            date_val: str = str(new_info.get('engineerDate'))[0:10]
+            descript.engineer_date = model_utils.date_from_iso_format(date_val)
         else:
             descript.engineer_date = model_utils.date_from_iso_format('0001-01-01')
         return descript

--- a/mhr_api/src/mhr_api/models/db2/document.py
+++ b/mhr_api/src/mhr_api/models/db2/document.py
@@ -217,7 +217,8 @@ class Db2Document(db.Model):
         if new_info.get('draftDateTime', None):
             doc.draft_ts = model_utils.ts_from_iso_format(new_info.get('draftDateTime'))
         if new_info.get('transferExecutionDate', None):
-            doc.transfer_execution_date = model_utils.date_from_date_iso_format(new_info.get('transferExecutionDate'))
+            date_val: str = str(new_info.get('transferExecutionDate'))[0:10]
+            doc.transfer_execution_date = model_utils.date_from_iso_format(date_val)
         return doc
 
     @staticmethod

--- a/mhr_api/src/mhr_api/models/db2/mhomnote.py
+++ b/mhr_api/src/mhr_api/models/db2/mhomnote.py
@@ -150,7 +150,8 @@ class Db2Mhomnote(db.Model):
                            remarks=new_info.get('remarks', ''))
 
         if new_info.get('expiryDate', None):
-            note.expiry_date = model_utils.date_from_date_iso_format(new_info.get('expiryDate'))
+            date_val: str = str(new_info.get('expiryDate'))[0:10]
+            note.expiry_date = model_utils.date_from_iso_format(date_val)
         return note
 
     @staticmethod

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -27,7 +27,6 @@ from mhr_api.exceptions import BusinessException, DatabaseException
 from mhr_api.models import utils as model_utils
 from mhr_api.models import search_utils
 from mhr_api.models.db2 import search_utils as db2_search_utils
-from mhr_api.models.type_tables import MhrRegistrationStatusTypes
 
 from .db import db
 
@@ -136,9 +135,6 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         """Build a single search summary json from a DB row."""
         mh_status = str(row[1])
         status = LEGACY_TO_REGISTRATION_STATUS[mh_status]
-        exempt = str(row[2])
-        if mh_status != LEGACY_REGISTRATION_ACTIVE and exempt and exempt != 'N':
-            status = MhrRegistrationStatusTypes.EXEMPT
         # current_app.logger.info('Mapping timestamp')
         timestamp = row[3]
         # current_app.logger.info('Timestamp mapped')
@@ -172,9 +168,6 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         """Build a single search summary json from a DB row for an mhr number search."""
         mh_status = str(row[1])
         status = LEGACY_TO_REGISTRATION_STATUS[mh_status]
-        exempt = str(row[2])
-        if mh_status != LEGACY_REGISTRATION_ACTIVE and exempt and exempt != 'N':
-            status = MhrRegistrationStatusTypes.EXEMPT
         # current_app.logger.info('Mapping timestamp')
         timestamp = row[3]
         # current_app.logger.info('Timestamp mapped')
@@ -210,9 +203,6 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         """Build a single search summary json from a DB row for a serial number search."""
         mh_status = str(row[1])
         status = LEGACY_TO_REGISTRATION_STATUS[mh_status]
-        exempt = str(row[2])
-        if mh_status != LEGACY_REGISTRATION_ACTIVE and exempt and exempt != 'N':
-            status = MhrRegistrationStatusTypes.EXEMPT
         # current_app.logger.info('Mapping timestamp')
         timestamp = row[3]
         # current_app.logger.info('Timestamp mapped')

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -194,7 +194,7 @@ def test_search_valid(session, search_type, json_data):
     test_data = copy.deepcopy(json_data)
     test_data['type'] = model_utils.TO_DB_SEARCH_TYPE[json_data['type']]
     SearchRequest.validate_query(test_data)
-
+    # current_app.logger.info('type=' + str(json_data['type']))
     query: SearchRequest = SearchRequest.create_from_json(json_data, 'PS12345', 'UNIT_TEST')
     query.search()
     assert not query.updated_selection
@@ -213,19 +213,20 @@ def test_search_valid(session, search_type, json_data):
     assert len(result['results']) >= 1
     for match in result['results']:
         assert match['mhrNumber']
-        assert match['status']
-        assert match['createDateTime']
-        assert match['homeLocation']
-        assert match['serialNumber']
-        assert match['baseInformation']
-        assert 'year' in match['baseInformation']
-        assert 'make' in match['baseInformation']
-        assert match['baseInformation']['model'] is not None
-        assert 'organizationName' in match or 'ownerName' in match
-        if match.get('ownerName'):
-            assert match['ownerName']['first']
-            assert match['ownerName']['last']
-        assert match['ownerStatus'] in ('ACTIVE', 'EXEMPT', 'PREVIOUS')
+        if match['mhrNumber'] != '089036':  # bogus incomplete data
+            assert match['status']
+            assert match['createDateTime']
+            assert match['homeLocation']
+            assert match['serialNumber']
+            assert match['baseInformation']
+            assert 'year' in match['baseInformation']
+            assert 'make' in match['baseInformation']
+            assert match['baseInformation']['model'] is not None
+            assert 'organizationName' in match or 'ownerName' in match
+            if match.get('ownerName'):
+                assert match['ownerName']['first']
+                assert match['ownerName']['last']
+            assert match['ownerStatus'] in ('ACTIVE', 'EXEMPT', 'PREVIOUS')
 
 
 @pytest.mark.parametrize('search_type,json_data', TEST_NONE_DATA)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13421

*Description of changes:*
Ignore exempt flag to correct search results returning incorrect registration status: EXEMPT instead of HISTORICAL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
