### PR TITLE
New endpoint to verify new MHR reg doc IDs.

### DIFF
--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from flask import Flask
 
+from .documents import bp as documents_bp
 from .manufacturer import bp as manufacturers_bp
 from .meta import bp as meta_bp
 from .ops import bp as ops_bp
@@ -43,6 +44,7 @@ class V1Endpoint:
 
         self.app = app
 
+        self.app.register_blueprint(documents_bp)
         self.app.register_blueprint(manufacturers_bp)
         self.app.register_blueprint(meta_bp)
         self.app.register_blueprint(ops_bp)

--- a/mhr_api/src/mhr_api/resources/v1/documents.py
+++ b/mhr_api/src/mhr_api/resources/v1/documents.py
@@ -1,0 +1,65 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for requests to maintain MH documents."""
+
+from http import HTTPStatus
+
+from flask import Blueprint
+from flask import current_app, request
+from flask_cors import cross_origin
+
+from mhr_api.utils.auth import jwt
+from mhr_api.exceptions import DatabaseException
+from mhr_api.services.authz import authorized
+from mhr_api.resources import utils as resource_utils
+from mhr_api.utils import registration_validator
+
+
+bp = Blueprint('DOCUMENTS1',  # pylint: disable=invalid-name
+               __name__, url_prefix='/api/v1/documents')
+
+
+@bp.route('/verify/<string:document_id>', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_verify_ids(document_id: str):
+    """Get summary status information for a an MH document ID."""
+    try:
+        current_app.logger.info(f'get_verify_ids document_id={document_id}')
+        if document_id is None:
+            return resource_utils.path_param_error_response('Document Id')
+        # Quick check: must be staff or provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        # Verify the doc id, start with a valid response.
+        response_json = {
+            'documentId': document_id,
+            'exists': False,
+            'valid': True
+        }
+        error_msg = registration_validator.validate_doc_id(response_json)
+        if error_msg and error_msg.find(registration_validator.DOC_ID_EXISTS) != -1:
+            response_json['exists'] = True
+        if error_msg and error_msg.find(registration_validator.DOC_ID_INVALID_CHECKSUM) != -1:
+            response_json['valid'] = False
+        return response_json, HTTPStatus.OK
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id,
+                                                    'GET verify doc id=' + document_id)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.7'  # pylint: disable=invalid-name
+__version__ = '1.0.8'  # pylint: disable=invalid-name

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -725,7 +725,7 @@
 					"response": []
 				},
 				{
-					"name": "Get other account registration Copy",
+					"name": "Get other account registration",
 					"protocolProfileBehavior": {
 						"disabledSystemHeaders": {
 							"accept": true
@@ -765,6 +765,54 @@
 								"v1",
 								"other-registrations",
 								"037462"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Document ID",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/documents/verify/40590422",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents",
+								"verify",
+								"40590422"
 							]
 						},
 						"description": "Retrieve the recent history of search requests for the account."

--- a/mhr_api/tests/unit/api/test_documents.py
+++ b/mhr_api/tests/unit/api/test_documents.py
@@ -1,0 +1,60 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the endpoints for maintaining MH documents.
+
+Test-Suite to ensure that the /documents endpoint is working as expected.
+"""
+from http import HTTPStatus
+
+import pytest
+from flask import current_app
+
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
+from tests.unit.services.utils import create_header, create_header_account
+
+
+# testdata pattern is ({desc}, {roles}, {status}, {has_account}, {doc_id}, {exists}, {valid})
+TEST_VERIFY_ID_DATA = [
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '40583993', True, True),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '40583993', True, True),
+    ('Valid request exists', [MHR_ROLE], HTTPStatus.OK, True, '40583993', True, True),
+    ('Valid request not exists no checksum', [MHR_ROLE], HTTPStatus.OK, True, '80888999', False, True),
+    ('Valid request not exists checksum', [MHR_ROLE], HTTPStatus.OK, True, '79289202', False, True),
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '40583993', True, True)
+]
+
+
+@pytest.mark.parametrize('desc,roles,status,has_account,doc_id,exists,valid', TEST_VERIFY_ID_DATA)
+def test_get_doc_id_verify(session, client, jwt, desc, roles, status, has_account, doc_id, exists, valid):
+    """Assert that a get document id status endpoint works as expected."""
+    headers = None
+    # setup
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
+    # test
+    rv = client.get('/api/v1/documents/verify/' + doc_id,
+                    headers=headers)
+
+    # check
+    assert rv.status_code == status
+    if rv.status_code == HTTPStatus.OK:
+        response = rv.json
+        current_app.logger.debug(response)
+        assert response
+        assert response['documentId'] == doc_id
+        assert response['exists'] == exists
+        assert response['valid'] == valid


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13438

*Description of changes:*
- Add a new endpoint to validate a document id for staff new MHR registrations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
