### PR TITLE
MHR api owner, owner group updates.

### DIFF
--- a/mhr_api/report-templates/coverV2.html
+++ b/mhr_api/report-templates/coverV2.html
@@ -63,8 +63,8 @@
         {% endif %}
       </div>
       <div class="cover-data"><span class="cover-data-bold">Document Registration Number:</span>
-        {% if documentRegistrationId is defined and documentRegistrationId != '' %}
-         {{ documentRegistrationId }}
+        {% if documentRegistrationNumber is defined and documentRegistrationNumber != '' %}
+         {{ documentRegistrationNumber }}
         {% else %}
           N/A
         {% endif %}

--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -1,5 +1,5 @@
 <div class="section-title mt-3">
-    {% if documentType in ('TRAN', 'DEAT') %}New{% endif %} Registered Owner(s) Information
+    {% if registrationType in ('TRANS', 'TRAND') %}New{% endif %} Registered Owner(s) Information
 </div>
 {% if ownerGroups is defined %}
     {% if ownerGroups|length > 1 %}

--- a/mhr_api/report-templates/template-parts/registration/submittingParty.html
+++ b/mhr_api/report-templates/template-parts/registration/submittingParty.html
@@ -27,7 +27,7 @@
                      {{ submittingParty.address.country }}</div>
             </td>
             <td class="col-33">
-                {% if documentType in ('TRAN', 'DEAT')  %}
+                {% if registrationType in ('TRANS', 'TRAND')  %}
                     <div class="section-sub-title">Affirmed By</div>
                     <div class="pt-2">
                         {% if affirmByName is defined and affirmByName != '' %} 

--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.5.3
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.6.4#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.5#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.6.4#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.5#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -199,9 +199,8 @@ class Db2Descript(db.Model):
             description['lengthInches4'] = self.length_inches_4
             description['widthFeet4'] = self.width_feet_4
             description['widthInches4'] = self.width_inches_4
-        if self.engineer_date:
+        if self.engineer_date and self.engineer_date.year > 1900:
             description['engineerDate'] = model_utils.format_local_date(self.engineer_date)
-
         return description
 
     @property
@@ -260,10 +259,8 @@ class Db2Descript(db.Model):
             'rebuiltRemarks': self.rebuilt_remarks,
             'otherRemarks': self.other_remarks
         }
-        if self.engineer_date:
+        if self.engineer_date and self.engineer_date.year > 1900:
             description['engineerDate'] = model_utils.format_local_date(self.engineer_date)
-        if description.get('engineerDate', '') == '0001-01-01':
-            del description['engineerDate']
         if self.circa == '?':
             description['baseInformation']['circa'] = True
         return description

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -258,12 +258,14 @@ class MhrRegistrationStatusTypes(BaseEnum):
 class MhrRegistrationTypes(BaseEnum):
     """Render an Enum of the MHR registration types."""
 
+    DECAL_REPLACE = 'DECAL_REPLACE'
     MHREG = 'MHREG'
     TRAND = 'TRAND'
     TRANS = 'TRANS'
     EXEMPTION_RES = 'EXEMPTION_RES'
     EXEMPTION_NON_RES = 'EXEMPTION_NON_RES'
     PERMIT = 'PERMIT'
+    PERMIT_EXTENSION = 'PERMIT_EXTENSION'
 
 
 class MhrStatusTypes(BaseEnum):

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -270,6 +270,7 @@ COUNTRY_CA = 'CA'
 COUNTRY_US = 'US'
 PROVINCE_BC = 'BC'
 REGISTRATION_PATH = '/mhr/api/v1/registrations/'
+OWNER_INTEREST_UNDIVIDED = 'UNDIVIDED'
 
 
 def get_max_registrations_size():

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -321,7 +321,9 @@ class Report:  # pylint: disable=too-few-public-methods
                 self._set_ppr_search()
             if self._report_key != ReportTypes.MHR_TRANSFER:
                 self._set_location()
+                current_app.logger.info('5')
                 self._set_description()
+                current_app.logger.info('6')
         return self._report_data
 
     def _set_ppr_search(self):  # pylint: disable=too-many-branches, too-many-statements
@@ -436,15 +438,18 @@ class Report:  # pylint: disable=too-few-public-methods
                         detail['declaredValue'] = '$' + '{:0,.2f}'.format(float(declared_value))
                     else:
                         detail['declaredValue'] = ''
-                    if detail.get('description') and 'engineerDate' in detail['description']:
+                    if detail.get('description') and detail['description'].get('engineerDate'):
                         if detail['description']['engineerDate'] == '0001-01-01':
                             detail['description']['engineerDate'] = ''
                         else:
                             detail['description']['engineerDate'] = \
-                                Report._to_report_datetime(detail['description']['engineerDate'], False)
+                                   Report._to_report_datetime(detail['description']['engineerDate'], False)
+                    else:
+                        detail['description']['engineerDate'] = ''
         elif self._report_key == ReportTypes.MHR_REGISTRATION:
             reg = self._report_data
             reg['createDateTime'] = Report._to_report_datetime(reg['createDateTime'])
+            current_app.logger.info('4')
             if reg.get('declaredDateTime'):
                 reg['declaredDateTime'] = Report._to_report_datetime(reg['declaredDateTime'], False)
             declared_value = str(reg['declaredValue'])
@@ -452,12 +457,14 @@ class Report:  # pylint: disable=too-few-public-methods
                 reg['declaredValue'] = '$' + '{:0,.2f}'.format(float(declared_value))
             else:
                 reg['declaredValue'] = ''
-            if reg.get('description') and 'engineerDate' in reg['description']:
+            if reg.get('description') and reg['description'].get('engineerDate'):
                 if reg['description']['engineerDate'] == '0001-01-01':
                     reg['description']['engineerDate'] = ''
                 else:
                     reg['description']['engineerDate'] = \
                         Report._to_report_datetime(reg['description']['engineerDate'], False)
+            else:
+                reg['description']['engineerDate'] = ''
         elif self._report_key == ReportTypes.MHR_TRANSFER:
             reg = self._report_data
             reg['createDateTime'] = Report._to_report_datetime(reg['createDateTime'])

--- a/mhr_api/src/mhr_api/services/payment/client/__init__.py
+++ b/mhr_api/src/mhr_api/services/payment/client/__init__.py
@@ -419,8 +419,7 @@ class SBCPaymentClient(BaseClient):
             del data['details']
         # current_app.logger.debug('create non-staff search paymnent payload:')
         # current_app.logger.debug(json.dumps(data))
-        include_account = not staff_gov
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=include_account)
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data)
         invoice_id = str(invoice_data['id'])
         receipt_path = self.api_url.replace('https://', '')
         receipt_path = receipt_path[receipt_path.find('/'): None] + PATH_RECEIPT.format(invoice_id=invoice_id)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.1'  # pylint: disable=invalid-name
+__version__ = '1.1.2'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_owngroup.py
+++ b/mhr_api/tests/unit/models/db2/test_owngroup.py
@@ -27,6 +27,15 @@ TEST_DATA = [
     (True, 101917, 1, '60164729', 'SO'),
     (False, 0, 0, None, None)
 ]
+# testdata pattern is ({interest}, {numerator}, {denominator})
+TEST_DATA_INTEREST = [
+    ('', 0, 0),
+    ('1/2', 1, 2),
+    ('UNDIVIED 9/10', 9, 10),
+    ('UNDIVIDED 3/8', 3, 8),
+    ('UNDIVIDED 1/2 INT.', 1, 2),
+    ('A 55/100 INTEREST', 55, 100)
+]
 
 
 @pytest.mark.parametrize('exists,manuhome_id,group_id,reg_doc_id,type', TEST_DATA)
@@ -104,6 +113,16 @@ def test_find_by_reg_doc_id(session, exists, manuhome_id, group_id, reg_doc_id, 
         assert not groups
 
 
+@pytest.mark.parametrize('interest, numerator, denominator', TEST_DATA_INTEREST)
+def test_get_interest_fraction(interest, numerator, denominator):
+    """Assert that find document by manuhome id contains all expected elements."""
+    owngroup = Db2Owngroup(interest=interest, interest_numerator=1, tenancy_type='TC')
+    num_value = owngroup.get_interest_fraction(True)
+    den_value = owngroup.get_interest_fraction(False)
+    assert num_value == numerator
+    assert den_value == denominator
+
+
 def test_owngroup_json(session):
     """Assert that the owngroup renders to a json format correctly."""
     owngroup = Db2Owngroup(manuhome_id=1,
@@ -118,7 +137,7 @@ def test_owngroup_json(session):
                            lessor='',
                            interest='interest',
                            interest_numerator=0,
-                           tenancy_specified='tenancy_specified')
+                           tenancy_specified='Y')
 
     test_json = {
         'manuhomeId': owngroup.manuhome_id,
@@ -134,6 +153,7 @@ def test_owngroup_json(session):
         'lessor': owngroup.lessor,
         'interest': owngroup.interest,
         'interestNumerator': owngroup.interest_numerator,
+        'interestDenominator': 0,
         'tenancySpecified': owngroup.tenancy_specified
     }
     assert owngroup.json == test_json

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -155,7 +155,7 @@ def test_find_by_id(session, reg_id, has_results, legacy):
             # current_app.logger.debug(report_json)
             assert report_json.get('documentDescription')
             assert report_json.get('documentId')
-            assert report_json.get('documentRegistrationId')
+            assert report_json.get('documentRegistrationNumber')
     else:
         assert not registration
 
@@ -266,6 +266,8 @@ def test_create_new_from_json(session):
     assert location.change_registration_id > 0
     assert location.location_type in MhrLocationTypes
     assert location.status_type in MhrStatusTypes
+    mh_json = registration.new_registration_json
+    assert mh_json
 
 
 def test_save_new(session):
@@ -274,6 +276,8 @@ def test_save_new(session):
     json_data['documentId'] = '88878888'
     registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
     registration.save()
+    mh_json = registration.new_registration_json
+    assert mh_json
     reg_new = MhrRegistration.find_by_mhr_number(registration.mhr_number, 'PS12345')
     assert reg_new
     draft_new = MhrDraft.find_by_draft_number(registration.draft.draft_number, True)

--- a/mhr_api/tests/unit/reports/data/registration-test-example.json
+++ b/mhr_api/tests/unit/reports/data/registration-test-example.json
@@ -28,6 +28,7 @@
   }, 
   "documentDescription": "REGISTER NEW UNIT", 
   "documentId": "80049421", 
+  "documentRegistrationNumber": "00269803", 
   "location": {
     "additionalDescription": "", 
     "address": {

--- a/mhr_api/tests/unit/reports/data/trans-test-example-jt.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example-jt.json
@@ -105,7 +105,7 @@
   "documentDescription": "SALE OR GIFT", 
   "documentId": "10200079", 
   "documentRegistrationNumber": "00500240", 
-  "documentType": "TRAN", 
+  "registrationType": "TRANS",
   "mhrNumber": "100173", 
   "ownLand": true, 
   "payment": {

--- a/mhr_api/tests/unit/reports/data/trans-test-example-tc.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example-tc.json
@@ -64,7 +64,7 @@
   "documentDescription": "SALE OR GIFT", 
   "documentId": "10200078", 
   "documentRegistrationNumber": "00500239", 
-  "documentType": "TRAN", 
+  "registrationType": "TRANS",
   "mhrNumber": "005569", 
   "ownLand": true, 
   "payment": {

--- a/mhr_api/tests/unit/reports/data/trans-test-example.json
+++ b/mhr_api/tests/unit/reports/data/trans-test-example.json
@@ -62,7 +62,7 @@
   "documentDescription": "SALE OR GIFT", 
   "documentId": "10200077", 
   "documentRegistrationNumber": "00500238", 
-  "documentType": "TRAN", 
+  "registrationType": "TRANS",
   "mhrNumber": "150155", 
   "ownLand": true, 
   "payment": {

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -21,7 +21,7 @@ from registry_schemas.example_data.mhr import REGISTRATION, TRANSFER
 
 from mhr_api.utils import registration_validator as validator
 from mhr_api.models import MhrRegistration
-from mhr_api.models.type_tables import MhrRegistrationStatusTypes
+from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrTenancyTypes
 from mhr_api.models.utils import is_legacy
 
 
@@ -116,8 +116,141 @@ SO_GROUP_MULTIPLE = [
         'type': 'SOLE'
     }
 ]
-
-
+TC_GROUPS_VALID = [
+    {
+        'groupId': 1,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED 1/2',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    },
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED 1/2',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }
+]
+TC_GROUP_VALID = {
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567'
+        }
+    ],
+    'type': 'COMMON',
+    'interest': 'UNDIVIDED 1/2',
+    'interestNumerator': 1,
+    'interestDenominator': 2
+}
+TC_GROUP_TRANSFER_DELETE = [
+    {
+        'groupId': 4,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED 1/2',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }
+]
+TC_GROUP_TRANSFER_ADD = [
+    {
+        'groupId': 5,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED 1/2',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }
+]
+INTEREST_VALID_1 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 2 }
+]
+INTEREST_VALID_2 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
+]
+INTEREST_VALID_3 = [
+    { 'numerator': 1, 'denominator': 10 }, { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 5 }
+]
+INTEREST_INVALID_1 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }
+]
+INTEREST_INVALID_2 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
+]
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content})
 TEST_REG_DATA = [
     (DESC_VALID, True, True, DOC_ID_VALID, None),
@@ -193,13 +326,35 @@ TEST_TRANSFER_DATA_SO = [
     ('Invalid add SO 2 groups', False, SO_GROUP_MULTIPLE, validator.ADD_SOLE_OWNER_INVALID),
     ('Invalid add SO 2 owners', False, SO_OWNER_MULTIPLE, validator.ADD_SOLE_OWNER_INVALID)
 ]
+# testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {message content})
+TEST_REG_DATA_COMMON = [
+    ('Invalid only 1 group', False, 2, 2, validator.GROUP_COMMON_INVALID),
+    ('Invalid numerator missing', False, None, 2, validator.GROUP_NUMERATOR_MISSING),
+    ('Invalid numerator < 1', False, 0, 2, validator.GROUP_NUMERATOR_MISSING),
+    ('Invalid denominator missing', False, 1, None, validator.GROUP_DENOMINATOR_MISSING),
+    ('Invalid denominator < 1', False, 1, 0, validator.GROUP_DENOMINATOR_MISSING)
+]
+# testdata pattern is ({description}, {valid}, {interest_data}, {common_denominator}, {message content})
+TEST_DATA_GROUP_INTEREST = [
+    ('Valid 2 groups', True, INTEREST_VALID_1, 2, None),
+    ('Valid 3 groups', True, INTEREST_VALID_2, 4, None),
+    ('Valid 3 groups', True, INTEREST_VALID_3, 10, None),
+    ('Invalid numerator sum low', False, INTEREST_INVALID_1, 4, validator.GROUP_INTEREST_MISMATCH),
+    ('Inalid numerator sum high', False, INTEREST_INVALID_2, 4, validator.GROUP_INTEREST_MISMATCH)
+]
+# testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {message content})
+TEST_TRANSFER_DATA_GROUP_INTEREST = [
+    ('Valid add', True, 1, 2, None),
+    ('Invalid numerator < 1', False, 1, 4, validator.GROUP_INTEREST_MISMATCH),
+    ('Invalid numerator sum high', False, 3, 4, validator.GROUP_INTEREST_MISMATCH)
+]
 
 
 @pytest.mark.parametrize('desc,valid,staff,doc_id,message_content', TEST_REG_DATA)
 def test_validate_registration(session, desc, valid, staff, doc_id, message_content):
     """Assert that new MH registration validation works as expected."""
     # setup
-    json_data = copy.deepcopy(REGISTRATION)
+    json_data = get_valid_registration(MhrTenancyTypes.SOLE)
     if desc == DESC_MISSING_OWNER_GROUP:
         del json_data['ownerGroups']
     elif desc == DESC_MISSING_SUBMITTING:
@@ -211,6 +366,40 @@ def test_validate_registration(session, desc, valid, staff, doc_id, message_cont
     valid_format, errors = schema_utils.validate(json_data, 'registration', 'mhr')
     # Additional validation not covered by the schema.
     error_msg = validator.validate_registration(json_data, staff)
+    if errors:
+        current_app.logger.debug(errors)
+    if valid:
+        assert valid_format and error_msg == ''
+    else:
+        assert error_msg != ''
+        if message_content:
+            assert error_msg.find(message_content) != -1
+
+
+@pytest.mark.parametrize('desc,valid,numerator,denominator,message_content', TEST_REG_DATA_COMMON)
+def test_validate_registration_common(session, desc, valid, numerator, denominator, message_content):
+    """Assert that new MH registration validation works as expected."""
+    # setup
+    json_data = get_valid_registration(MhrTenancyTypes.COMMON)
+    if json_data.get('documentId'):
+        del json_data['documentId']
+    if desc == 'Invalid only 1 group':
+        del json_data['ownerGroups'][1]
+    else:
+        for group in json_data.get('ownerGroups'):
+            if not numerator:
+                if 'interestNumerator' in group:
+                    del group['interestNumerator']
+                else:
+                    group['interestNumerator'] = numerator
+            if not denominator:
+                if 'interestDenominator' in group:
+                    del group['interestDenominator']
+                else:
+                    group['interestDenominator'] = denominator
+    valid_format, errors = schema_utils.validate(json_data, 'registration', 'mhr')
+    # Additional validation not covered by the schema.
+    error_msg = validator.validate_registration(json_data, False)
     if errors:
         current_app.logger.debug(errors)
     if valid:
@@ -313,6 +502,28 @@ def test_validate_transfer_so(session, desc, valid, add_group, message_content):
             assert error_msg.find(message_content) != -1
 
 
+@pytest.mark.parametrize('desc,valid,numerator,denominator,message_content', TEST_TRANSFER_DATA_GROUP_INTEREST)
+def test_validate_transfer_group_interest(session, desc, valid, numerator, denominator, message_content):
+    """Assert that transfer group interest validation works as expected."""
+    # setup
+    json_data = copy.deepcopy(TRANSFER)
+    json_data['deleteOwnerGroups'] = copy.deepcopy(TC_GROUP_TRANSFER_DELETE)
+    json_data['addOwnerGroups'] = copy.deepcopy(TC_GROUP_TRANSFER_ADD)
+    json_data['addOwnerGroups'][0]['interestNumerator'] = numerator
+    json_data['addOwnerGroups'][0]['interestDenominator'] = denominator
+    valid_format, errors = schema_utils.validate(json_data, 'transfer', 'mhr')
+    registration: MhrRegistration = MhrRegistration.find_by_mhr_number('088912', 'PS12345')
+    error_msg = validator.validate_transfer(registration, json_data, False)
+    if errors:
+        current_app.logger.debug(errors)
+    if valid:
+        assert valid_format and error_msg == ''
+    else:
+        assert error_msg != ''
+        if message_content:
+            assert error_msg.find(message_content) != -1
+
+
 @pytest.mark.parametrize('desc,bus_name,first,middle,last,message_content,data', TEST_PARTY_DATA)
 def test_validate_submitting(session, desc, bus_name, first, middle, last, message_content, data):
     """Assert that submitting party invalid character set validation works as expected."""
@@ -372,7 +583,7 @@ def test_validate_owner(session, desc, bus_name, first, middle, last, message_co
 def test_validate_reg_location(session, desc, park_name, dealer, additional, except_plan, message_content):
     """Assert that location invalid character set validation works as expected."""
     # setup
-    json_data = copy.deepcopy(REGISTRATION)
+    json_data = get_valid_registration(MhrTenancyTypes.SOLE)
     location = json_data.get('location')
     if park_name:
         location['parkName'] = park_name
@@ -393,7 +604,7 @@ def test_validate_registration_legacy(session, desc, valid, street, city, messag
     """Assert that new MH registration legacy validation works as expected."""
     if is_legacy():
         # setup
-        json_data = copy.deepcopy(REGISTRATION)
+        json_data = get_valid_registration(MhrTenancyTypes.SOLE)
         json_data['location']['address']['street'] = street
         json_data['location']['address']['city'] = city
         valid_format, errors = schema_utils.validate(json_data, 'registration', 'mhr')
@@ -412,3 +623,34 @@ def test_checksum_valid(session, doc_id, valid):
     """Assert that the document id checksum validation works as expected."""
     result = validator.checksum_valid(doc_id)
     assert result == valid
+
+
+@pytest.mark.parametrize('desc, valid, interest_data, common_den, message_content', TEST_DATA_GROUP_INTEREST)
+def test_validate_group_interest(session, desc, valid, interest_data, common_den, message_content):
+    """Assert that the group interest validation works as expected."""
+    json_data = []
+    for interest in interest_data:
+        group = copy.deepcopy(TC_GROUP_VALID)
+        group['interestNumerator'] = interest.get('numerator')
+        group['interestDenominator'] = interest.get('denominator')
+        json_data.append(group)
+    error_msg = validator.validate_group_interest(json_data, common_den)
+    if valid:
+        assert error_msg == ''
+    else:
+        assert error_msg != ''
+        if message_content:
+            assert error_msg.find(message_content) != -1
+
+
+def get_valid_registration(type):
+    """Build a valid registration"""
+    json_data = copy.deepcopy(REGISTRATION)
+    if type == MhrTenancyTypes.COMMON:
+        json_data['ownerGroups'] = TC_GROUPS_VALID
+    else:
+        for group in json_data.get('ownerGroups'):
+            if group.get('type', '') in ('TC', 'COMMON'):
+                group['interestNumerator'] = 1
+                group['interestDenominator'] = 2
+    return json_data


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13934

*Description of changes:*
- Return an ownerId in the new MH registration and transfer responses
- For legacy registrations derive the interestDenominator value from the interest description
- Include interestDenominator in the ownerGroup for a registration response
- For tenants in common groups require and validate the group interestNumerator and interestDenominator for new registrations. Set the legacy interest description with the group interestNumerator and interestDenominator values.
- Change tenancy specified default to Y.
- 13854 gov agent submit account id with pay api request.
- Refactor documentType to registrationType (reports) to match the API spec.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
