### PR TITLE
Fix Owners count in Group Header

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -182,11 +182,10 @@ export default defineComponent({
     }
 
     // To render Group table header the owners array must not be empty
-    // If group is empty, owners array will have a 'placeholder' obj and not the actual owners
+    // check for at least one owner with an id
     // This util function will help to show Owners: 0 in the table header
     const hasActualOwners = (owners: MhrRegistrationHomeOwnersIF[]): boolean => {
-      // check for one 'placeholder' owner which will not have an id
-      return owners.length === 1 && owners[0]?.id !== undefined
+      return owners.length > 0 && owners[0]?.id !== undefined
     }
 
     watch(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13534

*Description of changes:*

- Fix counter in Owners Group header
- Now the counter correctly shows the number of Owners in the Group

<img width="751" alt="Screen Shot 2022-09-19 at 5 52 02 PM" src="https://user-images.githubusercontent.com/2333290/191143864-987421d6-3037-4ea6-a81d-623629a7a1f8.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
