### PR TITLE
Fix clearing of Submitting Party address fields

### DIFF
--- a/ppr-ui/src/components/parties/party/PartyAutocomplete.vue
+++ b/ppr-ui/src/components/parties/party/PartyAutocomplete.vue
@@ -156,6 +156,8 @@ export default defineComponent({
         setRegisteringParty(newParty)
       } else if (props.isMhrPartySearch) {
         localState.selectedCode = newParty.code
+        // pre-set country code to prevent clearing of base-address component fields (bug 13637)
+        setMhrSubmittingParty({ key: 'address.country', value: newParty.address.country })
         // Set submitting party data to store
         for (const [key, value] of Object.entries(newParty)) {
           setMhrSubmittingParty({ key, value })

--- a/ppr-ui/src/store/mutations/mutations-model.ts
+++ b/ppr-ui/src/store/mutations/mutations-model.ts
@@ -32,6 +32,7 @@ import {
   MhRegistrationSummaryIF
 } from '@/interfaces'
 import { StaffPaymentIF } from '@bcrs-shared-components/interfaces'
+import { set } from 'lodash'
 
 export const mutateAccountProductSubscribtion = (
   state: StateIF, productSubscriptions: AccountProductSubscriptionIF
@@ -369,7 +370,7 @@ export const mutateMhrBaseInformation = (state: StateIF, { key, value }) => {
 }
 
 export const mutateMhrSubmittingParty = (state: StateIF, { key, value }) => {
-  state.stateModel.mhrRegistration.submittingParty[key] = value
+  set(state.stateModel.mhrRegistration.submittingParty, key, value)
 }
 
 export const mutateMhrRegistrationDocumentId = (state: StateIF, value: string) => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13637

*Description of changes:*

Fixes the issue when look-up address component clears the fields of base address component:

- Any time when Country is changed, the address fields are cleared. So when we manually enter the address and then do a lookup and select a business from dropdown, the change of the Country clears the address fields.
- It does not happen when manually entered Country is the same as the looked up business Country. Because the Country does not change, the address is pre-filled correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
