### PR TITLE
Fix Home Owners Review page

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
@@ -13,7 +13,7 @@
           >Return to this step to complete it.
         </router-link>
       </div>
-      <section class="px-6 my-2" v-if="hasHomeOwners || hasGroups">
+      <section class="px-6 my-2" v-if="hasHomeOwners || (hasGroups && showGroups)">
         <article class="border-btm py-5">
           <v-row no-gutters data-test-id="home-tenancy-type">
             <v-col cols="3"><span class="generic-label">Home Tenancy Type </span></v-col>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13710

*Description of changes:*
- Fix to properly show Home Owners on the Review page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
