### PR TITLE
Fix clearing Groups for Home Owner

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -401,8 +401,10 @@ export default defineComponent({
             props.isMhrTransfer
           )
         }
+
+        // this should occur when trying to add the group and fractional info
         // check if group has some fractional data
-        if (localState.groupFractionalData.interestNumerator) {
+        if (localState.groupFractionalData.interestNumerator && localState.ownerGroupId) {
           setShowGroups(true)
 
           // Get fractional data based on owner's group id
@@ -411,6 +413,14 @@ export default defineComponent({
           }) as FractionalOwnershipWithGroupIdIF
 
           setGroupFractionalInterest(localState.ownerGroupId || '1', fractionalData)
+        } else if (localState.group) {
+          // this condition should only occur when trying to delete a group
+          // clear out any fractional info
+          delete localState.group.type
+          delete localState.group.interest
+          delete localState.group.interestNumerator
+          delete localState.group.interestTotal
+          delete localState.group.tenancySpecified
         }
 
         cancel()

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
@@ -23,7 +23,7 @@
       filled
       @change="setOwnerGroupId($event)"
       :clearable="groupItems.length === 1"
-      @click:clear="groupDropdown.blur()"
+      @click:clear="removeGroupDropdownValidation == true && groupDropdown.blur()"
       :menu-props="{ bottom: true, offsetY: true }"
       data-test-id="owner-group-select"
     ></v-select>
@@ -95,14 +95,15 @@ export default defineComponent({
     const groupDropdown = ref(null)
 
     const { required } = useInputRules()
-    const { getGroupDropdownItems, showGroups } = useHomeOwners()
+    const { getGroupDropdownItems, showGroups, setShowGroups } = useHomeOwners()
     const homeOwnerGroups = [...getMhrRegistrationHomeOwnerGroups.value]
 
     const localState = reactive({
       ownerGroupId: props.groupId,
+      removeGroupDropdownValidation: false,
       groupItems: computed(() => getGroupDropdownItems(props.isAddingHomeOwner, props.groupId)),
       groupRules: computed(() => {
-        return showGroups.value ? required('Select a group for this owner') : []
+        return showGroups.value && localState.removeGroupDropdownValidation ? required('Select a group for this owner') : []
       }),
       groupFractionalData: find(getMhrRegistrationHomeOwnerGroups.value, { groupId: props.groupId }),
       fractionalInfo: computed(() => props.fractionalData),
@@ -127,6 +128,10 @@ export default defineComponent({
     })
 
     const setOwnerGroupId = (groupId: string): void => {
+      console.log(groupId)
+      if (groupId === undefined) {
+        setShowGroups(false)
+      }
       emit('setOwnerGroupId', groupId)
     }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
@@ -128,8 +128,7 @@ export default defineComponent({
     })
 
     const setOwnerGroupId = (groupId: string): void => {
-      console.log(groupId)
-      if (groupId === undefined) {
+      if (!groupId) {
         setShowGroups(false)
       }
       emit('setOwnerGroupId', groupId)

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -58,6 +58,7 @@
           <v-icon
             v-if="hasHomeOwners"
             color="green darken-2"
+            data-test-id="reg-owner-checkmark"
           >
             mdi-check
           </v-icon>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13713

*Description of changes:*
- Fix the ability to clear Groups for Home Owners (for only one Home Owner and one Group)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
