### PR TITLE
Fix Home Owners Table error messages

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -38,7 +38,7 @@
           </td>
         </tr>
 
-        <tr v-else-if="row.item" :key="row.item.id" class="owner-info">
+        <tr v-else-if="row.item.id" :key="row.item.id" class="owner-info">
           <td class="owner-name">
             <div v-if="row.item.individualName" class="owner-icon-name">
               <v-icon class="mr-2">mdi-account</v-icon>
@@ -115,10 +115,10 @@
         </tr>
         <tr v-else>
           <td :colspan="4" class="py-1">
-            <div v-if="showGroups" class="error-text my-6 text-center">
+            <div v-if="showGroups" class="error-text my-6 text-center" :data-test-id="`no-owners-msg-group-${homeOwners.indexOf(row.item)}`">
               Group must contain at least one owner
             </div>
-            <div v-else class="my-6 text-center">
+            <div v-else class="my-6 text-center" data-test-id="no-owners-mgs">
               No owners added yet
             </div>
           </td>

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -180,7 +180,8 @@ export default defineComponent({
       isGlobalEditingMode,
       showGroups,
       getTotalOwnershipAllocationStatus,
-      hasMinimumGroups
+      hasMinimumGroups,
+      setShowGroups
     } = useHomeOwners()
 
     const localState = reactive({
@@ -217,6 +218,7 @@ export default defineComponent({
       isGlobalEditingMode,
       getHomeTenancyType,
       showGroups,
+      setShowGroups, // expose this for easier unit testing
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -379,6 +379,7 @@ describe('Home Owners', () => {
     expect(ownersTable.text()).toContain(mockedPerson.individualName.first)
     expect(ownersTable.text()).toContain(mockedPerson.individualName.last)
     expect(ownersTable.text()).toContain(mockedPerson.phoneNumber)
+    ownersTable.findComponent(TableGroupHeader).vm.$data.cancelOrProceed(true, '123')
   })
   
   it('should show correct error messages when deleting Owners from the Home Owners table', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13726

*Description of changes:*
- Fix Home Owners Table error messages when there are no owners/groups
- Add/Update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
