### PR TITLE
13362 Fix no OwnerName showing if last name only search

### DIFF
--- a/ppr-ui/src/components/search/SearchBar.vue
+++ b/ppr-ui/src/components/search/SearchBar.vue
@@ -91,7 +91,6 @@
               :hint="searchHintFirst"
               persistent-hint
               :placeholder="optionFirst"
-              v-validate=" isStaffBcolReg ? '' : 'required' "
               v-model="searchValueFirst"
               @keypress.enter="searchCheck()"
           />

--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -242,7 +242,7 @@ export default defineComponent({
       const second = query?.criteria?.[individualKey]?.second || query?.criteria?.[individualKey]?.middle
       const last = query?.criteria?.[individualKey]?.last
       const business = query?.criteria?.debtorName?.business
-      if (first && last) {
+      if (first || last) {
         if (second) {
           return `${first} ${second} ${last}`
         }

--- a/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
+++ b/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
@@ -2,7 +2,7 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { getVuexStore } from '@/store'
-import CompositionApi, {nextTick} from '@vue/composition-api'
+import CompositionApi, { nextTick } from '@vue/composition-api'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 
 // Components


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13362

*Description of changes:*

- Fix no OwnerName showing if Owner last name only search.
- Remove unneeded code.  Caused validation error.
- 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
