### PR TITLE
UX updates to transfer registration report.

### DIFF
--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -1,4 +1,6 @@
-<div class="section-title mt-3">Registered Owner(s) Information</div>
+<div class="section-title mt-3">
+    {% if documentType in ('TRAN', 'DEAT') %}New{% endif %} Registered Owner(s) Information
+</div>
 {% if ownerGroups is defined %}
     {% if ownerGroups|length > 1 %}
     <div class="no-page-break mt-3">
@@ -67,68 +69,7 @@
             <div class="separator-section mt-4 mb-1"></div>
          {% endif %}
     {% endfor %}
-{% elif addOwnerGroups is defined or deleteOwnerGroups is defined %}
-    {% for group in deleteOwnerGroups %}
-        {% if group.type == 'COMMON' %}
-        <div class="mt-3">
-            <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
-            {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|lower }}</span>
-            {% endif %}
-        </div>
-        {% endif %}
-    <table class="section-data section-data-table-new mt-4" role="presentation">
-        {% for party in group.owners %}
-        <tr class="no-page-break">
-            <td class="col-33">
-                <div class="section-sub-title pr-6">
-                    {% if party.organizationName is defined %}
-                        {{ party.organizationName }}
-                    {% elif party.individualName is defined %}
-                        {{ party.individualName.last }},
-                        {{ party.individualName.first }}
-                        {% if party.individualName.middle is defined %}&nbsp;{{ party.individualName.middle }}{% endif %}
-                    {% endif %}
-                </div>
-                {% if party.suffix is defined and party.suffix != '' %}
-                <div class="pt-2">{{ party.suffix }}</div>
-                {% endif %} 
-                <div class="pt-2"><span class="label">DELETED</span></div>
-            </td>
-            <td class="col-33">
-                <div class="section-sub-title">Address</div>
-                <div class="pt-2">{{ party.address.street }}</div>
-                <div>{{ party.address.streetAdditional }}</div>
-                <div>{{ party.address.city }} {{ party.address.region }}</div>
-                <div>
-                    {% if party.address.postalCode is defined and party.address.postalCode != '' %}
-                        {{ party.address.postalCode }}&nbsp;&nbsp; 
-                    {% endif %}
-                    {{ party.address.country}}
-                </div>
-            </td>
-            <td class="col-33">
-                <div class="section-sub-title">Tenancy Type</div>
-                <div class="pt-2">
-                    {% if group.type == 'SOLE' %}
-                        Sole Owner
-                    {% elif group.type == 'JOINT' %}
-                        Joint Tenants
-                    {% else %}
-                        Tenants in Common
-                    {% endif %}
-                </div>
-            </td>
-        </tr>
-        {% if not loop.last %}
-            <tr><td colspan="3"><div class="mt-4"></div></td></tr>            
-        {% endif %}
-    {% endfor %}
-    </table> 
-    {% endfor %}
-    {% if addOwnerGroups is defined and deleteOwnerGroups is defined %}
-        <div class="separator-section mt-4 mb-1"></div>
-    {% endif %}
+{% elif addOwnerGroups is defined %}
     {% for group in addOwnerGroups %}
         {% if group.type == 'COMMON' %}
         <div class="mt-3">
@@ -154,7 +95,6 @@
                 {% if party.suffix is defined and party.suffix != '' %}
                 <div class="pt-2">{{ party.suffix }}</div>
                 {% endif %} 
-                <div class="pt-2"><span class="label">ADDED</span></div>
             </td>
             <td class="col-33">
                 <div class="section-sub-title">Address</div>

--- a/mhr_api/report-templates/template-parts/registration/submittingParty.html
+++ b/mhr_api/report-templates/template-parts/registration/submittingParty.html
@@ -27,6 +27,16 @@
                      {{ submittingParty.address.country }}</div>
             </td>
             <td class="col-33">
+                {% if documentType in ('TRAN', 'DEAT')  %}
+                    <div class="section-sub-title">Affirmed By</div>
+                    <div class="pt-2">
+                        {% if affirmByName is defined and affirmByName != '' %} 
+                            {{ affirmByName }}
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </div>
+                 {% endif %}
             </td>
          </tr>
 </table>

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -307,6 +307,32 @@
 		width: 60%;
 	}
 
+	.registration-details-table-grey {
+		width: 100%;
+		font-family: 'BC Sans', sans-serif;
+		color: #313132!important;
+		font-size: 11pt;
+		line-height: 18px;
+		text-align: left;
+		padding: 1rem 1rem 0.75rem 1.5rem;
+		background-color: #E2E7ED;
+	}
+
+	.registration-details-table-grey td {
+		vertical-align: top;
+		padding-bottom: 2px;
+	}
+
+	.registration-details-table-grey td:nth-child(1) {
+		width: 45%; /* 35 */
+		font-family: 'BC Sans', sans-serif !important;
+		font-weight: bold;
+	}
+
+	.registration-details-table-grey td:nth-child(2) {
+		width: 55%;
+	}
+
 	.business-details-table-white {
 		width: 100%;
 		font-family: 'BC Sans', sans-serif;

--- a/mhr_api/report-templates/transferV2.html
+++ b/mhr_api/report-templates/transferV2.html
@@ -15,7 +15,7 @@
   </head>
   <body>
   <div class="business-details-container mtn-2">
-    <table class="business-details-table-grey mt-0" role="presentation">
+    <table class="registration-details-table-grey mt-0" role="presentation">
       <tr>
         <td>Document ID:</td>
         <td>{{documentId}} </td>
@@ -31,7 +31,11 @@
           </td>
       </tr>
       <tr>
-        <td>Registration Date and Time:</td>
+        <td>Document Registration Number:</td>
+        <td>{{documentRegistrationNumber}} </td>
+      </tr>
+      <tr>
+        <td>Document Registration Date and Time:</td>
         <td>
           {% if createDateTime is defined and createDateTime != '' %}
             {{createDateTime}} 
@@ -41,14 +45,12 @@
         </td>
       </tr>
         <tr>
-        <td>Status:</td>
+        <td>Attention/Reference Number:</td>
         <td>
-          {% if status == 'HISTORICAL' %}
-            Cancelled
-          {% elif status == 'EXEMPT' %}
-            Exempted
+          {% if attentionReference is defined and attentionReference != '' %}
+            {{attentionReference}} 
           {% else %}
-            Registered
+            N/A
           {% endif %}
         </td>
       </tr>

--- a/mhr_api/src/mhr_api/models/db2/document.py
+++ b/mhr_api/src/mhr_api/models/db2/document.py
@@ -162,7 +162,7 @@ class Db2Document(db.Model):
         document = {
             'mhrNumber': self.mhr_number,
             'documentType': self.document_type,
-            'documentRegistrationId': self.document_reg_id,
+            'documentRegistrationNumber': self.document_reg_id,
             'interimed': self.interimed,
             'ownerCrossReference': self.owner_cross_reference,
             'interestDenominator': self.interest_denominator,
@@ -196,9 +196,10 @@ class Db2Document(db.Model):
     def registration_json(self):
         """Return a search registration dict of this object, with keys in JSON format."""
         # Response legacy data: allow for any column to be null.
+        self.strip()
         document = {
             'documentId': self.id,
-            'documentRegistrationId': self.document_reg_id,
+            'documentRegistrationNumber': self.document_reg_id,
             'documentType': self.document_type,
             'mhrNumber': self.mhr_number,
             'declaredValue': self.declared_value,
@@ -294,6 +295,8 @@ class Db2Document(db.Model):
         doc.number_of_pages = 0
         doc.consideration_value = reg_json.get('consideration', '')
         doc.affirm_by_name = ''
+        if reg_json.get('affirmByName'):
+            doc.affirm_by_name = str(reg_json.get('affirmByName'))[0:40]
         doc.liens_with_consent = ''
         if reg_json.get('submittingParty'):
             submitting = reg_json.get('submittingParty')

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -259,7 +259,7 @@ class Db2Manuhome(db.Model):
             'mhrNumber': self.mhr_number,
             'status': LEGACY_STATUS_DESCRIPTION.get(self.mh_status),
             'documentId': doc_json.get('documentId', ''),
-            'documentRegistrationId': doc_json.get('documentRegistrationId', ''),
+            'documentRegistrationNumber': doc_json.get('documentRegistrationNumber', ''),
             'documentType': doc_json.get('documentType', ''),
             'createDateTime': doc_json.get('createDateTime', ''),
             'clientReferenceId': doc_json.get('clientReferenceId', ''),

--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -224,7 +224,7 @@ class Db2Owner(db.Model):
                          sequence_number=1,
                          owner_type=owner_type,
                          verified_flag='',
-                         phone_number=str(new_info.get('phoneNumber', ''))[0:9],
+                         phone_number=str(new_info.get('phoneNumber', ''))[0:10],
                          postal_code=address.get('postalCode', ''),
                          name=name[0:69],
                          compressed_name=compressed_name,

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -123,8 +123,6 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 location = self.locations[0]
                 current_app.logger.debug('Using PostreSQL location in registration.json.')
                 reg_json['location'] = location.json
-            if reg_json.get('documentType'):
-                del reg_json['documentType']
             if self.pay_invoice_id and self.pay_invoice_id > 0:  # Legacy will have no payment info.
                 return self.__set_payment_json(reg_json)
             return reg_json

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -606,7 +606,7 @@ class ReportMeta:  # pylint: disable=too-few-public-methods
         ReportTypes.MHR_TRANSFER: {
             'reportDescription': 'MHRTransfer',
             'fileName': 'transferV2',
-            'metaTitle': 'VERIFICATION OF SERVICE',
+            'metaTitle': 'TRANSFER VERIFICATION',
             'metaSubtitle': 'MANUFACTURED HOME ACT',
             'metaSubject': ''
         },

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -113,6 +113,7 @@ def pay_and_save_transfer(req: request,  # pylint: disable=too-many-arguments
                                                                               account_id,
                                                                               token.get('username', None),
                                                                               user_group)
+    request_json['affirmByName'] = get_transfer_affirmby(token)
     invoice_id = None
     pay_ref = None
     if not is_reg_staff_account(account_id):
@@ -316,3 +317,14 @@ def get_registration_report(registration: MhrRegistration,  # pylint: disable=to
         return resource_utils.service_exception_response('MHR reg report storage API error: ' + str(storage_err))
     except DatabaseException as db_exception:
         return resource_utils.db_exception_response(db_exception, None, 'Generate MHR registration report state.')
+
+
+def get_transfer_affirmby(token) -> str:
+    """Get the transfer registration affirm by name from the user token."""
+    firstname = token.get('given_name', None)
+    if not firstname:
+        firstname = token.get('firstname', '')
+    lastname = token.get('family_name', None)
+    if not lastname:
+        lastname = token.get('lastname', '')
+    return firstname + ' ' + lastname

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -38,6 +38,7 @@ DELETE_GROUP_TYPE_INVALID = 'The owner group tenancy type with ID {group_id} is 
 DECLARED_VALUE_REQUIRED = 'Declared value is required and must be greater than 0 for this registration. '
 CONSIDERATION_REQUIRED = 'Consideration required for this registration. '
 TRANSFER_DATE_REQUIRED = 'Transfer date is required for this registration. '
+ADD_SOLE_OWNER_INVALID = 'Only one sole owner and only one sole owner group can be added. '
 
 
 def validate_registration(json_data, is_staff: bool = False):
@@ -63,9 +64,14 @@ def validate_transfer(registration: MhrRegistration, json_data, is_staff: bool =
         error_msg += validate_doc_id(json_data)
     error_msg += validate_submitting_party(json_data)
     if json_data.get('addOwnerGroups'):
+        so_count: int = 0
         for group in json_data.get('addOwnerGroups'):
             for owner in group.get('owners'):
+                if NEW_TENANCY_LEGACY.get(group.get('type', ''), '') == 'SO':
+                    so_count += 1
                 error_msg += validate_owner(owner)
+        if so_count > 1 or (so_count == 1 and len(json_data.get('addOwnerGroups')) > 1):
+            error_msg += ADD_SOLE_OWNER_INVALID
     error_msg += validate_registration_state(registration)
     if is_legacy() and registration and registration.manuhome and json_data.get('deleteOwnerGroups'):
         error_msg += validate_delete_owners_legacy(registration, json_data)

--- a/mhr_api/tests/unit/models/db2/test_document.py
+++ b/mhr_api/tests/unit/models/db2/test_document.py
@@ -172,7 +172,7 @@ def test_document_json(session):
     test_json = {
         'mhrNumber': doc.mhr_number,
         'documentType': doc.document_type,
-        'documentRegistrationId': doc.document_reg_id,
+        'documentRegistrationNumber': doc.document_reg_id,
         'interimed': doc.interimed,
         'ownerCrossReference': doc.owner_cross_reference,
         'interestDenominator': doc.interest_denominator,

--- a/mhr_api/tests/unit/models/test_mhr_location.py
+++ b/mhr_api/tests/unit/models/test_mhr_location.py
@@ -153,13 +153,13 @@ def test_create_from_json(session):
     """Assert that the new MHR location is created from json data correctly."""
     json_data = copy.deepcopy(REGISTRATION)
     loc_json = json_data.get('location')
-    loc_json['locationType'] = MhrLocationTypes.MH_DEALER
+    loc_json['locationType'] = MhrLocationTypes.MH_PARK
     loc_json['legalDescription'] = LTSA_DESCRIPTION
     location: MhrLocation = MhrLocation.create_from_json(loc_json, 1000)
     assert location
     assert location.registration_id == 1000
     assert location.change_registration_id == 1000
-    assert location.location_type == MhrLocationTypes.MH_DEALER
+    assert location.location_type == MhrLocationTypes.MH_PARK
     assert location.status_type == MhrStatusTypes.ACTIVE
     assert location.ltsa_description == LTSA_DESCRIPTION
     assert location.park_name

--- a/mhr_api/tests/unit/reports/data/trans-test-example-jt.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example-jt.json
@@ -1,0 +1,128 @@
+{
+  "addOwnerGroups": [
+    {
+      "groupId": 2, 
+      "interest": "", 
+      "interestNumerator": 0, 
+      "owners": [
+        {
+          "address": {
+            "city": "LANGLEY", 
+            "country": "CA", 
+            "postalCode": "V3A 6H4", 
+            "region": "BC", 
+            "street": "6665 238TH STREET"
+          }, 
+          "individualName": {
+            "first": "JOHN", 
+            "last": "WATSON"
+          }, 
+          "phoneNumber": "604462027", 
+          "type": "JOINT"
+        }, 
+        {
+          "address": {
+            "city": "LANGLEY", 
+            "country": "CA", 
+            "postalCode": "V3A 6H4", 
+            "region": "BC", 
+            "street": "6665 238TH STREET"
+          }, 
+          "individualName": {
+            "first": "SHERLOCK", 
+            "last": "HOLMES"
+          }, 
+          "phoneNumber": "604462027", 
+          "type": "JOINT"
+        }
+      ], 
+      "status": "ACTIVE", 
+      "tenancySpecified": true, 
+      "type": "JOINT"
+    }
+  ], 
+  "affirmByName": "BCREG2 Della FORTYTHREE", 
+  "clientReferenceId": "UT-TRANS0016", 
+  "consideration": "$100000.00", 
+  "createDateTime": "2022-10-12T13:03:36-07:53", 
+  "declaredValue": 100000, 
+  "deleteOwnerGroups": [
+    {
+      "groupId": 1, 
+      "interest": "", 
+      "interestNumerator": 0, 
+      "owners": [
+        {
+          "address": {
+            "city": "COLBERT WA USA", 
+            "country": "CA", 
+            "postalCode": "99005", 
+            "region": "BC", 
+            "street": "4515 ELO DOLCE ROAD"
+          }, 
+          "individualName": {
+            "first": "DAVID", 
+            "last": "SMITH", 
+            "middle": "STANLEY"
+          }, 
+          "phoneNumber": "5092385046", 
+          "type": "JOINT"
+        }, 
+        {
+          "address": {
+            "city": "COLBERT WA USA", 
+            "country": "CA", 
+            "postalCode": "99005", 
+            "region": "BC", 
+            "street": "4515 ELO DOLCE ROAD"
+          }, 
+          "individualName": {
+            "first": "SUSAN", 
+            "last": "SMITH", 
+            "middle": "HEATHER"
+          }, 
+          "phoneNumber": "5092385046", 
+          "type": "JOINT"
+        }, 
+        {
+          "address": {
+            "city": "FORT ST. JOHN", 
+            "country": "CA", 
+            "postalCode": "V1J 4M7", 
+            "region": "BC", 
+            "street": "S 2 SITE 12 COMP 185"
+          }, 
+          "organizationName": "CIMARRON CAMP SERVICES LTD.", 
+          "phoneNumber": "8669201156", 
+          "type": "JOINT"
+        }
+      ], 
+      "status": "PREVIOUS", 
+      "tenancySpecified": true, 
+      "type": "JOINT"
+    }
+  ], 
+  "documentDescription": "SALE OR GIFT", 
+  "documentId": "10200079", 
+  "documentRegistrationNumber": "00500240", 
+  "documentType": "TRAN", 
+  "mhrNumber": "100173", 
+  "ownLand": true, 
+  "payment": {
+    "invoiceId": "22651", 
+    "receipt": "/api/v1/payment-requests/22651/receipts"
+  }, 
+  "status": "ACTIVE", 
+  "submittingParty": {
+    "address": {
+      "city": "VICTORIA", 
+      "country": "CA", 
+      "postalCode": "V8W 2V8", 
+      "region": "BC", 
+      "street": "222 SUMMER STREET"
+    }, 
+    "businessName": "ABC SEARCHING COMPANY", 
+    "emailAddress": "bsmith@abc-search.com"
+  }, 
+  "transferDate": "2022-10-08T09:00:00-07:53"
+}

--- a/mhr_api/tests/unit/reports/data/trans-test-example-tc.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example-tc.json
@@ -1,0 +1,87 @@
+{
+  "addOwnerGroups": [
+    {
+      "groupId": 3, 
+      "interest": "UNDIVIDED 1/5", 
+      "interestNumerator": 1, 
+      "owners": [
+        {
+          "address": {
+            "city": "LANGLEY", 
+            "country": "CA", 
+            "postalCode": "V3A 6H4", 
+            "region": "BC", 
+            "street": "6665 238TH STREET"
+          }, 
+          "individualName": {
+            "first": "JOHN", 
+            "last": "CONNOLLY", 
+            "middle": "STEVEN"
+          }, 
+          "phoneNumber": "604462027", 
+          "type": "COMMON"
+        }
+      ], 
+      "status": "ACTIVE", 
+      "tenancySpecified": true, 
+      "type": "COMMON"
+    }
+  ], 
+  "affirmByName": "BCREG2 Della FORTYTHREE", 
+  "attentionReference": "UT-TRANS-0005", 
+  "clientReferenceId": "UT-TRANS0015", 
+  "consideration": "$100000.00", 
+  "createDateTime": "2022-10-12T12:47:45-07:53", 
+  "declaredValue": 100000, 
+  "deleteOwnerGroups": [
+    {
+      "groupId": 2, 
+      "interest": "", 
+      "interestNumerator": 0, 
+      "owners": [
+        {
+          "address": {
+            "city": "QUEEN CHARLOTTE CITY", 
+            "country": "CA", 
+            "postalCode": "V0T 1S0", 
+            "region": "BC", 
+            "street": "315 2ND AVENUE"
+          }, 
+          "individualName": {
+            "first": "KATHERINE", 
+            "last": "ASHER", 
+            "middle": "DEBORAH"
+          }, 
+          "phoneNumber": "604", 
+          "type": "COMMON"
+        }
+      ], 
+      "status": "PREVIOUS", 
+      "tenancySpecified": true, 
+      "type": "COMMON"
+    }
+  ], 
+  "documentDescription": "SALE OR GIFT", 
+  "documentId": "10200078", 
+  "documentRegistrationNumber": "00500239", 
+  "documentType": "TRAN", 
+  "mhrNumber": "005569", 
+  "ownLand": true, 
+  "payment": {
+    "invoiceId": "22648", 
+    "receipt": "/api/v1/payment-requests/22648/receipts"
+  }, 
+  "status": "ACTIVE", 
+  "submittingParty": {
+    "address": {
+      "city": "VICTORIA", 
+      "country": "CA", 
+      "postalCode": "V8W 2V8", 
+      "region": "BC", 
+      "street": "222 SUMMER STREET"
+    }, 
+    "businessName": "ABC SEARCHING COMPANY", 
+    "emailAddress": "bsmith@abc-search.com"
+  }, 
+  "transferDate": "2022-10-12T09:00:00-07:53"
+}

--- a/mhr_api/tests/unit/reports/data/trans-test-example.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example.json
@@ -1,23 +1,23 @@
 {
   "addOwnerGroups": [
     {
-      "groupId": 9, 
+      "groupId": 5, 
       "interest": "", 
       "interestNumerator": 0, 
       "owners": [
         {
           "address": {
-            "street": "11670 79A AVE",
-            "city": "DELTA",
-            "region": "BC",
-            "country": "CA",
-            "postalCode": "V4C 6W1"
-          },
-          "individualName": {
-            "first": "KANWARDEEP", 
-            "last": "AHLUWALIA"
+            "city": "KELOWNA", 
+            "country": "CA", 
+            "postalCode": "V2F 6H4", 
+            "region": "BC", 
+            "street": "1234 FRONT STREET"
           }, 
-          "phoneNumber": "604462027", 
+          "individualName": {
+            "first": "FORD", 
+            "last": "PREFECT"
+          }, 
+          "phoneNumber": "604727123", 
           "type": "SOLE"
         }
       ], 
@@ -26,27 +26,31 @@
       "type": "SOLE"
     }
   ], 
-  "clientReferenceId": "UT-TRANS0007                  ", 
-  "createDateTime": "2022-09-26T13:59:56-07:53", 
+  "affirmByName": "BCREG2 Della FORTYTHREE", 
+  "attentionReference": "UT-TRANS-0004", 
+  "clientReferenceId": "UT-TRANS0014", 
+  "consideration": "$100000.00", 
+  "createDateTime": "2022-10-12T11:15:12-07:53", 
+  "declaredValue": 100000, 
   "deleteOwnerGroups": [
     {
-      "groupId": 8, 
+      "groupId": 4, 
       "interest": "", 
       "interestNumerator": 0, 
       "owners": [
         {
           "address": {
-            "city": "LANGLEY", 
+            "city": "KELOWNA", 
             "country": "CA", 
-            "postalCode": "V3A 6H4", 
+            "postalCode": "V2F 6H4", 
             "region": "BC", 
-            "street": "6665 238TH STREET"
+            "street": "1234 FRONT STREET"
           }, 
           "individualName": {
-            "first": "MAX", 
-            "last": "BICKNELL"
+            "first": "ARTHUR", 
+            "last": "DENT"
           }, 
-          "phoneNumber": "604462027", 
+          "phoneNumber": "604727123", 
           "type": "SOLE"
         }
       ], 
@@ -56,11 +60,14 @@
     }
   ], 
   "documentDescription": "SALE OR GIFT", 
-  "documentId": "10200036", 
-  "mhrNumber": "103425", 
+  "documentId": "10200077", 
+  "documentRegistrationNumber": "00500238", 
+  "documentType": "TRAN", 
+  "mhrNumber": "150155", 
+  "ownLand": true, 
   "payment": {
-    "invoiceId": "22308", 
-    "receipt": "/api/v1/payment-requests/22308/receipts"
+    "invoiceId": "22639", 
+    "receipt": "/api/v1/payment-requests/22639/receipts"
   }, 
   "status": "ACTIVE", 
   "submittingParty": {
@@ -73,5 +80,6 @@
     }, 
     "businessName": "ABC SEARCHING COMPANY", 
     "emailAddress": "bsmith@abc-search.com"
-  }
+  }, 
+  "transferDate": "2022-10-11T09:00:00-07:53"
 }

--- a/mhr_api/tests/unit/reports/test_report_registration_v2.py
+++ b/mhr_api/tests/unit/reports/test_report_registration_v2.py
@@ -36,22 +36,52 @@ REGISTRATON_JOINT_PDFFILE = 'tests/unit/reports/data/registration-joint-example.
 REGISTRATON_MAIL_PDFFILE = 'tests/unit/reports/data/registration-mail-example.pdf'
 REGISTRATON_COVER_PDFFILE = 'tests/unit/reports/data/registration-cover-example.pdf'
 
-TRANSFER_TEST_DATAFILE = 'tests/unit/reports/data/trans-test-example.json'
-TRANSFER_TEST_PDFFILE = 'tests/unit/reports/data/trans-test-example.pdf'
+TRANSFER_TEST_SO_DATAFILE = 'tests/unit/reports/data/trans-test-example.json'
+TRANSFER_TEST_SO_PDFFILE = 'tests/unit/reports/data/trans-test-example-so.pdf'
+TRANSFER_TEST_JT_DATAFILE = 'tests/unit/reports/data/trans-test-example-jt.json'
+TRANSFER_TEST_JT_PDFFILE = 'tests/unit/reports/data/trans-test-example-jt.pdf'
+TRANSFER_TEST_TC_DATAFILE = 'tests/unit/reports/data/trans-test-example-tc.json'
+TRANSFER_TEST_TC_PDFFILE = 'tests/unit/reports/data/trans-test-example-tc.pdf'
 REPORT_VERSION_V2 = '2'
 
 
-def test_transfer_trans(session, client, jwt):
+def test_transfer_trans_so(session, client, jwt):
     """Assert that generation of a test report is as expected."""
     # setup
     if is_report_v2():
-        json_data = get_json_from_file(TRANSFER_TEST_DATAFILE)
+        json_data = get_json_from_file(TRANSFER_TEST_SO_DATAFILE)
         report = Report(json_data, 'PS12345', ReportTypes.MHR_TRANSFER, 'Account Name')
         # test
         content, status, headers = report.get_pdf()
         assert headers
         # verify
-        check_response(content, status, TRANSFER_TEST_PDFFILE)
+        check_response(content, status, TRANSFER_TEST_SO_PDFFILE)
+
+
+def test_transfer_trans_jt(session, client, jwt):
+    """Assert that generation of a test report is as expected."""
+    # setup
+    if is_report_v2():
+        json_data = get_json_from_file(TRANSFER_TEST_JT_DATAFILE)
+        report = Report(json_data, 'PS12345', ReportTypes.MHR_TRANSFER, 'Account Name')
+        # test
+        content, status, headers = report.get_pdf()
+        assert headers
+        # verify
+        check_response(content, status, TRANSFER_TEST_JT_PDFFILE)
+
+
+def test_transfer_trans_tc(session, client, jwt):
+    """Assert that generation of a test report is as expected."""
+    # setup
+    if is_report_v2():
+        json_data = get_json_from_file(TRANSFER_TEST_TC_DATAFILE)
+        report = Report(json_data, 'PS12345', ReportTypes.MHR_TRANSFER, 'Account Name')
+        # test
+        content, status, headers = report.get_pdf()
+        assert headers
+        # verify
+        check_response(content, status, TRANSFER_TEST_TC_PDFFILE)
 
 
 def test_registration_test(session, client, jwt):


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13735

*Description of changes:*
- add transfer properties documentType, documentRegistrationNumber, affirmByName
- add transfer data validation rule to allow adding only 1 SO owner group and owner.
- fix owner save phone number bug missing digit - saving 9 characters instead of 10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
