### PR TITLE
Fix output in MHR Found modals

### DIFF
--- a/ppr-ui/src/components/common/ErrorContact.vue
+++ b/ppr-ui/src/components/common/ErrorContact.vue
@@ -30,8 +30,8 @@ export default defineComponent({
       {
         icon: 'mdi-phone',
         label: 'Victoria Office:',
-        value: '250-952-0568',
-        href: 'tel:+1-250-952-0568'
+        value: '250-387-7878',
+        href: 'tel:+1-250-387-7878'
       },
       {
         icon: 'mdi-email',

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -438,17 +438,8 @@ export default defineComponent({
       } else {
         localState.myRegAddDialog.textExtra[1] += 'N/A'
       }
-      const regType = AllRegistrationTypes.find((regType: RegistrationTypeIF) => {
-        if (regType.registrationTypeAPI === reg.statusType) {
-          return true
-        }
-      })
-      if (regType) {
-        localState.myRegAddDialog.textExtra[2] += regType.registrationTypeUI
-      } else {
-        // Just in case some type gets added/changed and is not picked up by the UI.
-        localState.myRegAddDialog.textExtra[2] += 'Legacy'
-      }
+      localState.myRegAddDialog.textExtra[2] +=
+        reg.registrationDescription?.length > 0 ? reg.registrationDescription : 'N/A'
       localState.myRegAddDialog.textExtra[3] += reg.submittingParty
       localState.myRegAddDialogDisplay = true
     }

--- a/ppr-ui/tests/unit/ErrorContact.spec.ts
+++ b/ppr-ui/tests/unit/ErrorContact.spec.ts
@@ -39,7 +39,7 @@ describe('Error Contact component', () => {
     expect(contactItems.at(0).find('.contact-key').text()).toContain('Canada')
     expect(contactItems.at(0).find('.contact-value').text()).toBe('1-877-526-1526')
     expect(contactItems.at(1).find('.contact-key').text()).toContain('Victoria')
-    expect(contactItems.at(1).find('.contact-value').text()).toBe('250-952-0568')
+    expect(contactItems.at(1).find('.contact-value').text()).toBe('250-387-7878')
     expect(contactItems.at(2).find('.contact-key').text()).toContain('BC Registries')
     expect(contactItems.at(2).find('.contact-value').text()).toBe('BCRegistries@gov.bc.ca')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13136

*Description of changes:*

Fix two bugs as a part for 13136:
- Display Registration Type/Description in MH Found Modal
- Update Victoria Office phone number

<img width="805" alt="Screen Shot 2022-10-04 at 11 38 05 AM" src="https://user-images.githubusercontent.com/2333290/193898899-dc297db3-704b-4647-9a80-c86fa8df1fcb.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
