### PR TITLE
Fix two issues for Home Owners Groups

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -388,6 +388,9 @@ export default defineComponent({
       // @ts-ignore - function exists
       context.refs.addHomeOwnerForm.validate()
       if (localState.isHomeOwnerFormValid && localState.isAddressFormValid) {
+        if (!localState.ownerGroupId) {
+          setShowGroups(false)
+        }
         if (props.editHomeOwner) {
           editHomeOwner(
             localState.owner as MhrRegistrationHomeOwnerIF,
@@ -433,6 +436,7 @@ export default defineComponent({
       context.emit('remove')
     }
     const cancel = (): void => {
+      localState.ownerGroupId = props.editHomeOwner?.groupId
       context.emit('cancel')
     }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
@@ -95,7 +95,7 @@ export default defineComponent({
     const groupDropdown = ref(null)
 
     const { required } = useInputRules()
-    const { getGroupDropdownItems, showGroups, setShowGroups } = useHomeOwners()
+    const { getGroupDropdownItems, showGroups } = useHomeOwners()
     const homeOwnerGroups = [...getMhrRegistrationHomeOwnerGroups.value]
 
     const localState = reactive({
@@ -130,9 +130,6 @@ export default defineComponent({
     })
 
     const setOwnerGroupId = (groupId: string): void => {
-      if (!groupId) {
-        setShowGroups(false)
-      }
       emit('setOwnerGroupId', groupId)
     }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -115,8 +115,11 @@
         </tr>
         <tr v-else>
           <td :colspan="4" class="py-1">
-            <div class="error-text my-6 text-center">
+            <div v-if="showGroups" class="error-text my-6 text-center">
               Group must contain at least one owner
+            </div>
+            <div v-else class="my-6 text-center">
+              No owners added yet
             </div>
           </td>
         </tr>

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -337,5 +337,47 @@ describe('Home Owners', () => {
     expect(ownersTable.text()).not.toContain('Group 1')
     expect(ownersTable.text()).toContain(mockedOrganization.organizationName)
     expect(ownersTable.text()).toContain(mockedOrganization.phoneNumber)
+
+  })
+
+  it('should keep the Group shown after clearing dropdown but then clicking Cancel', async () => {
+
+    const homeOwnerGroup = [
+      {
+        groupId: '123',
+        owners: [mockedPerson],
+        interest: 'Undivided',
+        interestNumerator: 111,
+        interestTotal: 777
+      }
+    ] as MhrRegistrationHomeOwnerGroupIF[]
+
+    await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroup)
+
+    const homeOwnersData = wrapper.findComponent(HomeOwners).vm.$data
+    expect(homeOwnersData.getHomeOwners.length).toBe(1)
+    expect(homeOwnersData.isGlobalEditingMode).toBe(false)
+
+    await wrapper
+      .findComponent(HomeOwners)
+      .findComponent(HomeOwnersTable)
+      .find(getTestId('table-edit-btn'))
+      .trigger('click')
+
+    const addOwnerSection = wrapper.findComponent(HomeOwners).findComponent(AddEditHomeOwner)
+
+    const clearGroupButton = addOwnerSection
+    .findComponent(HomeOwnerGroups)
+    .find('.owner-groups-select')
+    .find('.v-icon.mdi-close')
+
+    await clearGroupButton.trigger('click')
+    await clickCancelAddOwner()
+
+    const ownersTable = wrapper.findComponent(HomeOwners).findComponent(HomeOwnersTable)
+    expect(ownersTable.text()).toContain('Group 123')
+    expect(ownersTable.text()).toContain(mockedPerson.individualName.first)
+    expect(ownersTable.text()).toContain(mockedPerson.individualName.last)
+    expect(ownersTable.text()).toContain(mockedPerson.phoneNumber)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13710
*Issue #:* /bcgov/entity#13713

*Description of changes:*
- Fix empty Home Owners table message
- Fix to preserve Home Owners Groups after clearing Groups dropdown but then clicking Cancel
- Add unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
