### PR TITLE
MHR api add account registration summary hierarchical results.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -142,6 +142,20 @@ class Db2Descript(db.Model):
             descript.strip()
         return descript
 
+    @classmethod
+    def find_by_doc_id(cls, reg_document_id: str):
+        """Return the description matching the document id."""
+        descript = None
+        if reg_document_id:
+            try:
+                descript = cls.query.filter(Db2Descript.reg_document_id == reg_document_id).one_or_none()
+            except Exception as db_exception:   # noqa: B902; return nicer error
+                current_app.logger.error('DB2 descript.find_by_doc_id exception: ' + str(db_exception))
+                raise DatabaseException(db_exception)
+        if descript:
+            descript.strip()
+        return descript
+
     @property
     def json(self):
         """Return a dict of this object, with keys in JSON format."""

--- a/mhr_api/src/mhr_api/models/db2/document.py
+++ b/mhr_api/src/mhr_api/models/db2/document.py
@@ -27,7 +27,9 @@ class Db2Document(db.Model):
     class DocumentTypes(BaseEnum):
         """Render an Enum of the legacy document types."""
 
+        CONV = 'CONV'
         MHREG = '101 '
+        MHREG_TRIM = '101'
         TRAND = 'DEAT'
         TRANS = 'TRAN'
 
@@ -125,12 +127,12 @@ class Db2Document(db.Model):
         return documents
 
     @classmethod
-    def find_by_doc_id(cls, document_id: str):
+    def find_by_doc_id(cls, doc_reg_id: str):
         """Return the document matching the document id."""
         document = None
-        if document_id:
+        if doc_reg_id:
             try:
-                document = cls.query.filter(Db2Document.id == document_id).one_or_none()
+                document = cls.query.filter(Db2Document.id == doc_reg_id).one_or_none()
             except Exception as db_exception:   # noqa: B902; return nicer error
                 current_app.logger.error('Db2Document.find_by_doc_id exception: ' + str(db_exception))
                 raise DatabaseException(db_exception)

--- a/mhr_api/src/mhr_api/models/db2/location.py
+++ b/mhr_api/src/mhr_api/models/db2/location.py
@@ -143,6 +143,20 @@ class Db2Location(db.Model):
             location.strip()
         return location
 
+    @classmethod
+    def find_by_doc_id(cls, reg_document_id: str):
+        """Return the location matching the document id."""
+        location = None
+        if reg_document_id:
+            try:
+                location = cls.query.filter(Db2Location.reg_document_id == reg_document_id).one_or_none()
+            except Exception as db_exception:   # noqa: B902; return nicer error
+                current_app.logger.error('DB2 location.find_by_doc_id exception: ' + str(db_exception))
+                raise DatabaseException(db_exception)
+        if location:
+            location.strip()
+        return location
+
     @property
     def json(self):
         """Return a dict of this object, with keys in JSON format."""

--- a/mhr_api/tests/unit/models/db2/test_descript.py
+++ b/mhr_api/tests/unit/models/db2/test_descript.py
@@ -30,6 +30,11 @@ TEST_DATA = [
     (True, 10, '1974', '3E3947', 2),
     (False, 0, None, None, 0)
 ]
+# testdata pattern is ({exists}, {manhomid}, {doc_reg_id})
+TEST_DATA_DOC_ID = [
+    (True, 1, 'REG22911'),
+    (False, 0, None)
+]
 
 
 @pytest.mark.parametrize('exists,manuhome_id,year,serial,count', TEST_DATA)
@@ -106,6 +111,18 @@ def test_find_by_manuhome_id_active(session, exists, manuhome_id, year, serial, 
             assert section['lengthInches'] == 0
             assert section['widthFeet']
             assert section['widthInches'] == 0
+    else:
+        assert not descript
+
+
+@pytest.mark.parametrize('exists,manuhome_id,doc_id', TEST_DATA_DOC_ID)
+def test_find_by_doc_id(session, exists, manuhome_id, doc_id):
+    """Assert that find descript by document id contains all expected elements."""
+    descript: Db2Descript = Db2Descript.find_by_doc_id(doc_id)
+    if exists:
+        assert descript
+        assert descript.reg_document_id == doc_id
+        assert descript.manuhome_id == manuhome_id
     else:
         assert not descript
 

--- a/mhr_api/tests/unit/models/db2/test_document.py
+++ b/mhr_api/tests/unit/models/db2/test_document.py
@@ -104,6 +104,42 @@ def test_find_by_mhr_number(session, exists, id, mhr_num, doc_type, doc_reg_id):
         assert not docs
 
 
+@pytest.mark.parametrize('exists,id,mhr_num,doc_type,doc_reg_id', TEST_DATA)
+def test_find_by_doc_id(session, exists, id, mhr_num, doc_type, doc_reg_id):
+    """Assert that find document by document id contains all expected elements."""
+    doc = Db2Document.find_by_doc_id(doc_reg_id)
+    if exists:
+        assert doc
+        assert doc.mhr_number == mhr_num
+        if doc.id == id:
+            assert doc.document_type == doc_type
+            assert doc.document_reg_id == doc_reg_id
+            assert doc.draft_ts is not None
+            assert doc.registration_ts is not None
+            assert doc.interimed is not None
+            assert doc.owner_cross_reference is not None
+            assert doc.interest_denominator is not None
+            assert doc.declared_value is not None
+            assert doc.own_land is not None
+            assert doc.routing_slip_number is not None
+            assert doc.last_service is not None
+            assert doc.bcol_account is not None
+            assert doc.dat_number is not None
+            assert doc.examiner_id is not None
+            assert doc.update_id is not None
+            assert doc.phone_number is not None
+            assert doc.attention_reference is not None
+            assert doc.legacy_address is not None
+            assert doc.number_of_pages is not None
+            assert doc.transfer_execution_date is not None
+            assert doc.consideration_value is not None
+            assert doc.affirm_by_name is not None
+            assert doc.liens_with_consent is not None
+            assert doc.client_reference_id is not None
+    else:
+        assert not doc
+
+
 def test_document_json(session):
     """Assert that the document renders to a json format correctly."""
     doc = Db2Document(mhr_number='022911',

--- a/mhr_api/tests/unit/models/db2/test_location.py
+++ b/mhr_api/tests/unit/models/db2/test_location.py
@@ -66,6 +66,11 @@ TEST_ADDRESS_DATA = [
     ('4004', 'POPLAR AVENUE', '4004 POPLAR AVENUE'),
     ('101-40', '04 POPLAR AVENUE', '101-4004 POPLAR AVENUE')
 ]
+# testdata pattern is ({exists}, {manhomid}, {doc_reg_id})
+TEST_DATA_DOC_ID = [
+    (True, 1, 'REG22911'),
+    (False, 0, None)
+]
 
 
 @pytest.mark.parametrize('exists,manuhome_id,park_name,pad,street_num,street,city,count', TEST_DATA)
@@ -101,7 +106,7 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, park_name, pad, stree
 
 
 @pytest.mark.parametrize('exists,manuhome_id,park_name,pad,street_num,street,city,count', TEST_DATA)
-def test_find_by_manuhome_id(session, exists, manuhome_id, park_name, pad, street_num, street, city, count):
+def test_find_by_manuhome_id_active(session, exists, manuhome_id, park_name, pad, street_num, street, city, count):
     """Assert that find locations by manuhome id contains all expected elements."""
     location: Db2Location = Db2Location.find_by_manuhome_id_active(manuhome_id)
     if exists:
@@ -147,6 +152,18 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, park_name, pad, stree
         assert reg_json['address']['region']
         assert reg_json['address']['country']
         assert reg_json['address']['postalCode'] is not None
+    else:
+        assert not location
+
+
+@pytest.mark.parametrize('exists,manuhome_id,doc_id', TEST_DATA_DOC_ID)
+def test_find_by_doc_id(session, exists, manuhome_id, doc_id):
+    """Assert that find location by document id contains all expected elements."""
+    location: Db2Location = Db2Location.find_by_doc_id(doc_id)
+    if exists:
+        assert location
+        assert location.reg_document_id == doc_id
+        assert location.manuhome_id == manuhome_id
     else:
         assert not location
 

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -178,6 +178,24 @@ def test_find_by_mhr_number(session, mhr_number, has_results, account_id):
         assert not_found_err
 
 
+@pytest.mark.parametrize('mhr_number, has_results, account_id', TEST_MHR_NUM_DATA)
+def test_find_original_by_mhr_number(session, mhr_number, has_results, account_id):
+    """Assert that finding the original MH registration information by MHR number works as expected."""
+    if has_results:
+        registration: MhrRegistration = MhrRegistration.find_original_by_mhr_number(mhr_number, account_id)
+        assert registration
+        assert registration.id
+        assert registration.mhr_number == mhr_number
+        assert registration.status_type in MhrRegistrationStatusTypes
+        assert registration.registration_type in MhrRegistrationTypes
+        assert registration.registration_ts
+    else:
+        with pytest.raises(BusinessException) as not_found_err:
+            MhrRegistration.find_by_mhr_number(mhr_number, 'PS12345')
+        # check
+        assert not_found_err
+
+
 @pytest.mark.parametrize('http_status,doc_id,mhr_num,doc_type,legacy,owner_count', TEST_DATA_DOC_ID)
 def test_find_by_document_id(session, http_status, doc_id, mhr_num, doc_type, legacy, owner_count):
     """Assert that find manufauctured home information by document id contains all expected elements."""

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -30,6 +30,8 @@ DESC_MISSING_DOC_ID = 'Missing document id'
 DESC_MISSING_SUBMITTING = 'Missing submitting party'
 DESC_MISSING_OWNER_GROUP = 'Missing owner group'
 DESC_DOC_ID_EXISTS = 'Invalid document id exists'
+DESC_INVALID_GROUP_ID = 'Invalid delete owner group id'
+DESC_NONEXISTENT_GROUP_ID = 'Invalid nonexistent delete owner group id'
 DOC_ID_EXISTS = '80038730'
 DOC_ID_VALID = '63166035'
 DOC_ID_INVALID_CHECKSUM = '63166034'
@@ -60,10 +62,8 @@ TEST_CHECKSUM_DATA = [
 # testdata pattern is ({description}, {valid}, {street}, {city}, {message content})
 TEST_LEGACY_REG_DATA = [
     (DESC_VALID, True, '0123456789012345678901234567890', '01234567890123456789', None),
-    ('Valid location street long', True, '01234567890123456789012345678901', 'KAMLOOPS',
-     validator.LEGACY_ADDRESS_STREET_TOO_LONG.format(add_desc='Location')),
-    ('Valid location city long', True, '1234 Front St.', '012345678901234567890',
-     validator.LEGACY_ADDRESS_CITY_TOO_LONG.format(add_desc='Location'))
+    ('Valid location street long', True, '01234567890123456789012345678901', 'KAMLOOPS', None),
+    ('Valid location city long', True, '1234 Front St.', '012345678901234567890', None)
 ]
 # testdata pattern is ({description}, {bus_name}, {first}, {middle}, {last}, {message content})
 TEST_PARTY_DATA = [
@@ -90,7 +90,10 @@ TEST_TRANSFER_DATA = [
     (DESC_MISSING_DOC_ID, False, True, None, validator.DOC_ID_REQUIRED, None),
     (DESC_DOC_ID_EXISTS, False, True, DOC_ID_EXISTS, validator.DOC_ID_EXISTS, None),
     ('Invalid EXEMPT', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT),
-    ('Invalid HISTORICAL', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL)
+    ('Invalid HISTORICAL', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL),
+    (DESC_INVALID_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_INVALID, MhrRegistrationStatusTypes.ACTIVE),
+    (DESC_NONEXISTENT_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_NONEXISTENT,
+     MhrRegistrationStatusTypes.ACTIVE)
 ]
 
 
@@ -129,11 +132,15 @@ def test_validate_transfer(session, desc, valid, staff, doc_id, message_content,
         json_data['documentId'] = doc_id
     elif json_data.get('documentId'):
         del json_data['documentId']
+    if valid:
+        json_data['deleteOwnerGroups'][0]['groupId'] = 2
+    elif desc == DESC_NONEXISTENT_GROUP_ID:
+        json_data['deleteOwnerGroups'][0]['groupId'] = 10
     valid_format, errors = schema_utils.validate(json_data, 'transfer', 'mhr')
     # Additional validation not covered by the schema.
-    registration: MhrRegistration = None
+    registration: MhrRegistration = MhrRegistration.find_by_mhr_number('045349', 'PS12345')
     if status:
-        registration = MhrRegistration(status_type=status)
+        registration.status_type = status
     error_msg = validator.validate_transfer(registration, json_data, staff)
     if errors:
         current_app.logger.debug(errors)
@@ -142,7 +149,14 @@ def test_validate_transfer(session, desc, valid, staff, doc_id, message_content,
     else:
         assert error_msg != ''
         if message_content:
-            assert error_msg.find(message_content) != -1
+            if desc == DESC_INVALID_GROUP_ID:
+                expected = message_content.format(group_id=1)
+                assert error_msg.find(expected) != -1
+            elif desc == DESC_NONEXISTENT_GROUP_ID:
+                expected = message_content.format(group_id=10)
+                assert error_msg.find(expected) != -1
+            else:
+                assert error_msg.find(message_content) != -1
 
 
 @pytest.mark.parametrize('desc,bus_name,first,middle,last,message_content,data', TEST_PARTY_DATA)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13748

*Description of changes:*
- Add the ability to retrieve the account registration summary list as parent-child registrations (new request parameter collapse=true).
- Enhance the get registration by MHR number endpoint to return the current state of the registration (new request parameter current=true).
- Add some transfer delete owner groups validation. More to come when rules defined.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
