### PR TITLE
Update location persistence for new registrations.

### DIFF
--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -55,7 +55,17 @@
         <tr class="no-page-break">
             <td class="col-33">
                 <div class="section-sub-title">Location Type</div>
-                <div class="pt-2">N/A</div>
+                <div class="pt-2">
+                    {% if location.locationType is defined and location.locationType == 'RESERVE' %}
+                        INDIAN RESERVE
+                    {% elif location.locationType is defined and location.locationType == 'STRATA' %}
+                        STRATA
+                    {% elif location.locationType is defined and location.locationType == 'OTHER' %}
+                        OTHER
+                    {% else %}
+                        N/A 
+                    {% endif %} 
+                </div>
             </td>
             <td class="col-33">
                 <div class="section-sub-title">Address</div>
@@ -83,10 +93,22 @@
         </tr>
     {% endif %}
 
-    {% if location.hasLTSAInfo or (location.additionalDescription is defined and location.additionalDescription != '') %}
+    {% if location.legalDescription is defined and location.legalDescription != '' %}
     <tr class="no-page-break">
         <td class="pt-3 pb-2">
-            <div class="section-sub-title">Legal Description</div>
+            <div class="section-sub-title">Legal Land Description</div>
+        </td>
+    </tr>
+    <tr class="no-page-break">
+        <td colspan="3">
+            {% if location.locationType is defined and location.locationType == 'STRATA' %}STRATA {% endif %}
+            {{ location.legalDescription }}
+        </td>
+    </tr>
+    {% elif location.hasLTSAInfo or (location.additionalDescription is defined and location.additionalDescription != '') %}
+    <tr class="no-page-break">
+        <td class="pt-3 pb-2">
+            <div class="section-sub-title">Legal Land Description</div>
         </td>
     </tr>
     <tr class="no-page-break">

--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -34,6 +34,7 @@ from .financing_statement import FinancingStatement
 from .general_collateral import GeneralCollateral
 from .mhr_draft import MhrDraft
 from .mhr_extra_registration import MhrExtraRegistration
+from .mhr_location import MhrLocation
 from .mhr_party import MhrParty
 from .mhr_registration import MhrRegistration
 from .mhr_registration_report import MhrRegistrationReport
@@ -53,6 +54,7 @@ from .type_tables import (
     SerialType,
     StateType,
     MhrDocumentType,
+    MhrLocationType,
     MhrNoteStatusType,
     MhrOwnerStatusType,
     MhrPartyType,
@@ -68,9 +70,9 @@ __all__ = ('db',
            'Db2Cmpserno', 'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manufact', 'Db2Manuhome',
            'Db2Mhomnote', 'Db2Owner', 'Db2Owngroup',
            'EventTracking', 'EventTrackingType', 'FinancingStatement', 'GeneralCollateral', 'MhrDraft',
-           'MhrExtraRegistration', 'MhrParty', 'MhrRegistration', 'MhrRegistrationReport',
-           'MhrDocumentType', 'MhrNoteStatusType', 'MhrOwnerStatusType', 'MhrPartyType', 'MhrRegistrationStatusType',
-           'MhrRegistrationType', 'MhrStatusType', 'MhrTenancyType',
+           'MhrExtraRegistration', 'MhrLocation', 'MhrParty', 'MhrRegistration', 'MhrRegistrationReport',
+           'MhrDocumentType', 'MhrLocationType', 'MhrNoteStatusType', 'MhrOwnerStatusType', 'MhrPartyType',
+           'MhrRegistrationStatusType', 'MhrRegistrationType', 'MhrStatusType', 'MhrTenancyType',
            'Party', 'PartyType', 'ProvinceType', 'Registration', 'RegistrationType',
            'RegistrationTypeClass', 'SearchRequest', 'SearchResult', 'SearchType', 'StateType', 'SerialType',
            'TrustIndenture', 'VehicleCollateral')

--- a/mhr_api/src/mhr_api/models/address.py
+++ b/mhr_api/src/mhr_api/models/address.py
@@ -44,6 +44,7 @@ class Address(db.Model):  # pylint: disable=too-many-instance-attributes
     country_type = db.relationship('CountryType', foreign_keys=[country],
                                    back_populates='address', cascade='all, delete', uselist=False)
     mhr_party = db.relationship('MhrParty', uselist=False, back_populates='address')
+    mhr_location = db.relationship('MhrLocation', uselist=False, back_populates='address')
 
     def save(self):
         """Save the object to the database immediately. Only used for unit testing."""

--- a/mhr_api/src/mhr_api/models/db2/location.py
+++ b/mhr_api/src/mhr_api/models/db2/location.py
@@ -299,7 +299,7 @@ class Db2Location(db.Model):
                                additional_description=new_info.get('additionalDescription', ''))
 
         if new_info.get('taxCertificateDate', None):
-            location.tax_certificate_date = model_utils.date_from_date_iso_format(new_info.get('taxCertificateDate'))
+            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxCertificateDate'))
 
         return location
 
@@ -322,8 +322,8 @@ class Db2Location(db.Model):
                                reg_document_id=reg_json.get('documentId', ''),
                                can_document_id='',
                                street_number=street_num,
-                               street_name=street_name[0:24],
-                               town_city=str(address['city'])[0:19],
+                               street_name=street_name[0:25],
+                               town_city=str(address['city'])[0:20],
                                province=address.get('region', ''),
                                area='',
                                jurisdiction='',
@@ -352,7 +352,7 @@ class Db2Location(db.Model):
         if new_info.get('taxCertificate'):
             location.tax_certificate = 'Y'
         if new_info.get('taxCertificateDate', None):
-            location.tax_certificate_date = model_utils.date_from_date_iso_format(new_info.get('taxCertificateDate'))
+            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxCertificateDate'))
         else:
             location.tax_certificate_date = model_utils.date_from_iso_format('0001-01-01')
         return location

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -338,6 +338,17 @@ class Db2Manuhome(db.Model):
                                                                                Db2Document.DocumentTypes.MHREG,
                                                                                now_local))
         manuhome.reg_location = Db2Location.create_from_registration(registration, reg_json)
+        # Adjust location address info.
+        address = reg_json['location']['address']
+        extra: str = ''
+        if len(address.get('street')) > 31:
+            extra = str(address['street'])[31:]
+        if address.get('streetAdditional'):
+            extra += ' ' + str(address.get('streetAdditional')).strip()
+        manuhome.reg_location.additional_description = extra.strip() + ' ' + \
+            manuhome.reg_location.additional_description
+        if len(manuhome.reg_location.additional_description) > 80:
+            manuhome.reg_location.additional_description = manuhome.reg_location.additional_description[0:80]
         manuhome.reg_descript = Db2Descript.create_from_registration(registration, reg_json)
         if reg_json.get('ownerGroups'):
             for i, group in enumerate(reg_json.get('ownerGroups')):

--- a/mhr_api/src/mhr_api/models/mhr_location.py
+++ b/mhr_api/src/mhr_api/models/mhr_location.py
@@ -1,0 +1,217 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for MHR locations."""
+
+# from flask import current_app
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+
+from mhr_api.models import utils as model_utils
+
+from .db import db
+from .address import Address  # noqa: F401 pylint: disable=unused-import
+from .type_tables import MhrLocationTypes, MhrStatusTypes
+
+
+class MhrLocation(db.Model):  # pylint: disable=too-many-instance-attributes
+    """This class manages all of the MHR location information."""
+
+    __tablename__ = 'mhr_locations'
+
+    id = db.Column('id', db.Integer, db.Sequence('mhr_location_id_seq'), primary_key=True)
+    ltsa_description = db.Column('ltsa_description', db.String(1000), nullable=True)
+    additional_description = db.Column('additional_description', db.String(250), nullable=True)
+    dealer_name = db.Column('dealer_name', db.String(150), nullable=True)
+    exception_plan = db.Column('exception_plan', db.String(150), index=True, nullable=True)
+    leave_province = db.Column('leave_province', db.String(1), nullable=True)
+    tax_certification = db.Column('tax_certification', db.String(1), nullable=True)
+    tax_certification_date = db.Column('tax_certification_date', db.DateTime, nullable=True)
+    # LTSA specific properties.
+    park_name = db.Column('park_name', db.String(100), nullable=True)
+    park_pad = db.Column('park_pad', db.String(10), nullable=True)
+    pid_number = db.Column('pid_number', db.String(9), nullable=True)
+    lot = db.Column('lot', db.String(10), nullable=True)
+    parcel = db.Column('parcel', db.String(10), nullable=True)
+    block = db.Column('block', db.String(10), nullable=True)
+    district_lot = db.Column('district_lot', db.String(20), nullable=True)
+    part_of = db.Column('part_of', db.String(10), nullable=True)
+    section = db.Column('section', db.String(10), nullable=True)
+    township = db.Column('township', db.String(10), nullable=True)
+    range = db.Column('range', db.String(10), nullable=True)
+    meridian = db.Column('meridian', db.String(10), nullable=True)
+    land_district = db.Column('land_district', db.String(30), nullable=True)
+    plan = db.Column('plan', db.String(20), nullable=True)
+
+    # parent keys
+    address_id = db.Column('address_id', db.Integer, db.ForeignKey('addresses.id'), nullable=True, index=True)
+    registration_id = db.Column('registration_id', db.Integer, db.ForeignKey('mhr_registrations.id'), nullable=False,
+                                index=True)
+    change_registration_id = db.Column('change_registration_id', db.Integer, nullable=False, index=True)
+    location_type = db.Column('location_type', PG_ENUM(MhrLocationTypes),
+                              db.ForeignKey('mhr_location_types.location_type'), nullable=False)
+    status_type = db.Column('status_type', PG_ENUM(MhrStatusTypes),
+                            db.ForeignKey('mhr_status_types.status_type'), nullable=False)
+
+    # Relationships - Address
+    address = db.relationship('Address', foreign_keys=[address_id], uselist=False,
+                              back_populates='mhr_location', cascade='all, delete')
+    # Relationships - MhrRegistration
+    registration = db.relationship('MhrRegistration', foreign_keys=[registration_id],
+                                   back_populates='locations', cascade='all, delete', uselist=False)
+
+    @property
+    def json(self) -> dict:  # pylint: disable=too-many-branches
+        """Return the location as a json object."""
+        location = {
+            'locationId': self.id,
+            'status': self.status_type,
+            'locationType': self.location_type
+        }
+        if self.ltsa_description:
+            location['legalDescription'] = self.ltsa_description
+        if self.address:
+            location['address'] = self.address.json
+        if self.park_name:
+            location['parkName'] = self.park_name
+        if self.park_pad:
+            location['pad'] = self.park_pad
+        if self.pid_number:
+            location['pidNumber'] = self.pid_number
+        if self.lot:
+            location['lot'] = self.lot
+        if self.parcel:
+            location['parcel'] = self.parcel
+        if self.block:
+            location['block'] = self.block
+        if self.district_lot:
+            location['districtLot'] = self.district_lot
+        if self.part_of:
+            location['partOf'] = self.part_of
+        if self.section:
+            location['section'] = self.section
+        if self.township:
+            location['township'] = self.township
+        if self.range:
+            location['range'] = self.range
+        if self.meridian:
+            location['meridian'] = self.meridian
+        if self.land_district:
+            location['landDistrict'] = self.land_district
+        if self.plan:
+            location['plan'] = self.plan
+        if self.leave_province and self.leave_province == 'Y':
+            location['leaveProvince'] = True
+        else:
+            location['leaveProvince'] = False
+        if self.tax_certification and self.tax_certification == 'Y':
+            location['taxCertificate'] = True
+        else:
+            location['taxCertificate'] = False
+        if self.tax_certification_date:
+            location['taxCertificateDate'] = model_utils.format_ts(self.tax_certification_date)
+        if self.exception_plan:
+            location['exceptionPlan'] = self.exception_plan
+        if self.dealer_name:
+            location['dealerName'] = self.dealer_name
+        if self.additional_description:
+            location['additionalDescription'] = self.additional_description
+        return location
+
+    @classmethod
+    def find_by_id(cls, location_id: int = None):
+        """Return a location object by location ID."""
+        location = None
+        if location_id:
+            location = cls.query.get(location_id)
+
+        return location
+
+    @classmethod
+    def find_by_registration_id(cls, registration_id: int = None):
+        """Return a list of location objects by registration id."""
+        locations = None
+        if registration_id:
+            locations = cls.query.filter(MhrLocation.registration_id == registration_id) \
+                                 .order_by(MhrLocation.id).all()
+
+        return locations
+
+    @classmethod
+    def find_by_change_registration_id(cls, registration_id: int = None):
+        """Return a list of location objects by change registration id."""
+        locations = None
+        if registration_id:
+            locations = cls.query.filter(MhrLocation.change_registration_id == registration_id) \
+                                 .order_by(MhrLocation.id).all()
+
+        return locations
+
+    @staticmethod
+    def create_from_json(json_data,  # pylint: disable=too-many-statements, too-many-branches
+                         registration_id: int = None):
+        """Create a location object from a json schema object: map json to db."""
+        # current_app.logger.info(json_data)
+        location: MhrLocation = MhrLocation()
+        location.location_type = json_data.get('locationType', MhrLocationTypes.OTHER)
+        location.status_type = MhrStatusTypes.ACTIVE
+        location.address = Address.create_from_json(json_data['address'])
+        if registration_id:
+            location.registration_id = registration_id
+            location.change_registration_id = registration_id
+        if 'legalDescription' in json_data:
+            location.ltsa_description = json_data['legalDescription'].strip()
+        if 'parkName' in json_data:
+            location.park_name = json_data['parkName'].strip()
+        if 'pad' in json_data:
+            location.park_pad = json_data['pad'].strip()
+        if 'pidNumber' in json_data:
+            location.pid_number = json_data['pidNumber'].strip()
+        if 'parcel' in json_data:
+            location.parcel = json_data['parcel'].strip()
+        if 'block' in json_data:
+            location.block = json_data['block'].strip()
+        if 'districtLot' in json_data:
+            location.district_lot = json_data['districtLot'].strip()
+        if 'partOf' in json_data:
+            location.part_of = json_data['partOf'].strip()
+        if 'section' in json_data:
+            location.section = json_data['section'].strip()
+        if 'township' in json_data:
+            location.township = json_data['township'].strip()
+        if 'range' in json_data:
+            location.range = json_data['range'].strip()
+        if 'meridian' in json_data:
+            location.meridian = json_data['meridian'].strip()
+        if 'landDistrict' in json_data:
+            location.land_district = json_data['landDistrict'].strip()
+        if 'plan' in json_data:
+            location.plan = json_data['plan'].strip()
+        if 'exceptionPlan' in json_data:
+            location.exception_plan = json_data['exceptionPlan'].strip()
+        if 'dealerName' in json_data:
+            location.dealer_name = json_data['dealerName'].strip()
+        if 'additionalDescription' in json_data:
+            location.additional_description = json_data['additionalDescription'].strip()
+        if json_data.get('leaveProvince'):
+            location.leave_province = 'Y'
+        else:
+            location.leave_province = 'N'
+        if json_data.get('taxCertificate'):
+            location.tax_certification = 'Y'
+        else:
+            location.tax_certification = 'N'
+
+        if json_data.get('taxCertificateDate', None):
+            location.tax_certification_date = model_utils.ts_from_iso_format(json_data.get('taxCertificateDate'))
+
+        return location

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -211,6 +211,16 @@ class MhrDocumentTypes(BaseEnum):
     WILL = 'WILL'
 
 
+class MhrLocationTypes(BaseEnum):
+    """Render an Enum of the MHR location types."""
+
+    MANUFACTURER = 'MANUFACTURER'
+    MH_DEALER = 'MH_DEALER'
+    OTHER = 'OTHER'
+    RESERVE = 'RESERVE'
+    STRATA = 'STRATA'
+
+
 class MhrNoteStatusTypes(BaseEnum):
     """Render an Enum of the MHR note status types."""
 
@@ -290,6 +300,22 @@ class MhrDocumentType(db.Model):  # pylint: disable=too-few-public-methods
         if not doc_type or doc_type not in MhrDocumentTypes:
             return None
         return cls.query.filter(MhrDocumentType.document_type == doc_type).one_or_none()
+
+
+class MhrLocationType(db.Model):  # pylint: disable=too-few-public-methods
+    """This class defines the model for the mhr_location_types table."""
+
+    __tablename__ = 'mhr_location_types'
+
+    location_type = db.Column('location_type', PG_ENUM(MhrLocationTypes), primary_key=True)
+    location_type_desc = db.Column('location_type_desc', db.String(100), nullable=False)
+
+    # Relationships -
+
+    @classmethod
+    def find_all(cls):
+        """Return all the type records."""
+        return db.session.query(MhrLocationType).all()
 
 
 class MhrNoteStatusType(db.Model):  # pylint: disable=too-few-public-methods

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -18,7 +18,7 @@ from http import HTTPStatus
 from flask import request, current_app, g
 
 from mhr_api.exceptions import DatabaseException
-from mhr_api.models import EventTracking, MhrRegistration, MhrRegistrationReport, Db2Manuhome
+from mhr_api.models import EventTracking, MhrRegistration, MhrRegistrationReport
 from mhr_api.models import utils as model_utils
 from mhr_api.reports import get_pdf  # get_callback_pdf, get_report_api_payload
 from mhr_api.resources import utils as resource_utils
@@ -84,11 +84,6 @@ def pay_and_save_registration(req: request, request_json, account_id: str, trans
     # Try to save the financing statement: failure throws an exception.
     try:
         registration.save()
-        use_legacy_db: bool = current_app.config.get('USE_LEGACY_DB', True)
-        if use_legacy_db:
-            manuhome: Db2Manuhome = Db2Manuhome.create_from_registration(registration, request_json)
-            manuhome.save()
-            registration.manuhome = manuhome
     except Exception as db_exception:   # noqa: B902; handle all db related errors.
         current_app.logger.error(SAVE_ERROR_MESSAGE.format(account_id, 'registration', str(db_exception)))
         if account_id and invoice_id is not None:

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -88,14 +88,7 @@ def post_registrations():  # pylint: disable=too-many-return-statements
                                                            request_json,
                                                            account_id,
                                                            TransactionTypes.REGISTRATION)
-        response_json = {}
-        if registration.manuhome:
-            response_json = registration.manuhome.new_registration_json
-            if request_json.get('submittingParty'):
-                response_json['submittingParty'] = request_json.get('submittingParty')
-            response_json = reg_utils.add_payment_json(registration, response_json)
-        else:
-            response_json = registration.json
+        response_json = registration.new_registration_json
 
         # Return report if request header Accept MIME type is application/pdf.
         if resource_utils.is_pdf(request):

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -18,6 +18,7 @@ Validation includes verifying the data combination for various registrations/fil
 from flask import current_app
 
 from mhr_api.models import MhrRegistration
+from mhr_api.models.type_tables import MhrLocationTypes
 from mhr_api.models.utils import is_legacy
 from mhr_api.utils import valid_charset
 
@@ -46,7 +47,11 @@ def validate_registration(json_data, is_staff: bool = False):
             for owner in group.get('owners'):
                 error_msg += validate_owner(owner)
     error_msg += validate_location(json_data)
-    error_msg += validate_registration_legacy(json_data)
+    # Remove default locationType when schema validation update in place.
+    if json_data.get('location'):
+        location = json_data['location']
+        if not location.get('locationType') or location.get('locationType') not in MhrLocationTypes:
+            location['locationType'] = MhrLocationTypes.OTHER
     return error_msg
 
 

--- a/mhr_api/tests/unit/models/test_mhr_location.py
+++ b/mhr_api/tests/unit/models/test_mhr_location.py
@@ -1,0 +1,168 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the MHR location Model.
+
+Test-Suite to ensure that the MHR location Model is working as expected.
+"""
+import copy
+
+import pytest
+from registry_schemas.example_data.mhr import REGISTRATION
+
+from mhr_api.models import MhrLocation
+from mhr_api.models.type_tables import MhrLocationTypes, MhrStatusTypes
+
+
+# testdata pattern is ({id}, {has_results})
+TEST_ID_DATA = [
+    (200000000, True),
+    (300000000, False)
+]
+LTSA_DESCRIPTION = 'LOT 1 DISTRICT LOT 16 QUEEN CHARLOTTE DISTRICT PLAN PRP14213'
+TEST_LOCATION = MhrLocation(id=1,
+    location_type=MhrLocationTypes.OTHER,
+    status_type=MhrStatusTypes.ACTIVE,
+    ltsa_description=LTSA_DESCRIPTION,
+    park_name='LAZY WHEEL MOBILE HOME PARK',
+    park_pad='37',
+    pid_number='012777846',
+    lot='54',
+    parcel='A 1',
+    block='block',
+    district_lot='1535',
+    part_of='part',
+    section='N.E. 6',
+    township='9',
+    range='range',
+    meridian='merid',
+    land_district='PEACE RIVER',
+    plan='25262',
+    tax_certification='Y',
+    leave_province='N',
+    exception_plan='except',
+    dealer_name='dealer',
+    additional_description='additional',
+    address_id=1)
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_id(session, id, has_results):
+    """Assert that find location by location ID contains all expected elements."""
+    location: MhrLocation = MhrLocation.find_by_id(id)
+    if has_results:
+        assert location
+        assert location.id == 200000000
+        assert location.registration_id == 200000000
+        assert location.change_registration_id == 200000000
+        assert location.address_id > 0
+        assert location.location_type == MhrLocationTypes.OTHER
+        assert location.status_type == MhrStatusTypes.ACTIVE
+        assert location.ltsa_description
+        assert location.additional_description == 'additional'
+        assert location.dealer_name == 'dealer'
+        assert location.exception_plan == 'except'
+        assert location.leave_province == 'N'
+        assert location.tax_certification == 'Y'
+        assert location.tax_certification_date
+        assert location.park_name == 'park name'
+        assert location.park_pad == 'pad'
+        assert location.pid_number == '123456789'
+        assert location.lot == 'lot'
+        assert location.parcel == 'parcel'
+        assert location.block == 'block'
+        assert location.district_lot == 'dist lot'
+        assert location.part_of == 'part of'
+        assert location.section == 'section'
+        assert location.township == 'town'
+        assert location.range == 'range'
+        assert location.meridian == 'merid'
+        assert location.land_district == 'land district'
+        assert location.plan == 'plan'
+    else:
+        assert not location
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_registration_id(session, id, has_results):
+    """Assert that find location by registration id contains all expected elements."""
+    locations = MhrLocation.find_by_registration_id(id)
+    if has_results:
+        assert locations
+        assert len(locations) == 1
+        assert locations[0].location_type == MhrLocationTypes.OTHER
+    else:
+        assert not locations
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_change_registration_id(session, id, has_results):
+    """Assert that find location by change registration id contains all expected elements."""
+    locations = MhrLocation.find_by_change_registration_id(id)
+    if has_results:
+        assert locations
+        assert len(locations) == 1
+        assert locations[0].location_type == MhrLocationTypes.OTHER
+    else:
+        assert not locations
+
+
+def test_location_json(session):
+    """Assert that the location model renders to a json format correctly."""
+    location: MhrLocation = TEST_LOCATION
+    location_json = {
+        'locationId': location.id,
+        'status': location.status_type,
+        'locationType': location.location_type,
+        'legalDescription': location.ltsa_description,
+        'parkName': location.park_name,
+        'pad': location.park_pad,
+        'pidNumber': location.pid_number,
+        'lot': location.lot,
+        'parcel': location.parcel,
+        'block': location.block,
+        'districtLot': location.district_lot,
+        'partOf': location.part_of,
+        'section': location.section,
+        'township': location.township,
+        'range': location.range,
+        'meridian': location.meridian,
+        'landDistrict': location.land_district,
+        'plan': location.plan,
+        'leaveProvince': False,
+        'taxCertificate': True,
+        'exceptionPlan': location.exception_plan,
+        'dealerName': location.dealer_name,
+        'additionalDescription': location.additional_description
+    }
+    assert location.json == location_json
+
+
+def test_create_from_json(session):
+    """Assert that the new MHR location is created from json data correctly."""
+    json_data = copy.deepcopy(REGISTRATION)
+    loc_json = json_data.get('location')
+    loc_json['locationType'] = MhrLocationTypes.MH_DEALER
+    loc_json['legalDescription'] = LTSA_DESCRIPTION
+    location: MhrLocation = MhrLocation.create_from_json(loc_json, 1000)
+    assert location
+    assert location.registration_id == 1000
+    assert location.change_registration_id == 1000
+    assert location.location_type == MhrLocationTypes.MH_DEALER
+    assert location.status_type == MhrStatusTypes.ACTIVE
+    assert location.ltsa_description == LTSA_DESCRIPTION
+    assert location.park_name
+    assert location.park_pad
+    assert location.address
+    assert location.dealer_name

--- a/mhr_api/tests/unit/models/test_types.py
+++ b/mhr_api/tests/unit/models/test_types.py
@@ -91,3 +91,13 @@ def test_mhr_document_type(session):
     assert doc_result.legacy_fee_code == 'MHR400'
     doc_result = type_tables.MhrDocumentType.find_by_doc_type('XXX')
     assert not doc_result
+
+
+def test_mhr_location_type(session):
+    """Assert that MhrLocationType.find_all() contains all expected elements."""
+    results = type_tables.MhrLocationType.find_all()
+    assert results
+    assert len(results) >= 5
+    for result in results:
+        assert result.location_type in type_tables.MhrLocationTypes
+        assert result.location_type_desc

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -58,9 +58,9 @@ TEST_CHECKSUM_DATA = [
 # testdata pattern is ({description}, {valid}, {street}, {city}, {message content})
 TEST_LEGACY_REG_DATA = [
     (DESC_VALID, True, '0123456789012345678901234567890', '01234567890123456789', None),
-    ('Invalid location street too long', False, '01234567890123456789012345678901', 'KAMLOOPS',
+    ('Valid location street long', True, '01234567890123456789012345678901', 'KAMLOOPS',
      validator.LEGACY_ADDRESS_STREET_TOO_LONG.format(add_desc='Location')),
-    ('Invalid location city too long', False, '1234 Front St.', '012345678901234567890',
+    ('Valid location city long', True, '1234 Front St.', '012345678901234567890',
      validator.LEGACY_ADDRESS_CITY_TOO_LONG.format(add_desc='Location'))
 ]
 # testdata pattern is ({description}, {bus_name}, {first}, {middle}, {last}, {message content})


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13527

*Description of changes:*
- Save location information to Postgres and DB2
- Save standard address, locationType, legalDescription to Postgres
- Use Postgres locations table as source for API responses and reports
- Move conditional DB2 persistence code from registration resource to registration model
- Update reg report template to add locationType, legalDescription


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
