### PR TITLE
Made search result table headers adaptive

### DIFF
--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -100,7 +100,7 @@
 
           <template  v-else v-slot:[headerSearchTypeSlot]>
             <span v-if="isOwnerOrOrgSearch" class="pl-8">
-              {{ personOrOrgLabel }} Name
+              {{ ownerOrOrgHeader }} Name
             </span>
             <span v-else class="pl-8">{{ headerSlotLabel }}</span>
           </template>
@@ -231,7 +231,7 @@ import {
 import { BaseHeaderIF, ManufacturedHomeSearchResultIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { FolioNumber } from '@/components/common'
 import { pacificDate } from '@/utils'
-import { APIMHRMapSearchTypes, RouteNames, UIMHRSearchTypes, UIMHRSearchTypeValues } from '@/enums'
+import { RouteNames, UIMHRSearchTypes, UIMHRSearchTypeValues } from '@/enums'
 import { cloneDeep } from 'lodash'
 
 export default defineComponent({
@@ -319,11 +319,6 @@ export default defineComponent({
       }),
       headerSlotLabel: computed((): string => {
         return localState.searchType === UIMHRSearchTypes.MHRMHR_NUMBER ? 'Registration Number' : localState.searchType
-      }),
-      personOrOrgLabel: computed((): string => {
-        return getManufacturedHomeSearchResults.value?.searchQuery.type === APIMHRMapSearchTypes.MHRORGANIZATION_NAME
-          ? 'Organization'
-          : 'Owner'
       }),
       ownerOrOrgHeader: computed((): string => {
         const found = getManufacturedHomeSearchResults.value.results

--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -65,6 +65,14 @@
           return-object
         >
 
+          <template v-if="!isReviewMode" v-slot:[`header.ownerName`]>
+            <span>{{ ownerOrOrgHeader }} Name</span>
+          </template>
+
+          <template v-if="!isReviewMode" v-slot:[`header.ownerStatus`]>
+            <span>{{ ownerOrOrgHeader }} Status</span>
+          </template>
+
           <template  v-if="!isReviewMode" v-slot:[headerSearchTypeSlot]>
             <v-tooltip
               top
@@ -95,10 +103,6 @@
               {{ personOrOrgLabel }} Name
             </span>
             <span v-else class="pl-8">{{ headerSlotLabel }}</span>
-          </template>
-
-          <template  v-slot:[`header.ownerStatus`]>
-            <span>{{ personOrOrgLabel }} Status</span>
           </template>
 
           <template  v-if="!isReviewMode" v-slot:[`header.edit`]>
@@ -320,6 +324,12 @@ export default defineComponent({
         return getManufacturedHomeSearchResults.value?.searchQuery.type === APIMHRMapSearchTypes.MHRORGANIZATION_NAME
           ? 'Organization'
           : 'Owner'
+      }),
+      ownerOrOrgHeader: computed((): string => {
+        const found = getManufacturedHomeSearchResults.value.results
+        if (found) {
+          return found[0]?.organizationName ? 'Organization' : 'Owner'
+        } else return ''
       }),
       areAllSelected: computed((): boolean => {
         return localState.results?.every(result => result && result.selected === true)


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Added function to check if the result of an MHR search should have "Organization" or "Owner" headers. Made the table header slots adaptive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
