### PR TITLE
Add endpoints to maintain MHR draft registrations.

### DIFF
--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.5.3
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.6.2#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.3#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.6.2#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.3#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -261,6 +261,9 @@ class MhrRegistrationTypes(BaseEnum):
     MHREG = 'MHREG'
     TRAND = 'TRAND'
     TRANS = 'TRANS'
+    EXEMPTION_RES = 'EXEMPTION_RES'
+    EXEMPTION_NON_RES = 'EXEMPTION_NON_RES'
+    PERMIT = 'PERMIT'
 
 
 class MhrStatusTypes(BaseEnum):

--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -18,6 +18,7 @@ from typing import Optional
 from flask import Flask
 
 from .documents import bp as documents_bp
+from .drafts import bp as drafts_bp
 from .manufacturer import bp as manufacturers_bp
 from .meta import bp as meta_bp
 from .ops import bp as ops_bp
@@ -46,6 +47,7 @@ class V1Endpoint:
         self.app = app
 
         self.app.register_blueprint(documents_bp)
+        self.app.register_blueprint(drafts_bp)
         self.app.register_blueprint(manufacturers_bp)
         self.app.register_blueprint(meta_bp)
         self.app.register_blueprint(ops_bp)

--- a/mhr_api/src/mhr_api/resources/v1/drafts.py
+++ b/mhr_api/src/mhr_api/resources/v1/drafts.py
@@ -1,0 +1,178 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for maintainging draft registrations."""
+
+from http import HTTPStatus
+
+from flask import Blueprint
+from flask import current_app, request, jsonify, g
+from flask_cors import cross_origin
+from registry_schemas import utils as schema_utils
+
+from mhr_api.utils.auth import jwt
+from mhr_api.exceptions import BusinessException, DatabaseException
+from mhr_api.models import MhrDraft
+from mhr_api.resources import utils as resource_utils
+from mhr_api.services.authz import authorized
+
+
+bp = Blueprint('DRAFTS1',  # pylint: disable=invalid-name
+               __name__, url_prefix='/api/v1/drafts')
+VAL_ERROR = 'Draft request data validation errors.'  # Validation error prefix
+
+
+@bp.route('', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_account_drafts():
+    """Get the list of draft statements belonging to the header account ID."""
+    account_id = ''
+    try:
+        # Quick check: must provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+
+        # Try to fetch draft list for account ID
+        draft_list = MhrDraft.find_all_by_account_id(account_id)
+        return jsonify(draft_list), HTTPStatus.OK
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id,
+                                                    'GET account drafts id=' + account_id)
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('', methods=['POST', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def post_drafts():  # pylint: disable=too-many-return-statements
+    """Create a new draft registration."""
+    account_id = ''
+    try:
+        # Quick check: must provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        current_app.logger.info(f'post_drafts account_id={account_id}')
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        request_json = request.get_json(silent=True)
+        valid_format, errors = schema_utils.validate(request_json, 'draft', 'mhr')
+        if not valid_format:
+            return resource_utils.validation_error_response(errors, VAL_ERROR, None)
+        # Save new draft statement: BusinessException raised if failure.
+        token: dict = g.jwt_oidc_token_info
+        draft = MhrDraft.create_from_json(request_json, account_id, token.get('username', None))
+        draft.save()
+        return draft.json, HTTPStatus.CREATED
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id,
+                                                    'POST mhr draft id=' + account_id)
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('/<string:draft_number>', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_drafts(draft_number: str):  # pylint: disable=too-many-return-statements
+    """Get a draft registration by draft number."""
+    try:
+        current_app.logger.info(f'get_drafts draft_number={draft_number}')
+        if draft_number is None:
+            return resource_utils.path_param_error_response('draft number')
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+
+        # Try to fetch draft by draft number
+        draft = MhrDraft.find_by_draft_number(draft_number, False)
+        return draft.json, HTTPStatus.OK
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id, 'GET draft id=' + draft_number)
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('/<string:draft_number>', methods=['PUT', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def put_drafts(draft_number: str):  # pylint: disable=too-many-return-statements
+    """Update a draft by draft number with data in the request body."""
+    try:
+        current_app.logger.info(f'put_drafts draft_number={draft_number}')
+        if draft_number is None:
+            return resource_utils.path_param_error_response('draft number')
+        # Quick check: must provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+
+        request_json = request.get_json(silent=True)
+        # Save draft statement update: BusinessException raised if failure.
+        draft = MhrDraft.update(request_json, draft_number)
+        draft.save()
+        return draft.json, HTTPStatus.OK
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except DatabaseException as db_exception:   # noqa: B902; return nicer default error
+        return resource_utils.db_exception_response(db_exception, account_id, 'PUT draft id=' + draft_number)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('/<string:draft_number>', methods=['DELETE', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def delete_drafts(draft_number: str):  # pylint: disable=too-many-return-statements
+    """Delete a draft registration by draft number."""
+    try:
+        current_app.logger.info(f'delete_drafts draft_number={draft_number}')
+        if draft_number is None:
+            return resource_utils.path_param_error_response('draft number')
+        # Quick check: must be staff or provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+
+        # Try to delete draft by draft number.
+        MhrDraft.delete(draft_number)
+        return '', HTTPStatus.NO_CONTENT
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except DatabaseException as db_exception:   # noqa: B902; return nicer default error
+        return resource_utils.db_exception_response(db_exception, account_id, 'DELETE draft id=' + draft_number)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.9'  # pylint: disable=invalid-name
+__version__ = '1.1.0'  # pylint: disable=invalid-name

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -8,6 +8,250 @@
 	},
 	"item": [
 		{
+			"name": "drafts",
+			"item": [
+				{
+					"name": "Get account drafts",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "example=/api/v1/drafts/get",
+								"description": "Prism only local  mock server header.",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/drafts",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"drafts"
+							]
+						},
+						"description": "Get drafts example."
+					},
+					"response": []
+				},
+				{
+					"name": "Create a draft Transfer",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": \"TRANS\",\n  \"registration\": {\n    \"mhrNumber\": \"125234\",\n    \"clientReferenceId\": \"EX-TRANS-002\",\n    \"submittingParty\": {\n      \"personName\": {\n        \"first\": \"JOHN\",\n        \"middle\": \"B\",\n        \"last\": \"SMITH\"\n      },\n      \"address\": {\n        \"street\": \"222 SUMMER STREET\",\n        \"city\": \"VICTORIA\",\n        \"region\": \"BC\",\n        \"country\": \"CA\",\n        \"postalCode\": \"V8W 2V8\"\n      },\n      \"emailAddress\": \"jbsmith@gmail.com\",\n      \"phoneNumber\": \"2504930122\",\n      \"phoneExtension\": \"\"\n    },\n    \"deleteOwnerGroups\": [\n      {\n        \"groupId\": 1,\n        \"owners\": [\n          {\n            \"individualName\": {\n              \"first\": \"MARY-ANNE\",\n              \"last\": \"BICKNELL\"\n            },\n            \"address\": {\n              \"street\": \"6665 238TH STREET\",\n              \"city\": \"LANGLEY\",\n              \"region\": \"BC\",\n              \"country\": \"CA\",\n              \"postalCode\": \"V3A 6H4\"\n            },\n            \"phoneNumber\": \"6044620279\"\n          }\n        ],\n        \"type\": \"SOLE\",\n        \"status\": \"ACTIVE\"\n      }\n    ],\n    \"addOwnerGroups\": [\n      {\n        \"groupId\": 2,\n        \"owners\": [\n          {\n            \"individualName\": {\n              \"first\": \"JOHN\",\n              \"middle\": \"STEVEN\",\n              \"last\": \"CONNOLLY\"\n            },\n            \"address\": {\n              \"street\": \"6665 238TH STREET\",\n              \"city\": \"LANGLEY\",\n              \"region\": \"BC\",\n              \"country\": \"CA\",\n              \"postalCode\": \"V3A 6H4\"\n            },\n            \"phoneNumber\": \"6044620279\"\n          }\n        ],\n        \"type\": \"SOLE\"\n      }\n    ],\n    \"deathOfOwner\": false\n  }\n}\n"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/drafts",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"drafts"
+							]
+						},
+						"description": "Example of a request to create a draft of a Financing Statement.."
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve a Transfer draft",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Prefer",
+								"value": "example=/api/v1/drafts/D0034002/get",
+								"description": "Prism only local  mock server header.",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/drafts/100169",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"drafts",
+								"100169"
+							]
+						},
+						"description": "Get a draft Amendment Statement example."
+					},
+					"response": []
+				},
+				{
+					"name": "Update Transfer Draft",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Prefer",
+								"value": "example=/api/v1/drafts/D0034001/put",
+								"description": "Prism only local  mock server header.",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"draftId\": \"100169\",\n  \"createDateTime\": \"2022-11-23T14:31:01-08:00\",\n  \"lastUpdateDateTime\": \"2022-11-23T14:31:01-08:00\",\n  \"type\": \"TRANS\",\n  \"registration\": {\n    \"mhrNumber\": \"125234\",\n    \"clientReferenceId\": \"EX-TRANS-0022\",\n    \"submittingParty\": {\n      \"personName\": {\n        \"first\": \"JOHN\",\n        \"middle\": \"BARNARD\",\n        \"last\": \"SMITH\"\n      },\n      \"address\": {\n        \"street\": \"222 SUMMER STREET\",\n        \"city\": \"VICTORIA\",\n        \"region\": \"BC\",\n        \"country\": \"CA\",\n        \"postalCode\": \"V8W 2V8\"\n      },\n      \"emailAddress\": \"jbsmith@gmail.com\",\n      \"phoneNumber\": \"2504930122\",\n      \"phoneExtension\": \"\"\n    },\n    \"deleteOwnerGroups\": [\n      {\n        \"groupId\": 1,\n        \"owners\": [\n          {\n            \"individualName\": {\n              \"first\": \"MARY-ANNE\",\n              \"last\": \"BICKNELL\"\n            },\n            \"address\": {\n              \"street\": \"6665 238TH STREET\",\n              \"city\": \"LANGLEY\",\n              \"region\": \"BC\",\n              \"country\": \"CA\",\n              \"postalCode\": \"V3A 6H4\"\n            },\n            \"phoneNumber\": \"6044620279\"\n          }\n        ],\n        \"type\": \"SOLE\",\n        \"status\": \"ACTIVE\"\n      }\n    ],\n    \"addOwnerGroups\": [\n      {\n        \"groupId\": 2,\n        \"owners\": [\n          {\n            \"individualName\": {\n              \"first\": \"JOHN\",\n              \"middle\": \"STEVEN\",\n              \"last\": \"CONNOLLY\"\n            },\n            \"address\": {\n              \"street\": \"6665 238TH STREET\",\n              \"city\": \"LANGLEY\",\n              \"region\": \"BC\",\n              \"country\": \"CA\",\n              \"postalCode\": \"V3A 6H4\"\n            },\n            \"phoneNumber\": \"6044620279\"\n          }\n        ],\n        \"type\": \"SOLE\"\n      }\n    ],\n    \"deathOfOwner\": false\n  }\n}\n"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/drafts/100169",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"drafts",
+								"100169"
+							]
+						},
+						"description": "Update draft by ID example."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete draft by ID",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/drafts/100169",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"drafts",
+								"100169"
+							]
+						},
+						"description": "Delete draft by ID example."
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "searches",
 			"item": [
 				{

--- a/mhr_api/tests/unit/api/test_drafts.py
+++ b/mhr_api/tests/unit/api/test_drafts.py
@@ -1,0 +1,239 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the endpoints for maintaining MH draft registrations.
+
+Test-Suite to ensure that the /drafts endpoint is working as expected.
+"""
+import copy
+from http import HTTPStatus
+
+import pytest
+from flask import current_app
+from registry_schemas.example_data.mhr import REGISTRATION
+
+from mhr_api.models import MhrDraft
+from mhr_api.models.type_tables import MhrRegistrationTypes
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
+from tests.unit.services.utils import create_header, create_header_account
+
+
+DRAFT_TRANSFER = {
+  'type': 'TRANS',
+  'registration': {
+    'mhrNumber': '125234',
+    'clientReferenceId': 'EX-TRANS-001',
+    'submittingParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+        'street': '222 SUMMER STREET',
+        'city': 'VICTORIA',
+        'region': 'BC',
+        'country': 'CA',
+        'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com',
+      'phoneNumber': '6041234567',
+      'phoneExtension': '546'
+    },
+    'deleteOwnerGroups': [
+      {
+        'groupId': 1,
+        'owners': [
+          {
+            'individualName': {
+              'first': 'Jane',
+              'last': 'Smith'
+            },
+            'address': {
+              'street': '3122B LYNNLARK PLACE',
+              'city': 'VICTORIA',
+              'region': 'BC',
+              'postalCode': ' ',
+              'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+          }
+        ],
+        'type': 'SOLE'
+      }
+    ],
+    'addOwnerGroups': [
+      {
+        'groupId': 2,
+        'owners': [
+          {
+            'individualName': {
+              'first': 'James',
+              'last': 'Smith'
+            },
+            'address': {
+              'street': '3122B LYNNLARK PLACE',
+              'city': 'VICTORIA',
+              'region': 'BC',
+              'postalCode': ' ',
+              'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+          }
+        ],
+        'type': 'SOLE',
+        'status': 'ACTIVE'
+      }
+    ],
+    'deathOfOwner': False
+  }
+}
+
+# testdata pattern is ({desc}, {roles}, {status}, {has_account}, {results_size})
+TEST_GET_ACCOUNT_DATA = [
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, 0),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, 0),
+    ('Valid request', [MHR_ROLE], HTTPStatus.OK, True, 2),
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, 0)
+]
+# testdata pattern is ({description}, {roles}, {status}, {has_account}, {reg_type})
+TEST_CREATE_DATA = [
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, MhrRegistrationTypes.TRANS),
+    ('Staff missing account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, MhrRegistrationTypes.TRANS),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, MhrRegistrationTypes.TRANS),
+    ('Invalid type schema validation', [MHR_ROLE], HTTPStatus.BAD_REQUEST, True, 'XXXXX'),
+    ('Valid', [MHR_ROLE], HTTPStatus.CREATED, True, MhrRegistrationTypes.TRANS)
+]
+# testdata pattern is ({description}, {roles}, {status}, {account}, {mhr_num})
+TEST_GET_DRAFT = [
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, None, 'UT0001'),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345', 'UT0001'),
+    ('Valid Request', [MHR_ROLE], HTTPStatus.OK, 'PS12345', 'UT0001'),
+    ('Invalid Draft Number', [MHR_ROLE], HTTPStatus.NOT_FOUND, 'PS12345', 'XXXXXX'),
+    ('Invalid request Staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, None, 'UT0001')
+]
+
+
+@pytest.mark.parametrize('desc,roles,status,has_account,results_size', TEST_GET_ACCOUNT_DATA)
+def test_get_account_drafts(session, client, jwt, desc, roles, status, has_account, results_size):
+    """Assert that a get account drafts summary list endpoint works as expected."""
+    headers = None
+    # setup
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
+    # test
+    rv = client.get('/api/v1/drafts',
+                    headers=headers)
+
+    # check
+    assert rv.status_code == status
+    if rv.status_code == HTTPStatus.OK:
+        assert rv.json
+        assert len(rv.json) >= results_size
+        for registration in rv.json:
+            assert registration['draftNumber']
+            assert registration['registrationType'] is not None
+            assert registration['registrationDescription']
+            assert registration['createDateTime'] is not None
+            assert registration['lastUpdateDateTime'] is not None
+            assert registration['registeringName'] is not None
+            assert registration['submittingParty'] is not None
+            assert registration['clientReferenceId'] is not None
+            assert registration['path'] is not None
+            if registration['registrationType'] != MhrRegistrationTypes.MHREG:
+                assert registration.get('mhrNumber')
+
+
+@pytest.mark.parametrize('desc,roles,status,has_account,reg_type', TEST_CREATE_DATA)
+def test_create_draft(session, client, jwt, desc, roles, status, has_account, reg_type):
+    """Assert that a post MH draft works as expected."""
+    # setup
+    headers = None
+    json_data = {
+        'type': reg_type,
+        'registration': copy.deepcopy(DRAFT_TRANSFER)
+    }
+    if has_account:
+        headers = create_header_account(jwt, roles)
+    else:
+        headers = create_header(jwt, roles)
+
+    # test
+    response = client.post('/api/v1/drafts',
+                           json=json_data,
+                           headers=headers,
+                           content_type='application/json')
+
+    # check
+    assert response.status_code == status
+    if response.status_code == HTTPStatus.CREATED:
+        draft: MhrDraft = MhrDraft.find_by_draft_number(response.json['draftNumber'], False)
+        assert draft
+
+
+@pytest.mark.parametrize('desc,roles,status,account_id,draft_num', TEST_GET_DRAFT)
+def test_get_draft(session, client, jwt, desc, roles, status, account_id, draft_num):
+    """Assert that a get account draft by draft number works as expected."""
+    # setup
+    headers = None
+    if account_id:
+        headers = create_header_account(jwt, roles, 'test-user', account_id)
+    else:
+        headers = create_header(jwt, roles)
+
+    # test
+    response = client.get('/api/v1/drafts/' + draft_num,
+                          headers=headers)
+    # check
+    assert response.status_code == status
+
+
+@pytest.mark.parametrize('desc,roles,status,account_id,draft_num', TEST_GET_DRAFT)
+def test_delete_draft(session, client, jwt, desc, roles, status, account_id, draft_num):
+    """Assert that a delete account draft by draft number works as expected."""
+    # setup
+    headers = None
+    if account_id:
+        headers = create_header_account(jwt, roles, 'test-user', account_id)
+    else:
+        headers = create_header(jwt, roles)
+
+    # test
+    response = client.delete('/api/v1/drafts/' + draft_num,
+                             headers=headers)
+    # check
+    if status != HTTPStatus.OK:
+        assert response.status_code == status
+    else:
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+
+@pytest.mark.parametrize('desc,roles,status,account_id,draft_num', TEST_GET_DRAFT)
+def test_update_draft(session, client, jwt, desc, roles, status, account_id, draft_num):
+    """Assert that an update account draft by draft number works as expected."""
+    # setup
+    json_data = {
+        'registration': copy.deepcopy(DRAFT_TRANSFER)
+    }
+    headers = None
+    if account_id:
+        headers = create_header_account(jwt, roles, 'test-user', account_id)
+    else:
+        headers = create_header(jwt, roles)
+
+    # test
+    response = client.put('/api/v1/drafts/' + draft_num,
+                          json=json_data,
+                          headers=headers,
+                          content_type='application/json')
+    # check
+    assert response.status_code == status

--- a/mhr_api/tests/unit/models/test_mhr_draft.py
+++ b/mhr_api/tests/unit/models/test_mhr_draft.py
@@ -20,6 +20,7 @@ import copy
 from http import HTTPStatus
 
 from flask import current_app
+from mhr_api.resources.utils import NOT_FOUND
 
 import pytest
 from registry_schemas.example_data.mhr import REGISTRATION
@@ -29,63 +30,171 @@ from mhr_api.models import MhrDraft, utils as model_utils
 from mhr_api.models.type_tables import MhrRegistrationTypes
 
 
-def test_find_all_by_account_id(session):
+DRAFT_TRANSFER = {
+  'type': 'TRANS',
+  'registration': {
+    'mhrNumber': '125234',
+    'clientReferenceId': 'EX-TRANS-001',
+    'submittingParty': {
+      'businessName': 'ABC SEARCHING COMPANY',
+      'address': {
+        'street': '222 SUMMER STREET',
+        'city': 'VICTORIA',
+        'region': 'BC',
+        'country': 'CA',
+        'postalCode': 'V8W 2V8'
+      },
+      'emailAddress': 'bsmith@abc-search.com',
+      'phoneNumber': '6041234567',
+      'phoneExtension': '546'
+    },
+    'deleteOwnerGroups': [
+      {
+        'groupId': 1,
+        'owners': [
+          {
+            'individualName': {
+              'first': 'Jane',
+              'last': 'Smith'
+            },
+            'address': {
+              'street': '3122B LYNNLARK PLACE',
+              'city': 'VICTORIA',
+              'region': 'BC',
+              'postalCode': ' ',
+              'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+          }
+        ],
+        'type': 'SOLE'
+      }
+    ],
+    'addOwnerGroups': [
+      {
+        'groupId': 2,
+        'owners': [
+          {
+            'individualName': {
+              'first': 'James',
+              'last': 'Smith'
+            },
+            'address': {
+              'street': '3122B LYNNLARK PLACE',
+              'city': 'VICTORIA',
+              'region': 'BC',
+              'postalCode': ' ',
+              'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+          }
+        ],
+        'type': 'SOLE',
+        'status': 'ACTIVE'
+      }
+    ],
+    'deathOfOwner': False
+  }
+}
+# testdata pattern is ({account_id}, {has_results}, {draft_num}, {mhr_num}, {reg_type})
+TEST_ACCOUNT_DRAFT_DATA = [
+    ('PS12345', True, 'T500000', None, MhrRegistrationTypes.MHREG),
+    ('PS12345', True, 'UT0001', 'UT-001', MhrRegistrationTypes.TRANS),
+    ('999999', False, None, None, None)
+]
+# testdata pattern is ({account_id}, {status}, {draft_num}, {mhr_num}, {reg_type})
+TEST_DRAFT_DATA = [
+    ('PS12345', HTTPStatus.OK, 'T500000', None, MhrRegistrationTypes.MHREG),
+    ('PS12345', HTTPStatus.OK, 'UT0001', 'UT-001', MhrRegistrationTypes.TRANS),
+    ('999999', HTTPStatus.NOT_FOUND, None, None, None),
+    ('PS12345', HTTPStatus.BAD_REQUEST, 'T500001', None, None)
+]
+# testdata pattern is ({account_id}, {mhr_num}, {reg_type}, {draft_data})
+TEST_SAVE_DRAFT_DATA = [
+    ('PS12345', None, MhrRegistrationTypes.MHREG, REGISTRATION),
+    ('PS12345', '125234', MhrRegistrationTypes.TRANS, DRAFT_TRANSFER)
+]
+# testdata pattern is ({status}, {draft_num}, {reg_type}, {draft_data}, {client_ref})
+TEST_UPDATE_DRAFT_DATA = [
+    (HTTPStatus.OK, 'T500000', MhrRegistrationTypes.MHREG, REGISTRATION, 'TEST-001'),
+    (HTTPStatus.OK, 'UT0001', MhrRegistrationTypes.TRANS, DRAFT_TRANSFER, 'TEST-002'),
+    (HTTPStatus.NOT_FOUND, None, None, None, None),
+    (HTTPStatus.BAD_REQUEST, 'T500001', None, None, None)
+]
+
+
+@pytest.mark.parametrize('account_id, has_results, draft_num, mhr_num, reg_type', TEST_ACCOUNT_DRAFT_DATA)
+def test_find_all_by_account_id(session, account_id, has_results, draft_num, mhr_num, reg_type):
     """Assert that the draft summary list items contains all expected elements."""
-    draft_list = MhrDraft.find_all_by_account_id('PS12345')
-    # print(draft_list)
-    assert draft_list
-    for draft in draft_list:
-        assert draft['draftNumber']
-        assert draft['registrationType']
-        assert draft['registrationDescription']
-        assert draft['createDateTime']
-        assert draft['lastUpdateDateTime']
-        assert 'clientReferenceId' in draft
-        assert draft['path']
-        assert 'submittingParty' in draft
+    draft_list = MhrDraft.find_all_by_account_id(account_id)
+    if has_results:
+        assert draft_list
+        found_draft = False
+        found_mhr = False
+        for draft in draft_list:
+            current_app.logger.info(draft)
+            assert draft['draftNumber']
+            assert draft['createDateTime']
+            assert draft['lastUpdateDateTime']
+            assert draft['path']
+            assert draft.get('registrationDescription')
+            assert draft.get('clientReferenceId')
+            assert draft.get('submittingParty')
+            if mhr_num and draft.get('mhrNumber') and draft['mhrNumber'] == mhr_num:
+                found_mhr = True
+            if draft['draftNumber'] == draft_num:
+                assert draft['registrationType'] == reg_type
+                found_draft = True
+        assert found_draft
+        if mhr_num:
+            assert found_mhr
+    else:
+        assert not draft_list
 
 
-def test_find_by_draft_number(session):
+@pytest.mark.parametrize('account_id, status, draft_num, mhr_num, reg_type', TEST_DRAFT_DATA)
+def test_find_by_draft_number(session, account_id, status, draft_num, mhr_num, reg_type):
     """Assert that the find draft by draft number contains all expected elements."""
-    draft: MhrDraft = MhrDraft.find_by_draft_number('T500000', True)
-    assert draft
-    assert draft.id
-    assert draft.draft_number
-    assert draft.draft
-    assert draft.create_ts
-    assert draft.account_id
-    assert draft.user_id
+    if status == HTTPStatus.OK:
+        draft: MhrDraft = MhrDraft.find_by_draft_number(draft_num, False)
+        assert draft
+        assert draft.id
+        assert draft.account_id == account_id
+        assert draft.draft_number == draft_num
+        assert draft.draft
+        assert draft.create_ts
+        assert draft.account_id
+        assert draft.user_id
+        assert draft.registration_type == reg_type
+        if mhr_num:
+            assert draft.mhr_number == mhr_num
+    else:
+        with pytest.raises(BusinessException) as error:
+            MhrDraft.find_by_draft_number(draft_num, False)
+        assert error
+        assert error.value.status_code == status
 
 
-def test_find_by_account_id_no_result(session):
-    """Assert that the find draft statement by invalid account ID returns the expected result."""
-    drafts = MhrDraft.find_all_by_account_id('X12345X')
-
-    # check
-    assert not drafts
-
-
-def test_find_by_draft_number_invalid(session):
-    """Assert that the find draft by invalid draft number returns the expected result."""
-    with pytest.raises(BusinessException) as not_found_err:
-        MhrDraft.find_by_draft_number('X12345X', False)
-
-    # check
-    assert not_found_err
-    assert not_found_err.value.status_code == HTTPStatus.NOT_FOUND
-
-
-def test_save_then_delete(session):
+@pytest.mark.parametrize('account_id, mhr_num, reg_type, draft_data', TEST_SAVE_DRAFT_DATA)
+def test_save_then_delete(session, account_id, mhr_num, reg_type, draft_data):
     """Assert that a save then delete draft statement returns the expected result."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['registrationType'] = 'MHREG'
-    new_draft: MhrDraft = MhrDraft.create_from_json(json_data, 'PS12345')
+    json_data = copy.deepcopy(draft_data)
+    if mhr_num:
+        json_data['mhrNumber'] = mhr_num
+    draft_data = {
+        'type': reg_type,
+        'registration': json_data
+    } 
+    new_draft: MhrDraft = MhrDraft.create_from_json(draft_data, account_id, 'TESTUSER')
     new_draft.save()
     draft = new_draft.json
     assert draft
-    assert draft['registrationType'] == 'MHREG'
+    assert draft['type'] == reg_type
     assert draft['createDateTime']
     assert draft['draftNumber']
+    assert draft['registration']
+    if mhr_num:
+        draft['mhrNumber'] = mhr_num
 
     # Now test delete draft
     draft_number = draft['draftNumber']
@@ -93,71 +202,73 @@ def test_save_then_delete(session):
     assert delete_draft
 
 
-def test_update(session):
-    """Assert that a valid update draft returns the expected result."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['registrationType'] = 'MHREG'
-    new_draft: MhrDraft = MhrDraft.create_from_json(json_data, 'PS12345')
-    new_draft.save()
-    draft_number = new_draft.draft_number
-    json_data['clientReferenceId'] = 'TU-0001'
-    updated = MhrDraft.update(json_data, draft_number)
-    updated.save()
-    draft = updated.json
-    assert draft
-    assert draft['registrationType'] == 'MHREG'
-    assert draft['createDateTime']
-    assert draft['lastUpdateDateTime']
-    assert draft['draftNumber'] == draft_number
-    assert draft['clientReferenceId'] == 'TU-0001'
+@pytest.mark.parametrize('status, draft_num, reg_type, draft_data, client_ref', TEST_UPDATE_DRAFT_DATA)
+def test_update(session, status, draft_num, reg_type, draft_data, client_ref):
+    """Assert that update draft returns the expected result."""
+    if status == HTTPStatus.OK:
+        json_data = {
+            'type': reg_type,
+            'registration': copy.deepcopy(draft_data)
+        }
+        json_data['registration']['clientReferenceId'] = client_ref
+        updated = MhrDraft.update(json_data, draft_num)
+        # current_app.logger.info(updated.draft)
+        updated_json = updated.save()
+        # current_app.logger.info(updated_json)
+        assert updated_json
+        assert updated_json['type'] == reg_type
+        assert updated_json['createDateTime']
+        assert updated_json['lastUpdateDateTime']
+        assert updated_json['draftNumber'] == draft_num
+        assert updated_json['registration']
+    else:
+        with pytest.raises(BusinessException) as error:
+            MhrDraft.find_by_draft_number(draft_num, False)
+        assert error
+        assert error.value.status_code == status
 
 
-def test_update_invalid(session):
-    """Assert that an update draft a non-existent draft number returns the expected result."""
-    json_data = copy.deepcopy(REGISTRATION)
-
-    with pytest.raises(BusinessException) as not_found_err:
-        MhrDraft.update(json_data, 'X12345X')
-
-    # check
-    assert not_found_err
-    assert not_found_err.value.status_code == HTTPStatus.NOT_FOUND
-
-
-def test_delete_bad_id(session):
-    """Assert that delete by invalid draft number works as expected."""
-    with pytest.raises(BusinessException) as not_found_err:
-        MhrDraft.delete('X12345X')
-
-    # check
-    assert not_found_err
-    assert not_found_err.value.status_code == HTTPStatus.NOT_FOUND
+@pytest.mark.parametrize('account_id, status, draft_num, mhr_num, reg_type', TEST_DRAFT_DATA)
+def test_delete(session, account_id, status, draft_num, mhr_num, reg_type):
+    """Assert that delete draft returns the expected result."""
+    if status == HTTPStatus.OK:
+        delete_draft = MhrDraft.delete(draft_num)
+        assert delete_draft
+    else:
+        with pytest.raises(BusinessException) as error:
+            MhrDraft.find_by_draft_number(draft_num, False)
+        assert error
+        assert error.value.status_code == status
 
 
 def test_draft_json(session):
     """Assert that the draft renders to a json format correctly."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['registrationType'] = MhrRegistrationTypes.MHREG
+    json_data = {
+        'type': MhrRegistrationTypes.MHREG,
+        'registration': copy.deepcopy(REGISTRATION)
+    }
     draft: MhrDraft = MhrDraft(
         draft_number='TEST1234',
         account_id='PS12345',
         create_ts=model_utils.now_ts(),
-        registration_type=json_data['registrationType'],
-        draft=json_data,
+        registration_type=json_data['type'],
+        draft=json_data['registration']
     )
-
     draft_json = draft.json
     assert draft_json
+    assert draft_json['createDateTime']
     assert draft_json['draftNumber'] == draft.draft_number
-    assert draft_json['registrationType'] == draft.registration_type
+    assert draft_json['type'] == draft.registration_type
+    assert draft_json['registration'] == draft.draft
 
 
 def test_draft_create_from_json(session):
     """Assert that the draft is created from json data correctly."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['registrationType'] = MhrRegistrationTypes.MHREG
-    draft: MhrDraft = MhrDraft.create_from_json(json_data, 'PS12345')
-
-    assert draft.draft
+    json_data = {
+        'type': MhrRegistrationTypes.MHREG,
+        'registration': copy.deepcopy(REGISTRATION)
+    }
+    draft: MhrDraft = MhrDraft.create_from_json(json_data, 'PS12345', 'TESTUSER')
+    assert draft.draft == json_data['registration']
     assert draft.account_id == 'PS12345'
-    assert draft.registration_type == json_data['registrationType']
+    assert draft.registration_type == json_data['type']


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13708

*Description of changes:*
- Add MHR api endpoints to create, update, delete, and get an individual draft of a registration.
- Add an MHR api endpoint to view the current list of draft summary information for drafts belonging to an account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
