### PR TITLE
Manually add MHR to the registration table

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -168,16 +168,17 @@ import {
   DraftResultIF,
   ErrorIF,
   RegistrationSortIF,
+  MhRegistrationSummaryIF,
   RegistrationSummaryIF,
   RegistrationTypeIF,
   RegTableNewItemI,
   StateModelIF,
-  UserSettingsIF,
-  MhRegistrationSummaryIF
+  UserSettingsIF
 } from '@/interfaces'
 import { APIStatusTypes, ErrorCategories, RouteNames, SettingOptions, TableActions } from '@/enums'
 import {
   addRegistrationSummary,
+  addMHRegistrationSummary,
   convertDate,
   deleteDraft, deleteRegistrationSummary, draftHistory,
   getMHRegistrationSummary, getRegistrationSummary, registrationHistory,
@@ -188,6 +189,7 @@ import {
   registrationAddErrorDialog,
   registrationAlreadyAddedDialog,
   registrationFoundDialog,
+  mhRegistrationFoundDialog,
   registrationNotFoundDialog,
   registrationRestrictedDialog, renewConfirmationDialog, tableDeleteDialog, tableRemoveDialog
 } from '@/resources/dialogOptions'
@@ -361,15 +363,20 @@ export default defineComponent({
       localState.loading = true
       localState.myRegAddDialog = null
       regNum = regNum.trim()
-      const reg = await props.isMhr ? getMHRegistrationSummary(regNum, false) : getRegistrationSummary(regNum, false)
+      const reg = props.isMhr
+        ? await getMHRegistrationSummary(regNum, false)
+        : await getRegistrationSummary(regNum, false)
       if (!reg.error) {
-        myRegAddFoundSetDialog(regNum, reg)
+        props.isMhr
+          ? myMHRegAddFoundSetDialog(regNum, reg as MhRegistrationSummaryIF)
+          : myRegAddFoundSetDialog(regNum, reg as RegistrationSummaryIF)
       } else {
         myRegAddErrSetDialog(reg.error)
       }
       localState.loading = false
     }
 
+    // PPR Found Dialog
     const myRegAddFoundSetDialog = (searchedRegNum: string, reg: RegistrationSummaryIF): void => {
       localState.myRegAddDialog = Object.assign({ ...registrationFoundDialog })
       searchedRegNum = searchedRegNum?.trim()?.toUpperCase()
@@ -408,6 +415,44 @@ export default defineComponent({
       localState.myRegAddDialogDisplay = true
     }
 
+    // MHR Found Dialog
+    const myMHRegAddFoundSetDialog = (searchedRegNum: string, reg: MhRegistrationSummaryIF): void => {
+      localState.myRegAddDialog = Object.assign({ ...mhRegistrationFoundDialog })
+      // if the searched registration is a child of the base registration
+      if (searchedRegNum !== reg.mhrNumber) {
+        localState.myRegAddDialog.text = `The registration number you entered (<b>${searchedRegNum}</b>) ` +
+          'is associated with the following MHR number. Would you like to add this MHR registration to ' +
+          'your table? Adding the MHR registration to your table will automatically include all ' +
+          'associated registrations.'
+      }
+      localState.myRegAddDialog.textExtra = [
+        '<b>MHR Number:</b> ',
+        '<b>MH Registration Date:</b> ',
+        '<b>Registration Type:</b> ',
+        '<b>Submitting Party:</b> '
+      ]
+      localState.myRegAddDialog.textExtra[0] += reg.mhrNumber
+      if (reg.createDateTime) {
+        const createDate = new Date(reg.createDateTime)
+        localState.myRegAddDialog.textExtra[1] += convertDate(createDate, false, false)
+      } else {
+        localState.myRegAddDialog.textExtra[1] += 'N/A'
+      }
+      const regType = AllRegistrationTypes.find((regType: RegistrationTypeIF) => {
+        if (regType.registrationTypeAPI === reg.statusType) {
+          return true
+        }
+      })
+      if (regType) {
+        localState.myRegAddDialog.textExtra[2] += regType.registrationTypeUI
+      } else {
+        // Just in case some type gets added/changed and is not picked up by the UI.
+        localState.myRegAddDialog.textExtra[2] += 'Legacy'
+      }
+      localState.myRegAddDialog.textExtra[3] += reg.submittingParty
+      localState.myRegAddDialogDisplay = true
+    }
+
     const myRegAddErrSetDialog = (error: ErrorIF): void => {
       localState.myRegAddDialogError = error.statusCode
       const regNum = localState.myRegAdd?.trim()?.toUpperCase()
@@ -440,7 +485,7 @@ export default defineComponent({
       // add registration or not
       if (val && !localState.myRegAddDialogError &&
         (localState.myRegAddDialog.title === 'Registration Found')) {
-        addRegistration(localState.myRegAdd)
+        props.isMhr ? addMHRegistration(localState.myRegAdd) : addRegistration(localState.myRegAdd)
       }
       // reset values
       if (localState.myRegAddDialogError !== StatusCodes.NOT_FOUND) {
@@ -450,6 +495,7 @@ export default defineComponent({
       localState.myRegAddDialogDisplay = false
     }
 
+    // Add PPR summary to registration table
     const addRegistration = async (regNum: string): Promise<void> => {
       localState.loading = true
       const addReg = await addRegistrationSummary(regNum)
@@ -461,6 +507,30 @@ export default defineComponent({
         if (regNum.toUpperCase() !== addReg.registrationNumber.toUpperCase()) {
         // not a base registration so add parent reg num
           parentRegNum = addReg.registrationNumber.toUpperCase()
+        }
+        const newRegItem: RegTableNewItemI = {
+          addedReg: regNum.toUpperCase(),
+          addedRegParent: parentRegNum,
+          addedRegSummary: addReg,
+          prevDraft: ''
+        }
+        setRegTableNewItem(newRegItem)
+      }
+      localState.loading = false
+    }
+
+    // Add MHR summary to registration table
+    const addMHRegistration = async (regNum: string): Promise<void> => {
+      localState.loading = true
+      const addReg = await addMHRegistrationSummary(regNum)
+      if (addReg.error) {
+        myRegAddErrSetDialog(addReg.error)
+      } else {
+      // set new item (watcher will add it etc.)
+        let parentRegNum = ''
+        if (regNum !== addReg.mhrNumber) {
+        // not a base registration so add parent reg num
+          parentRegNum = addReg.mhrNumber
         }
         const newRegItem: RegTableNewItemI = {
           addedReg: regNum.toUpperCase(),

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -73,7 +73,7 @@
               @keypress.enter="findRegistration(myRegAdd)"
             />
             <p v-if="myRegAddInvalid" class="validation-msg mx-3 my-1">
-              Registration numbers contain 7 characters
+              Registration numbers contain {{ isMhr ? '6' : '7' }} characters
             </p>
           </v-col>
         </v-row>
@@ -180,7 +180,7 @@ import {
   addRegistrationSummary,
   convertDate,
   deleteDraft, deleteRegistrationSummary, draftHistory,
-  getRegistrationSummary, registrationHistory,
+  getMHRegistrationSummary, getRegistrationSummary, registrationHistory,
   setupFinancingStatementDraft, updateUserSettings
 } from '@/utils'
 import {
@@ -278,7 +278,8 @@ export default defineComponent({
         return []
       }),
       myRegAddInvalid: computed((): boolean => {
-        return ![0, 7].includes(
+        const maxLength = props.isMhr ? 6 : 7
+        return ![0, maxLength].includes(
           localState.myRegAdd?.trim().length || 0) || (localState.myRegAdd && !localState.myRegAdd?.trim()
         )
       }),
@@ -360,7 +361,7 @@ export default defineComponent({
       localState.loading = true
       localState.myRegAddDialog = null
       regNum = regNum.trim()
-      const reg = await getRegistrationSummary(regNum, false)
+      const reg = await props.isMhr ? getMHRegistrationSummary(regNum, false) : getRegistrationSummary(regNum, false)
       if (!reg.error) {
         myRegAddFoundSetDialog(regNum, reg)
       } else {

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
@@ -85,6 +85,8 @@ export interface RegistrationSummaryIF {
 }
 
 export interface MhRegistrationSummaryIF {
+  inUserList?: boolean, // whether the registration is in their table or not
+  error?: ErrorIF,
   clientReferenceId: string
   createDateTime: string
   mhrNumber: string

--- a/ppr-ui/src/interfaces/store-interfaces/state-interfaces/reg-table-data-interface.ts
+++ b/ppr-ui/src/interfaces/store-interfaces/state-interfaces/reg-table-data-interface.ts
@@ -13,6 +13,6 @@ export interface RegTableDataI {
 export interface RegTableNewItemI {
   addedReg: string // used for highlight / scroll to
   addedRegParent: string // used for expand
-  addedRegSummary: RegistrationSummaryIF | DraftResultIF // new item to add in table
+  addedRegSummary: RegistrationSummaryIF | MhRegistrationSummaryIF | DraftResultIF // new item to add in table
   prevDraft: string // used to remove previous draft
 }

--- a/ppr-ui/src/resources/dialogOptions/registrationAddDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/registrationAddDialogs.ts
@@ -16,6 +16,7 @@ export const registrationAlreadyAddedDialog: DialogOptionsIF = {
   text: '' // added in component (contains dynamic info)
 }
 
+// PPR dialog content
 export const registrationFoundDialog: DialogOptionsIF = {
   acceptText: 'Add to My Registrations Table',
   cancelText: 'Cancel',
@@ -23,6 +24,18 @@ export const registrationFoundDialog: DialogOptionsIF = {
   label: 'a Renewal',
   text: 'The following existing registration was found. Would you like to add ' +
     'it to your registrations table? Adding the base registration to your ' +
+    'registrations table will automatically include all associated registrations.',
+  textExtra: [] // added in component
+}
+
+// MHR dialog content
+export const mhRegistrationFoundDialog: DialogOptionsIF = {
+  acceptText: 'Add to My Registrations Table',
+  cancelText: 'Cancel',
+  title: 'Registration Found',
+  label: 'a Renewal',
+  text: 'The following existing registration was found. Would you like to add ' +
+    'it to your registrations table? Adding the MH registration to your ' +
     'registrations table will automatically include all associated registrations.',
   textExtra: [] // added in component
 }

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -6,7 +6,8 @@ import { StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import {
   ManufacturedHomeSearchResultIF,
   SearchResponseIF,
-  MhrSearchCriteriaIF
+  MhrSearchCriteriaIF,
+  RegistrationSummaryIF
 } from '@/interfaces'
 import { ErrorCategories, ErrorCodes } from '@/enums'
 import { useSearch } from '@/composables/useSearch'
@@ -93,6 +94,63 @@ function mhrStaffPaymentParameters (staffPayment: StaffPaymentIF) {
     }
   }
   return paymentParams
+}
+
+// Get registration summary information
+export async function getMHRegistrationSummary (
+  registrationNum: string,
+  refreshing: boolean
+): Promise<(RegistrationSummaryIF)> {
+  const url = sessionStorage.getItem('MHR_API_URL')
+  const config = { baseURL: url, headers: { Accept: 'application/json' } }
+
+  return axios
+    .get(`registrations/${registrationNum}`, config)
+    .then(response => {
+      const data = response?.data as RegistrationSummaryIF
+      if (!data) throw new Error('Invalid API response')
+      if (!refreshing && data.inUserList) {
+        data.error = {
+          statusCode: StatusCodes.CONFLICT,
+          message: 'Registration is already added to this account.'
+        }
+      }
+      return data
+    })
+    .catch(error => {
+      if (error?.response?.data) {
+        try {
+          error.response.data.rootCause = error.response.data.rootCause
+            .replace('detail:', '"detail":"')
+            .replace('type:', '"type":"')
+            .replace('message:', '"message":"')
+            .replace('status_code:', '"statusCode":"')
+            .replaceAll(',', '",')
+          error.response.data.rootCause = `{${error.response.data.rootCause}"}`
+          error.response.data.rootCause = JSON.parse(error.response.data.rootCause)
+        } catch (error) {
+          // continue
+        }
+      }
+      return {
+        baseRegistrationNumber: '',
+        createDateTime: '',
+        path: '',
+        registeringParty: '',
+        registrationClass: '',
+        registrationDescription: '',
+        registrationNumber: '',
+        registrationType: null,
+        securedParties: '',
+        error: {
+          category: ErrorCategories.HISTORY_REGISTRATIONS,
+          statusCode: error?.response?.status || StatusCodes.INTERNAL_SERVER_ERROR,
+          message: error?.response?.data?.message,
+          detail: error?.response?.data?.rootCause?.detail,
+          type: error?.response?.data?.rootCause?.type?.trim() as ErrorCodes
+        }
+      }
+    })
 }
 
 // Submit selected matches in mhr search results

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -7,10 +7,11 @@ import {
   ManufacturedHomeSearchResultIF,
   SearchResponseIF,
   MhrSearchCriteriaIF,
-  RegistrationSummaryIF
+  MhRegistrationSummaryIF
 } from '@/interfaces'
 import { ErrorCategories, ErrorCodes } from '@/enums'
 import { useSearch } from '@/composables/useSearch'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 const { mapMhrSearchType } = useSearch()
 
 // Submit an mhr search query request.
@@ -100,14 +101,15 @@ function mhrStaffPaymentParameters (staffPayment: StaffPaymentIF) {
 export async function getMHRegistrationSummary (
   registrationNum: string,
   refreshing: boolean
-): Promise<(RegistrationSummaryIF)> {
+): Promise<MhRegistrationSummaryIF> {
   const url = sessionStorage.getItem('MHR_API_URL')
   const config = { baseURL: url, headers: { Accept: 'application/json' } }
 
   return axios
-    .get(`registrations/${registrationNum}`, config)
+    .get(`other-registrations/${registrationNum}`, config)
     .then(response => {
-      const data = response?.data as RegistrationSummaryIF
+      const data = response?.data as MhRegistrationSummaryIF
+      console.log(data)
       if (!data) throw new Error('Invalid API response')
       if (!refreshing && data.inUserList) {
         data.error = {
@@ -133,17 +135,71 @@ export async function getMHRegistrationSummary (
         }
       }
       return {
-        baseRegistrationNumber: '',
+        clientReferenceId: '',
         createDateTime: '',
+        mhrNumber: '',
+        ownerNames: '',
         path: '',
-        registeringParty: '',
-        registrationClass: '',
         registrationDescription: '',
-        registrationNumber: '',
-        registrationType: null,
-        securedParties: '',
+        statusType: '',
+        submittingParty: '',
+        username: '',
         error: {
           category: ErrorCategories.HISTORY_REGISTRATIONS,
+          statusCode: error?.response?.status || StatusCodes.INTERNAL_SERVER_ERROR,
+          message: error?.response?.data?.message,
+          detail: error?.response?.data?.rootCause?.detail,
+          type: error?.response?.data?.rootCause?.type?.trim() as ErrorCodes
+        }
+      }
+    })
+}
+
+// Add MHR to My Registrations
+export async function addMHRegistrationSummary (registrationNum: string): Promise<MhRegistrationSummaryIF> {
+  const url = sessionStorage.getItem('MHR_API_URL')
+
+  const currentAccount = sessionStorage.getItem(SessionStorageKeys.CurrentAccount)
+  if (!currentAccount) console.error('Error: current account expected, but not found.')
+  const currentAccountId = JSON.parse(currentAccount)?.id
+
+  const config = { baseURL: url, headers: { Accept: 'application/json', 'Account-Id': currentAccountId } }
+
+  return axios
+    .post(`other-registrations/registrations/${registrationNum}`, {}, config)
+    .then(response => {
+      const data = response?.data as MhRegistrationSummaryIF
+      if (!data) {
+        throw new Error('Invalid API response')
+      }
+      return data
+    })
+    .catch(error => {
+      if (error?.response?.data) {
+        try {
+          error.response.data.rootCause = error.response.data.rootCause
+            .replace('detail:', '"detail":"')
+            .replace('type:', '"type":"')
+            .replace('message:', '"message":"')
+            .replace('status_code:', '"statusCode":"')
+            .replaceAll(',', '",')
+          error.response.data.rootCause = `{${error.response.data.rootCause}"}`
+          error.response.data.rootCause = JSON.parse(error.response.data.rootCause)
+        } catch (error) {
+          // continue
+        }
+      }
+      return {
+        clientReferenceId: '',
+        createDateTime: '',
+        mhrNumber: '',
+        ownerNames: '',
+        path: '',
+        registrationDescription: '',
+        statusType: '',
+        submittingParty: '',
+        username: '',
+        error: {
           statusCode: error?.response?.status || StatusCodes.INTERNAL_SERVER_ERROR,
           message: error?.response?.data?.message,
           detail: error?.response?.data?.rootCause?.detail,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13136

*Description of changes:*
- Update validation for MHR number retrieval
- GET and POST requests to add MHR to the registration table
- Based on the PPR flow

### Please Note:

This functionality needs to be tested in DEV because of the following:
- Searching for a registration number that's _already in the table_ returns a flag `inUserList: false` as if the record does not exists in the table
- `CURRENT_ACCOUNT` is not present in Session Storage, but it is needed for the POST request call to manually add MHR to the table
- CC: @doug-lovett 

### Screenshot of Registration Found dialog with MHR related content
 
<img width="1107" alt="Screen Shot 2022-09-22 at 4 56 20 PM" src="https://user-images.githubusercontent.com/2333290/191870806-f8e946b9-f31b-4df0-900f-24c8d4d237b6.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
