### PR TITLE
14064 review and confirm home owners table

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -83,7 +83,7 @@
             </div>
 
             <!-- Hide Chips for Review Mode -->
-            <template v-if="!isReadonlyTable">
+            <template v-if="!isReadonlyTable || showChips">
               <v-chip
                 v-if="isMhrTransfer && isAddedHomeOwner(row.item)"
                 class="badge-added ml-8 mt-2"
@@ -230,7 +230,8 @@ export default defineComponent({
     isAdding: { default: false },
     isReadonlyTable: { type: Boolean, default: false },
     isMhrTransfer: { type: Boolean, default: false },
-    hideRemovedOwners: { type: Boolean, default: false }
+    hideRemovedOwners: { type: Boolean, default: false },
+    showChips: { type: Boolean, default: false }
   },
   components: {
     BaseAddress,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -38,9 +38,7 @@
 
               <!-- MHR Information Review Section -->
               <template v-if="isReviewMode" data-test-id="review-mode">
-                <!-- TODO: Add some form of transferDetails review, either review flag in existing component or
-                new component. To be added in ticket 13905 -->
-                <section>
+                <section id="owners-review">
                   <HomeOwners
                     isMhrTransfer
                     isReadonlyTable

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -27,12 +27,13 @@
               </v-col>
             </v-row>
             <header id="yellow-message-bar" class="message-bar" v-if="isReviewMode">
-              <label><b>Important:</b> This information must match the information on the bill of sale</label>
+              <label><b>Important:</b> This information must match the information on the bill of sale.</label>
             </header>
             <section v-if="dataLoaded" class="py-4">
               <header class="review-header mt-1">
                 <v-icon class="ml-1" color="darkBlue">mdi-home</v-icon>
-                <label class="font-weight-bold pl-2">Home Owners</label>
+                <label class="font-weight-bold pl-2">{{ isReviewMode ?
+                'Ownership Transfer or Change - Sale or Beneficiary' : 'Home Owners' }}</label>
               </header>
 
               <!-- MHR Information Review Section -->
@@ -40,8 +41,7 @@
                 <!-- TODO: Add some form of transferDetails review, either review flag in existing component or
                 new component. To be added in ticket 13905 -->
                 <section>
-                  <HomeOwnersTable
-                    class="px-7"
+                  <HomeOwners
                     isMhrTransfer
                     isReadonlyTable
                     :homeOwners="reviewOwners"

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -165,7 +165,7 @@
       </v-row>
 
       <!-- Read Only Template -->
-      <v-card  v-else class="review-table">
+      <v-card v-else class="review-table" id="read-only-owners">
         <v-row class="my-6 px-7 pt-10" no-gutters>
           <v-col cols="12">
             <span class="generic-label">Home Owners </span>

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -79,7 +79,7 @@
       </template>
 
       <!-- Add/Remove Owner Actions -->
-      <v-row no-gutters>
+      <v-row no-gutters v-if="!isReadonlyTable">
         <v-col cols="12">
           <v-btn
             outlined
@@ -130,7 +130,7 @@
         </v-col>
       </v-row>
 
-      <v-row class="my-6" no-gutters>
+      <v-row v-if="!isReadonlyTable" class="my-6" no-gutters>
         <v-col cols="12">
           <span class="generic-label">Home Tenancy Type: </span>
           <span data-test-id="home-owner-tenancy-type">{{ homeTenancyType }}</span>
@@ -163,6 +163,38 @@
           </span>
         </v-col>
       </v-row>
+
+      <!-- Read Only Template -->
+      <v-card  v-else class="review-table">
+        <v-row class="my-6 px-7 pt-10" no-gutters>
+          <v-col cols="12">
+            <span class="generic-label">Home Owners </span>
+            <span
+              v-if="isMhrTransfer && hasRemovedOwners"
+              class="float-right hide-show-owners fs-14"
+              @click="hideShowRemovedOwners()"
+            >
+              <v-icon v-if="hideRemovedOwners" class="hide-show-owners-icon pr-1" color="primary">mdi-eye</v-icon>
+              <v-icon v-else class="hide-show-owners-icon pr-1" color="primary">mdi-eye-off</v-icon>
+              {{ hideShowRemovedOwnersLabel }} Deleted Owners
+            </span>
+          </v-col>
+        </v-row>
+        <v-row class="my-6 px-7" no-gutters>
+          <v-col cols="12">
+            <span class="generic-label">Home Tenancy Type: </span>
+            <span data-test-id="home-owner-tenancy-type">{{ homeTenancyType }}</span>
+          </v-col>
+        </v-row>
+        <HomeOwnersTable
+          class="px-7"
+          :homeOwners="hideRemovedOwners ? filteredHomeOwners : getHomeOwners"
+          :isAdding="disableAddHomeOwnerBtn"
+          :isMhrTransfer="isMhrTransfer"
+          :isReadonlyTable="isReadonlyTable"
+          :hideRemovedOwners="hideRemovedOwners"
+        />
+      </v-card>
     </section>
 
     <v-expand-transition>
@@ -182,7 +214,7 @@
       />
     </v-expand-transition>
 
-    <div>
+    <div v-if="!isReadonlyTable">
       <v-fade-transition>
         <HomeOwnersTable
           :homeOwners="hideRemovedOwners ? filteredHomeOwners : getHomeOwners"
@@ -200,7 +232,7 @@ import { useActions, useGetters } from 'vuex-composition-helpers'
 import { AddEditHomeOwner, HomeOwnersTable } from '@/components/mhrRegistration/HomeOwners'
 import { BaseDialog } from '@/components/dialogs'
 import { SimpleHelpToggle } from '@/components/common'
-import { computed, defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
+import { computed, defineComponent, onMounted, reactive, toRefs, watch } from '@vue/composition-api'
 import { useHomeOwners } from '@/composables/mhrRegistration'
 /* eslint-disable no-unused-vars */
 import { MhrRegistrationTotalOwnershipAllocationIF } from '@/interfaces'
@@ -217,6 +249,10 @@ export default defineComponent({
   },
   props: {
     isMhrTransfer: {
+      type: Boolean,
+      default: false
+    },
+    isReadonlyTable: {
       type: Boolean,
       default: false
     }
@@ -326,6 +362,13 @@ export default defineComponent({
       }
     )
 
+    onMounted(() => {
+      // when mounted in review mode, deleted owners hidden as per default
+      if (props.isReadonlyTable) {
+        hideShowRemovedOwners()
+      }
+    })
+
     return {
       getMhrRegistrationHomeOwners,
       getMhrTransferCurrentHomeOwners,
@@ -366,5 +409,10 @@ export default defineComponent({
   span {
     vertical-align: text-bottom;
   }
+}
+
+.review-table{
+  margin-top: -40px !important;
+  padding-top: 0px !important;
 }
 </style>

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -181,8 +181,10 @@
           </v-col>
         </v-row>
         <v-row class="my-6 px-7" no-gutters>
-          <v-col cols="12">
-            <span class="generic-label">Home Tenancy Type: </span>
+          <v-col cols="3">
+            <span class="generic-label">Home Tenancy Type</span>
+          </v-col>
+          <v-col cols="9">
             <span data-test-id="home-owner-tenancy-type">{{ homeTenancyType }}</span>
           </v-col>
         </v-row>

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -190,6 +190,7 @@
         </v-row>
         <HomeOwnersTable
           class="px-7"
+          showChips
           :homeOwners="hideRemovedOwners ? filteredHomeOwners : getHomeOwners"
           :isAdding="disableAddHomeOwnerBtn"
           :isMhrTransfer="isMhrTransfer"

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -79,7 +79,7 @@
       </template>
 
       <!-- Add/Remove Owner Actions -->
-      <v-row no-gutters>
+      <v-row no-gutters v-if="!isReadonlyTable">
         <v-col cols="12">
           <v-btn
             outlined
@@ -130,7 +130,7 @@
         </v-col>
       </v-row>
 
-      <v-row class="my-6" no-gutters>
+      <v-row v-if="!isReadonlyTable" class="my-6" no-gutters>
         <v-col cols="12">
           <span class="generic-label">Home Tenancy Type: </span>
           <span data-test-id="home-owner-tenancy-type">{{ homeTenancyType }}</span>
@@ -163,6 +163,38 @@
           </span>
         </v-col>
       </v-row>
+
+      <!-- Read Only Template -->
+      <v-card  v-else class="review-table">
+        <v-row class="my-6 px-7 pt-10" no-gutters>
+          <v-col cols="12">
+            <span class="generic-label">Home Owners </span>
+            <span
+              v-if="isMhrTransfer && hasRemovedOwners"
+              class="float-right hide-show-owners fs-14"
+              @click="hideShowRemovedOwners()"
+            >
+              <v-icon v-if="hideRemovedOwners" class="hide-show-owners-icon pr-1" color="primary">mdi-eye</v-icon>
+              <v-icon v-else class="hide-show-owners-icon pr-1" color="primary">mdi-eye-off</v-icon>
+              {{ hideShowRemovedOwnersLabel }} Deleted Owners
+            </span>
+          </v-col>
+        </v-row>
+        <v-row class="my-6 px-7" no-gutters>
+          <v-col cols="12">
+            <span class="generic-label">Home Tenancy Type: </span>
+            <span data-test-id="home-owner-tenancy-type">{{ homeTenancyType }}</span>
+          </v-col>
+        </v-row>
+        <HomeOwnersTable
+          class="px-7"
+          :homeOwners="hideRemovedOwners ? filteredHomeOwners : getHomeOwners"
+          :isAdding="disableAddHomeOwnerBtn"
+          :isMhrTransfer="isMhrTransfer"
+          :isReadonlyTable="isReadonlyTable"
+          :hideRemovedOwners="hideRemovedOwners"
+        />
+      </v-card>
     </section>
 
     <v-expand-transition>
@@ -182,7 +214,7 @@
       />
     </v-expand-transition>
 
-    <div>
+    <div v-if="!isReadonlyTable">
       <v-fade-transition>
         <HomeOwnersTable
           :homeOwners="hideRemovedOwners ? filteredHomeOwners : getHomeOwners"
@@ -200,7 +232,7 @@ import { useActions, useGetters } from 'vuex-composition-helpers'
 import { AddEditHomeOwner, HomeOwnersTable } from '@/components/mhrRegistration/HomeOwners'
 import { BaseDialog } from '@/components/dialogs'
 import { SimpleHelpToggle } from '@/components/common'
-import { computed, defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
+import { computed, defineComponent, onMounted, reactive, toRefs, watch } from '@vue/composition-api'
 import { useHomeOwners } from '@/composables/mhrRegistration'
 /* eslint-disable no-unused-vars */
 import { MhrRegistrationTotalOwnershipAllocationIF } from '@/interfaces'
@@ -217,6 +249,10 @@ export default defineComponent({
   },
   props: {
     isMhrTransfer: {
+      type: Boolean,
+      default: false
+    },
+    isReadonlyTable: {
       type: Boolean,
       default: false
     }
@@ -329,6 +365,13 @@ export default defineComponent({
       }
     )
 
+    onMounted(() => {
+      // when mounted in review mode, deleted owners hidden as per default
+      if (props.isReadonlyTable) {
+        hideShowRemovedOwners()
+      }
+    })
+
     return {
       getMhrRegistrationHomeOwners,
       getMhrTransferCurrentHomeOwners,
@@ -369,5 +412,10 @@ export default defineComponent({
   span {
     vertical-align: text-bottom;
   }
+}
+
+.review-table{
+  margin-top: -40px !important;
+  padding-top: 0px !important;
 }
 </style>

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -174,8 +174,9 @@
               class="float-right hide-show-owners fs-14"
               @click="hideShowRemovedOwners()"
             >
-              <v-icon v-if="hideRemovedOwners" class="hide-show-owners-icon pr-1" color="primary">mdi-eye</v-icon>
-              <v-icon v-else class="hide-show-owners-icon pr-1" color="primary">mdi-eye-off</v-icon>
+            <v-icon class="hide-show-owners-icon pr-1" color="primary">
+              {{ hideRemovedOwners ? 'mdi-eye' : 'mdi-eye-off' }}
+            </v-icon>
               {{ hideShowRemovedOwnersLabel }} Deleted Owners
             </span>
           </v-col>
@@ -235,7 +236,7 @@ import { useActions, useGetters } from 'vuex-composition-helpers'
 import { AddEditHomeOwner, HomeOwnersTable } from '@/components/mhrRegistration/HomeOwners'
 import { BaseDialog } from '@/components/dialogs'
 import { SimpleHelpToggle } from '@/components/common'
-import { computed, defineComponent, onMounted, reactive, toRefs, watch } from '@vue/composition-api'
+import { computed, defineComponent, onBeforeMount, reactive, toRefs, watch } from '@vue/composition-api'
 import { useHomeOwners } from '@/composables/mhrRegistration'
 /* eslint-disable no-unused-vars */
 import { MhrRegistrationTotalOwnershipAllocationIF } from '@/interfaces'
@@ -368,8 +369,8 @@ export default defineComponent({
       }
     )
 
-    onMounted(() => {
-      // when mounted in review mode, deleted owners hidden as per default
+    onBeforeMount(() => {
+      // before mounted in review mode, deleted owners hidden as per default
       if (props.isReadonlyTable) {
         hideShowRemovedOwners()
       }

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -490,4 +490,20 @@ describe('Mhr Information', () => {
     expect(confirmCompletionCard.find(getTestId('confirm-completion-checkbox')).exists()).toBeTruthy()
     expect(confirmCompletionCard.find('.confirm-checkbox').text()).toContain(LEGAL_NAME)
   })
+
+  it('should render read only home owners on the Review screen', async () => {
+    setupCurrentHomeOwners()
+    wrapper.vm.$data.dataLoaded = true
+    await Vue.nextTick()
+
+    expect(wrapper.find('#owners-review').exists()).toBeFalsy()
+
+    wrapper.find('#btn-stacked-submit').trigger('click')
+    await Vue.nextTick()
+
+    const homeOwnerReadOnly = wrapper.find('#owners-review')
+    expect(homeOwnerReadOnly.exists()).toBeTruthy()
+
+  })
+
 })

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -496,14 +496,33 @@ describe('Mhr Information', () => {
     wrapper.vm.$data.dataLoaded = true
     await Vue.nextTick()
 
+    // TODO: check that removed owners are not displayed in review
+    const owners = [mockedRemovedPerson] as MhrRegistrationHomeOwnerIF[] // same IF for Transfer and Registration
+    const homeOwnerGroup = [
+      mockMhrTransferCurrentHomeOwner,
+      { groupId: 1, owners: owners }
+    ] as MhrRegistrationHomeOwnerGroupIF[]
+
+    await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
+    expect(wrapper.findComponent(HomeOwners).findComponent(HomeOwnersTable).exists()).toBeTruthy()
+    const ownersTable = wrapper.findComponent(HomeOwners).findComponent(HomeOwnersTable)
+
+    // check owners are in table
+    expect(ownersTable.props().homeOwners.length).toBe(2)
+    
+    // review table doesnt exist yet
     expect(wrapper.find('#owners-review').exists()).toBeFalsy()
 
     wrapper.find('#btn-stacked-submit').trigger('click')
     await Vue.nextTick()
 
+    //review table renders
     const homeOwnerReadOnly = wrapper.find('#owners-review')
     expect(homeOwnerReadOnly.exists()).toBeTruthy()
 
+    // values remain in table
+    expect(wrapper.findComponent(HomeOwners).props().isReadonlyTable).toBeTruthy()
+    expect(ownersTable.props().homeOwners.length).toBe(2)
   })
 
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14064

*Description of changes:*
-Added isReadonlyTable flag to existing HomeOwners component
-Used this in transfer review and confirm to display home owners table with option to show/hide removed owners.
-Made review header reactive, from ticket #13905
-Fixed tiny typo for ticket #13957

When review mode is entered...

![hidden](https://user-images.githubusercontent.com/112968185/199259777-f0977996-6807-482a-894b-89d1ad36d670.png)

When show/hide button is pressed

![shown](https://user-images.githubusercontent.com/112968185/199259806-16192f04-a6db-4cff-9922-5473e044f749.png)

Ignore invalid date and amount

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
