### PR TITLE
Made submitting party section valid only when Doc ID is valid

### DIFF
--- a/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
+++ b/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
@@ -193,9 +193,7 @@ export default defineComponent({
         const validateDocId: MhrDocIdResponseIF = await validateDocumentID(localState.documentId)
         localState.isUniqueDocId = !validateDocId.exists && validateDocId.valid
         localState.displayDocIdError = !localState.isUniqueDocId
-        localState.isVerifiedDocId
-          ? setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, true)
-          : setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
+        setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, localState.isVerifiedDocId)
       } else {
         localState.isUniqueDocId = false
         localState.displayDocIdError = false

--- a/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
+++ b/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
@@ -193,19 +193,19 @@ export default defineComponent({
         const validateDocId: MhrDocIdResponseIF = await validateDocumentID(localState.documentId)
         localState.isUniqueDocId = !validateDocId.exists && validateDocId.valid
         localState.displayDocIdError = !localState.isUniqueDocId
+        localState.isVerifiedDocId
+          ? setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, true)
+          : setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
       } else {
         localState.isUniqueDocId = false
         localState.displayDocIdError = false
+        setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, false)
       }
 
       localState.loadingDocId = false
       setMhrRegistrationDocumentId(val)
     }
     )
-
-    watch(() => localState.isDocumentIdValid, (val: boolean) => {
-      setValidation(MhrSectVal.SUBMITTING_PARTY_VALID, MhrCompVal.DOC_ID_VALID, val)
-    })
 
     watch(() => localState.validateDocId, async () => {
       // @ts-ignore - function exists


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- The stepper validation for submitting party section now relies on a valid Document ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
