### PR TITLE
Clean up Tech Debt - Refactor Group Ids as numbers

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -254,7 +254,7 @@ import { useGetters } from 'vuex-composition-helpers'
 import { find } from 'lodash'
 
 interface FractionalOwnershipWithGroupIdIF extends MhrRegistrationFractionalOwnershipIF {
-  groupId: string
+  groupId: number
 }
 
 let DEFAULT_OWNER_ID = 1
@@ -339,7 +339,7 @@ export default defineComponent({
 
     const allFractionalData = (getTransferOrRegistrationHomeOwnerGroups() || [{}]).map(group => {
       return {
-        groupId: group.groupId || '1',
+        groupId: group.groupId || 1,
         type: group?.type || '',
         interest: group?.interest || '',
         interestNumerator: group?.interestNumerator || null,
@@ -353,7 +353,7 @@ export default defineComponent({
 
     if (allFractionalData.length === 0 || props.editHomeOwner == null || hasMultipleOwnersInGroup) {
       allFractionalData.push({
-        groupId: (allFractionalData.length + 1).toString(),
+        groupId: (allFractionalData.length + 1),
         type: 'N/A',
         interest: '',
         interestNumerator: null,
@@ -377,7 +377,7 @@ export default defineComponent({
       showGroups: showGroups,
       isPerson: props.isHomeOwnerPerson,
       isAddingHomeOwner: props.editHomeOwner == null,
-      groupFractionalData: computed(() => find(allFractionalData, { groupId: localState.ownerGroupId || '1' })),
+      groupFractionalData: computed(() => find(allFractionalData, { groupId: localState.ownerGroupId || 1 })),
       isHomeOwnerFormValid: false,
       isAddressFormValid: false,
       triggerAddressErrors: false,
@@ -409,7 +409,7 @@ export default defineComponent({
         if (props.editHomeOwner) {
           editHomeOwner(
             localState.owner as MhrRegistrationHomeOwnerIF,
-            localState.ownerGroupId || '1'
+            localState.ownerGroupId || 1
           )
         } else {
           addOwnerToTheGroup(
@@ -428,7 +428,7 @@ export default defineComponent({
             groupId: localState.ownerGroupId
           }) as FractionalOwnershipWithGroupIdIF
 
-          setGroupFractionalInterest(localState.ownerGroupId || '1', fractionalData)
+          setGroupFractionalInterest(localState.ownerGroupId || 1, fractionalData)
         } else if (localState.group) {
           // this condition should only occur when trying to delete a group
           // clear out any fractional info

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
@@ -68,7 +68,7 @@ export default defineComponent({
   name: 'FractionalOwnership',
   props: {
     groupId: {
-      type: String,
+      type: Number,
       required: true
     },
     editHomeOwner: {

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
@@ -69,13 +69,13 @@ import { MhrRegistrationFractionalOwnershipIF } from '@/interfaces/mhr-registrat
 
 // Interface for readonly and Edit button states for Owner Groups
 interface ReadonlyOwnerGroupStateIF {
-  groupId: string,
+  groupId: number,
   isReadonly: Boolean,
   hasEditButton: Boolean
 }
 
 interface FractionalOwnershipWithGroupIdIF extends MhrRegistrationFractionalOwnershipIF {
-  groupId: string
+  groupId: number
 }
 
 export default defineComponent({
@@ -85,7 +85,7 @@ export default defineComponent({
     FractionalOwnership
   },
   props: {
-    groupId: { type: String },
+    groupId: { type: Number },
     fractionalData: { type: Object as () => FractionalOwnershipWithGroupIdIF },
     isAddingHomeOwner: { type: Boolean }, // makes additional Group available in dropdown when adding a new home owner
     isMhrTransfer: { type: Boolean, default: false }
@@ -119,13 +119,13 @@ export default defineComponent({
       allGroupsState: getTransferOrRegistrationHomeOwnerGroups()
         .map(group => {
           return {
-            groupId: group.groupId.toString(),
+            groupId: group.groupId,
             isReadonly: true && showGroups.value,
             hasEditButton: true && showGroups.value
           }
         })
         .concat({
-          groupId: (homeOwnerGroups.length + 1).toString(),
+          groupId: (homeOwnerGroups.length + 1),
           isReadonly: false,
           hasEditButton: false
         }) as ReadonlyOwnerGroupStateIF[],
@@ -135,13 +135,13 @@ export default defineComponent({
       showEditFractionalOwnershipBtn: true
     })
 
-    const setOwnerGroupId = (groupId: string): void => {
+    const setOwnerGroupId = (groupId: number): void => {
       emit('setOwnerGroupId', groupId)
     }
 
     const openEditFractionalOwnership = (): void => {
       const groupState = find(
-        localState.allGroupsState, { groupId: localState.ownerGroupId.toString() }) as ReadonlyOwnerGroupStateIF
+        localState.allGroupsState, { groupId: localState.ownerGroupId }) as ReadonlyOwnerGroupStateIF
       groupState.hasEditButton = false
       groupState.isReadonly = false
     }

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -104,7 +104,7 @@ import { MhrRegistrationFractionalOwnershipIF } from '@/interfaces/mhr-registrat
 export default defineComponent({
   name: 'TableGroupHeader',
   props: {
-    groupId: { default: '' },
+    groupId: { default: 1 },
     owners: { default: [] },
     showEditActions: { type: Boolean, default: true },
     isMhrTransfer: { type: Boolean, default: false }
@@ -178,7 +178,7 @@ export default defineComponent({
     )
 
     // Close Delete Group dialog or proceed to deleting a Group
-    const cancelOrProceed = (proceed: boolean, groupId: string): void => {
+    const cancelOrProceed = (proceed: boolean, groupId: number): void => {
       if (proceed) {
         deleteGroup(groupId)
         localState.showDeleteGroupDialog = false

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -13,7 +13,7 @@ import { MhrCompVal, MhrSectVal } from '@/composables/mhrRegistration/enums'
 import { useMhrValidations } from '@/composables'
 import { find, remove, set, findIndex, sumBy } from 'lodash'
 
-const DEFAULT_GROUP_ID = '1'
+const DEFAULT_GROUP_ID = 1
 
 // Show or hide grouping of the Owners in the table
 const showGroups = ref(false)
@@ -121,7 +121,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
   // WORKING WITH GROUPS
 
   // Generate dropdown items for the group selection
-  const getGroupDropdownItems = (isAddingHomeOwner: Boolean, groupId: string): Array<any> => {
+  const getGroupDropdownItems = (isAddingHomeOwner: Boolean, groupId: number): Array<any> => {
     // Make additional Group available in dropdown when adding a new home owner
     // or when there are more than one owner in the group
 
@@ -140,7 +140,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
       return Array(homeOwnerGroups.length + numOfAdditionalGroupsInDropdown)
         .fill({})
         .map((v, i) => {
-          return { text: 'Group ' + (i + 1), value: (i + 1).toString() }
+          return { text: 'Group ' + (i + 1), value: (i + 1) }
         })
     } else {
       return [
@@ -160,7 +160,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
     })
   }
 
-  const addOwnerToTheGroup = (owner: MhrRegistrationHomeOwnerIF, groupId: string) => {
+  const addOwnerToTheGroup = (owner: MhrRegistrationHomeOwnerIF, groupId: number) => {
     let homeOwnerGroups
 
     if (isMhrTransfer) {
@@ -192,7 +192,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
       : setMhrRegistrationHomeOwnerGroups(homeOwnerGroups)
   }
 
-  const editHomeOwner = (updatedOwner: MhrRegistrationHomeOwnerIF, newGroupId: string) => {
+  const editHomeOwner = (updatedOwner: MhrRegistrationHomeOwnerIF, newGroupId: number) => {
     const homeOwnerGroups = isMhrTransfer
       ? [...getMhrTransferHomeOwnerGroups.value]
       : [...getMhrRegistrationHomeOwnerGroups.value]
@@ -239,14 +239,14 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
   }
 
   // Delete group with its owners
-  const deleteGroup = (groupId: string): void => {
+  const deleteGroup = (groupId: number): void => {
     const homeOwnerGroups: MhrRegistrationHomeOwnerGroupIF[] = isMhrTransfer
       ? [...getMhrTransferHomeOwnerGroups.value]
       : [...getMhrRegistrationHomeOwnerGroups.value]
 
     remove(homeOwnerGroups, group => group.groupId === groupId)
     homeOwnerGroups.forEach((group, index) => {
-      group.groupId = (index + 1).toString()
+      group.groupId = (index + 1)
     })
 
     isMhrTransfer
@@ -254,7 +254,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
       : setMhrRegistrationHomeOwnerGroups(homeOwnerGroups)
   }
 
-  const setGroupFractionalInterest = (groupId: string, fractionalData: MhrRegistrationFractionalOwnershipIF): void => {
+  const setGroupFractionalInterest = (groupId: number, fractionalData: MhrRegistrationFractionalOwnershipIF): void => {
     const homeOwnerGroups = getTransferOrRegistrationHomeOwnerGroups()
 
     const allGroupsTotals = homeOwnerGroups.map(group => group.interestTotal)

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerGroupIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerGroupIF.ts
@@ -1,7 +1,7 @@
 import { MhrRegistrationHomeOwnerIF } from './MhrRegistrationHomeOwnerIF'
 import { MhrRegistrationFractionalOwnershipIF } from './MhrRegistrationFractionalOwnershipIF'
 export interface MhrRegistrationHomeOwnerGroupIF extends MhrRegistrationFractionalOwnershipIF {
-  groupId: string,
+  groupId: number,
   owners: MhrRegistrationHomeOwnerIF[],
   type: string // type is required for MHR submission
 }

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerIF.ts
@@ -3,7 +3,7 @@ import { ActionTypes } from '@/enums'
 
 export interface MhrRegistrationHomeOwnerIF {
   id?: string // optional property used for editing a home owner
-  groupId?: string
+  groupId?: number
   action?: ActionTypes
   individualName?: {
     first: string

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -197,8 +197,6 @@ export default defineComponent({
         for (const [index, owner] of ownerGroup.owners.entries()) {
           owner.id = ownerGroup.groupId + (index + 1)
         }
-        // TODO: refactor all group Ids to be numbers as per spec
-        ownerGroup.groupId = ownerGroup.groupId.toString()
       })
       setShowGroups(currentOwnerGroups.length > 1)
 

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -140,7 +140,7 @@ describe('Mhr Information', () => {
     const owners = [mockedAddedPerson, mockedRemovedPerson] as MhrRegistrationHomeOwnerIF[] // same IF for Transfer and Registration
     const homeOwnerGroup = [
       mockMhrTransferCurrentHomeOwner,
-      { groupId: '2', owners: owners }
+      { groupId: 1, owners: owners }
     ] as MhrRegistrationHomeOwnerGroupIF[]
 
     await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
@@ -229,7 +229,7 @@ describe('Mhr Information', () => {
     const homeOwnerGroups = store.getters.getMhrTransferHomeOwnerGroups as MhrRegistrationHomeOwnerGroupIF[]
 
     // Add a second Group
-    const NEW_GROUP_ID = '3'
+    const NEW_GROUP_ID = 3
     const newHomeOwnerGroup = { groupId: NEW_GROUP_ID, owners: [mockedPerson] } as MhrRegistrationHomeOwnerGroupIF
     homeOwnerGroups.push(newHomeOwnerGroup)
     await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroups)

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -163,7 +163,7 @@ describe('Mhr Information', () => {
     wrapper.vm.$data.dataLoaded = true
     await Vue.nextTick()
 
-    const homeOwnerGroup = [{ groupId: '1', owners: [mockedPerson] }]
+    const homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson] }]
 
     expect(wrapper.findComponent(HomeOwners).vm.$data.getHomeOwners.length).toBe(1)
     expect(
@@ -174,7 +174,7 @@ describe('Mhr Information', () => {
     ).toBe(HomeTenancyTypes.SOLE)
 
     // Add a second Owner
-    homeOwnerGroup.push({ groupId: '1', owners: [mockedOrganization] })
+    homeOwnerGroup.push({ groupId: 1, owners: [mockedOrganization] })
 
     await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
     await Vue.nextTick()

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -114,7 +114,7 @@ describe('Home Owners', () => {
 
   it('renders home owner (person and org) via store dispatch', async () => {
     const owners = [mockedPerson] as MhrRegistrationHomeOwnerIF[]
-    const homeOwnerGroup = [{ groupId: '1', owners: owners }] as MhrRegistrationHomeOwnerGroupIF[]
+    const homeOwnerGroup = [{ groupId: 1, owners: owners }] as MhrRegistrationHomeOwnerGroupIF[]
 
     // add a person
     await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroup)
@@ -167,7 +167,7 @@ describe('Home Owners', () => {
 
   it('should edit home owner', async () => {
     const homeOwnerGroup = [
-      { groupId: '1', owners: [mockedPerson, mockedOrganization] }
+      { groupId: 1, owners: [mockedPerson, mockedOrganization] }
     ] as MhrRegistrationHomeOwnerGroupIF[]
 
     await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroup)
@@ -204,8 +204,8 @@ describe('Home Owners', () => {
 
   it('should delete a home owner group', async () => {
     const homeOwnerGroups = [
-      { groupId: '1', owners: [mockedPerson] },
-      { groupId: '2', owners: [mockedOrganization] }
+      { groupId: 1, owners: [mockedPerson] },
+      { groupId: 2, owners: [mockedOrganization] }
     ] as MhrRegistrationHomeOwnerGroupIF[]
 
     await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroups)
@@ -232,7 +232,7 @@ describe('Home Owners', () => {
 
     // delete first group (person)
     const homeOwnersTableData = wrapper.findComponent(HomeOwnersTable).vm.$data
-    await homeOwnersTableData.deleteGroup('1')
+    await homeOwnersTableData.deleteGroup(1)
 
     // second group should become first
     expect(wrapper.findComponent(HomeOwnersTable).text()).toContain(mockedOrganization.organizationName)
@@ -243,7 +243,7 @@ describe('Home Owners', () => {
   it('should show fractional ownership', async () => {
     const homeOwnerGroup = [
       {
-        groupId: '1',
+        groupId: 1,
         owners: [mockedPerson, mockedOrganization],
         interest: 'Undivided',
         interestNumerator: 123,
@@ -272,7 +272,7 @@ describe('Home Owners', () => {
   })
 
   it('should correctly display At Least One Owner check mark', async () => {
-    await store.dispatch('setMhrRegistrationHomeOwnerGroups', [{ groupId: '1', owners: [mockedPerson] }])
+    await store.dispatch('setMhrRegistrationHomeOwnerGroups', [{ groupId: 1, owners: [mockedPerson] }])
 
     const registeredOwnerCheck = wrapper.findComponent(HomeOwners).find(getTestId('reg-owner-checkmark'))
     expect(registeredOwnerCheck.exists()).toBeTruthy()
@@ -300,7 +300,7 @@ describe('Home Owners', () => {
 
     const homeOwnerGroup = [
       {
-        groupId: '2',
+        groupId: 2,
         owners: [mockedOrganization],
         interest: 'Undivided',
         interestNumerator: 123,
@@ -343,7 +343,7 @@ describe('Home Owners', () => {
   it('should keep the Group shown after clearing dropdown but then clicking Cancel', async () => {
     const homeOwnerGroup = [
       {
-        groupId: '123',
+        groupId: 123,
         owners: [mockedPerson],
         interest: 'Undivided',
         interestNumerator: 111,
@@ -384,7 +384,7 @@ describe('Home Owners', () => {
   it('should show correct error messages when deleting Owners from the Home Owners table', async () => {
     // Should show 'Group must contain at least one owner' when there are no Owners in a Group
     // Should show 'No owners added yet' when there are no Owners and no Groups
-    const GROUP_ID = '12'
+    const GROUP_ID = 12
 
     const homeOwnerGroup = [
       {

--- a/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
@@ -96,7 +96,7 @@ describe('Mhr Review Confirm registration', () => {
     wrapper = createComponent()
 
     const owners = [mockedPerson] as MhrRegistrationHomeOwnerIF[]
-    const homeOwnerGroup = [{ groupId: '1', owners: owners }] as MhrRegistrationHomeOwnerGroupIF[]
+    const homeOwnerGroup = [{ groupId: 1, owners: owners }] as MhrRegistrationHomeOwnerGroupIF[]
 
     await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroup)
 
@@ -129,7 +129,7 @@ describe('Mhr Review Confirm registration', () => {
     wrapper = createComponent()
 
     const owners = [mockedPerson] as MhrRegistrationHomeOwnerIF[]
-    const homeOwnerGroup = [{ groupId: '1', owners: owners, ...mockedFractionalOwnership }] as MhrRegistrationHomeOwnerGroupIF[]
+    const homeOwnerGroup = [{ groupId: 1, owners: owners, ...mockedFractionalOwnership }] as MhrRegistrationHomeOwnerGroupIF[]
 
     await store.dispatch('setMhrRegistrationHomeOwnerGroups', homeOwnerGroup)
 

--- a/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
@@ -28,7 +28,7 @@ export const mockedAddressAlt: AddressIF = {
 }
 
 export const mockedEmptyGroup: MhrRegistrationHomeOwnerGroupIF = {
-  groupId: '100',
+  groupId: 100,
   owners: [],
   type: Object.keys(HomeTenancyTypes).find(key => HomeTenancyTypes[key] as string === HomeTenancyTypes.SOLE) // TODO: Mhr-Submission - UPDATE after the correct type can be determined
 }


### PR DESCRIPTION
*Description of changes:*
- Cleanup up tech debt
- User _numbers_ instead of _strings_ for Home Owner Group Ids

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
