### PR TITLE
Reset all form validations upon MH registration submission

### DIFF
--- a/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
@@ -21,6 +21,25 @@ export const useMhrValidations = (validationState: any) => {
     return validationState.reviewConfirmValid.value.validateSteps && !validationState[section].value[component]
   }
 
+  /** Reset submission validations to default . */
+  const resetAllValidations = (): void => {
+    // Reset your home validations
+    setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.MAKE_MODEL_VALID, false)
+    setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_SECTION_VALID, false)
+    setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_CERTIFICATION_VALID, false)
+    setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.REBUILT_STATUS_VALID, false)
+    setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.OTHER_VALID, false)
+    // Reset submitting party validations
+    setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.SUBMITTER_VALID, false)
+    setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
+    setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.REF_NUM_VALID, false)
+    // Reset home owner validations
+    setValidation(MhrSectVal.HOME_OWNERS_VALID, MhrCompVal.OWNERS_VALID, false)
+    // Reset home location validations
+    setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, false)
+    setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, false)
+  }
+
   /** Is true when input field ref is in error. */
   const hasError = (ref: any): boolean => {
     return ref?.hasError
@@ -56,6 +75,7 @@ export const useMhrValidations = (validationState: any) => {
     getValidation,
     getSectionValidation,
     getStepValidation,
+    resetAllValidations,
     scrollToInvalid
   }
 }

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -184,6 +184,27 @@ export default defineComponent({
       localState.dataLoaded = true
     })
 
+    const resetAllValidations = (): void => {
+      // Reset your home validations
+      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.MAKE_MODEL_VALID, false)
+      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_SECTION_VALID, false)
+      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_CERTIFICATION_VALID, false)
+      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.REBUILT_STATUS_VALID, false)
+      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.OTHER_VALID, false)
+
+      // Reset submitting party validations
+      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.SUBMITTER_VALID, false)
+      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
+      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.REF_NUM_VALID, false)
+
+      // Reset home owner validations
+      setValidation(MhrSectVal.HOME_OWNERS_VALID, MhrCompVal.OWNERS_VALID, false)
+
+      // Reset home location validations
+      setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, false)
+      setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, false)
+    }
+
     const submit = async () => {
       // Prompt App Validations
       await setValidation(MhrSectVal.REVIEW_CONFIRM_VALID, MhrCompVal.VALIDATE_APP, true)
@@ -194,7 +215,7 @@ export default defineComponent({
         localState.submitting = true
         const mhrSubmission = await submitMhrRegistration(buildApiData(), parseStaffPayment())
         localState.submitting = false
-
+        resetAllValidations()
         mhrSubmission?.mhrNumber
           ? await context.root.$router.push({ name: RouteNames.DASHBOARD })
           : console.log(mhrSubmission?.error) // Handle Schema or Api errors here..

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -105,6 +105,7 @@ export default defineComponent({
       setValidation,
       getValidation,
       getStepValidation,
+      resetAllValidations,
       scrollToInvalid
     } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
 
@@ -183,27 +184,6 @@ export default defineComponent({
       context.emit('emitHaveData', true)
       localState.dataLoaded = true
     })
-
-    const resetAllValidations = (): void => {
-      // Reset your home validations
-      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.MAKE_MODEL_VALID, false)
-      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_SECTION_VALID, false)
-      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_CERTIFICATION_VALID, false)
-      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.REBUILT_STATUS_VALID, false)
-      setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.OTHER_VALID, false)
-
-      // Reset submitting party validations
-      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.SUBMITTER_VALID, false)
-      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
-      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.REF_NUM_VALID, false)
-
-      // Reset home owner validations
-      setValidation(MhrSectVal.HOME_OWNERS_VALID, MhrCompVal.OWNERS_VALID, false)
-
-      // Reset home location validations
-      setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, false)
-      setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, false)
-    }
 
     const submit = async () => {
       // Prompt App Validations


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- Added function resetAllValidations to reset the forms along the stepper once the MH registration is submitted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
