### PR TITLE
UI cleanup and homeOwners validation edge case

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat class="py-6 px-8 mb-20 rounded">
+  <v-card flat class="py-6 px-8 mb-5 rounded">
     <v-row id="mhr-home-add-person">
       <v-col cols="3">
         <label class="generic-label"> {{ getSidebarTitle }} </label>
@@ -500,8 +500,5 @@ export default defineComponent({
     color: $gray7;
     line-height: 24px;
   }
-}
-.mb-20{
-  margin-bottom: 20px !important;
 }
 </style>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat class="py-6 px-8 rounded">
+  <v-card flat class="py-6 px-8 mb-20 rounded">
     <v-row id="mhr-home-add-person">
       <v-col cols="3">
         <label class="generic-label"> {{ getSidebarTitle }} </label>
@@ -500,5 +500,8 @@ export default defineComponent({
     color: $gray7;
     line-height: 24px;
   }
+}
+.mb-20{
+  margin-bottom: 20px !important;
 }
 </style>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat rounded :class="{ 'border-error-left': showTableError }">
+  <v-card flat rounded :class="{ 'border-error-left': showTableError || reviewedNoOwners}">
     <v-data-table
       id="mh-home-owners-table"
       class="home-owners-table"
@@ -219,7 +219,7 @@ import { AddEditHomeOwner } from '@/components/mhrRegistration/HomeOwners'
 import TableGroupHeader from '@/components/mhrRegistration/HomeOwners/TableGroupHeader.vue'
 /* eslint-disable no-unused-vars */
 import { MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { ActionTypes } from '@/enums'
+import { ActionTypes, RouteNames } from '@/enums'
 /* eslint-enable no-unused-vars */
 import { useActions } from 'vuex-composition-helpers'
 
@@ -238,7 +238,7 @@ export default defineComponent({
     AddEditHomeOwner,
     TableGroupHeader
   },
-  setup (props) {
+  setup (props, context) {
     const addressSchema = PartyAddressSchema
 
     const {
@@ -261,9 +261,11 @@ export default defineComponent({
 
     const localState = reactive({
       currentlyEditingHomeOwnerId: -1,
+      reviewed: false,
       isEditingMode: computed((): boolean => localState.currentlyEditingHomeOwnerId >= 0),
       isAddingMode: computed((): boolean => props.isAdding),
       showTableError: computed((): boolean => showGroups.value && (hasMinimumGroups() || hasEmptyGroup.value)),
+      reviewedNoOwners: computed((): boolean => !hasActualOwners(props.homeOwners) && localState.reviewed),
       showEditActions: computed((): boolean => !props.isReadonlyTable),
       homeOwnersTableHeaders: props.isReadonlyTable ? homeOwnersTableHeadersReview : homeOwnersTableHeaders,
       addedOwnerCount: computed((): number => {
@@ -342,6 +344,10 @@ export default defineComponent({
         setGlobalEditingMode(localState.isEditingMode)
       }
     )
+
+    watch(() => context.root.$route.name, (route: string) => {
+      if (route === RouteNames.MHR_REVIEW_CONFIRM) localState.reviewed = true
+    })
 
     return {
       ActionTypes,

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
@@ -7,7 +7,7 @@
 
     <div :class="{ 'border-error-left': !getStepValidation(MhrSectVal.HOME_OWNERS_VALID) }">
       <section v-show="!getStepValidation(MhrSectVal.HOME_OWNERS_VALID)"
-      :class="hasHomeOwners ? 'pt-30px px-6' : 'px-6 py-8'">
+        :class="hasHomeOwners ? 'pt-30px px-6' : 'px-6 py-8'">
         <span>
           <v-icon color="error">mdi-information-outline</v-icon>
           <span class="error-text mx-1">This step is unfinished.</span>
@@ -20,11 +20,11 @@
         <article class="border-btm py-5">
           <v-row no-gutters data-test-id="home-tenancy-type">
             <v-col cols="3"><span class="generic-label">Home Tenancy Type </span></v-col>
-            <v-col class="pl-2  gray7">{{ getHomeTenancyType() || 'N/A' }}</v-col>
+            <v-col class="pl-2  gray7">{{ getHomeTenancyType() }}</v-col>
           </v-row>
           <v-row no-gutters class="pt-2" v-if="showGroups" data-test-id="total-ownership">
             <v-col cols="3"><span class="generic-label">Total Ownership Allocated </span></v-col>
-            <v-col class="pl-2 gray7">{{ getTotalOwnershipAllocationStatus().totalAllocation || 'N/A' }}</v-col>
+            <v-col class="pl-2 gray7">{{ getTotalOwnershipAllocationStatus().totalAllocation }}</v-col>
           </v-row>
         </article>
 

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeOwnersReview.vue
@@ -6,22 +6,25 @@
     </header>
 
     <div :class="{ 'border-error-left': !getStepValidation(MhrSectVal.HOME_OWNERS_VALID) }">
-      <div v-show="!getStepValidation(MhrSectVal.HOME_OWNERS_VALID)" class="px-6 py-8">
-        <v-icon color="error">mdi-information-outline</v-icon>
-        <span class="error-text mx-1">This step is unfinished.</span>
-        <router-link :to="{ path: `/${RouteNames.MHR_REGISTRATION}/${RouteNames.HOME_OWNERS}` }"
-          >Return to this step to complete it.
-        </router-link>
-      </div>
-      <section class="px-6 my-2" v-if="hasHomeOwners || (hasGroups && showGroups)">
+      <section v-show="!getStepValidation(MhrSectVal.HOME_OWNERS_VALID)"
+      :class="hasHomeOwners ? 'pt-30px px-6' : 'px-6 py-8'">
+        <span>
+          <v-icon color="error">mdi-information-outline</v-icon>
+          <span class="error-text mx-1">This step is unfinished.</span>
+          <router-link :to="{ path: `/${RouteNames.MHR_REGISTRATION}/${RouteNames.HOME_OWNERS}` }"
+          >Return to this step to complete it.</router-link>
+        </span>
+      </section>
+
+      <section class="px-6 my-2" v-if="hasHomeOwners">
         <article class="border-btm py-5">
           <v-row no-gutters data-test-id="home-tenancy-type">
             <v-col cols="3"><span class="generic-label">Home Tenancy Type </span></v-col>
-            <v-col class="pl-2">{{ getHomeTenancyType() || 'N/A' }}</v-col>
+            <v-col class="pl-2  gray7">{{ getHomeTenancyType() || 'N/A' }}</v-col>
           </v-row>
           <v-row no-gutters class="pt-2" v-if="showGroups" data-test-id="total-ownership">
-            <v-col cols="3"><span class="generic-label">Total Ownership <br>Allocated </span></v-col>
-            <v-col class="pl-2">{{ getTotalOwnershipAllocationStatus().totalAllocation || 'N/A' }}</v-col>
+            <v-col cols="3"><span class="generic-label">Total Ownership Allocated </span></v-col>
+            <v-col class="pl-2 gray7">{{ getTotalOwnershipAllocationStatus().totalAllocation || 'N/A' }}</v-col>
           </v-row>
         </article>
 
@@ -90,4 +93,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
+.gray7 {
+  color: $gray7;
+}
 </style>

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import VueRouter from 'vue-router'
 import { getVuexStore } from '@/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 
@@ -12,10 +13,11 @@ import {
   FractionalOwnership
 } from '@/components/mhrRegistration/HomeOwners'
 import { SimpleHelpToggle } from '@/components/common'
+import mockRouter from './MockRouter'
 import { mockedPerson, mockedOrganization } from './test-data'
 import { getTestId } from './utils'
 import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { HomeTenancyTypes } from '@/enums'
+import { HomeTenancyTypes, RouteNames } from '@/enums'
 
 Vue.use(Vuetify)
 
@@ -25,11 +27,16 @@ const store = getVuexStore()
 function createComponent (): Wrapper<any> {
   const localVue = createLocalVue()
   localVue.use(Vuetify)
+  localVue.use(VueRouter)
+  const router = mockRouter.mock()
+  router.push({ name: RouteNames.MHR_REVIEW_CONFIRM })
+
   document.body.setAttribute('data-app', 'true')
   return mount(HomeOwners, {
     localVue,
     propsData: {},
     store,
+    router,
     vuetify
   })
 }

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
-import VueRouter from 'vue-router'
 import { getVuexStore } from '@/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 
@@ -13,11 +12,10 @@ import {
   FractionalOwnership
 } from '@/components/mhrRegistration/HomeOwners'
 import { SimpleHelpToggle } from '@/components/common'
-import mockRouter from './MockRouter'
 import { mockedPerson, mockedOrganization } from './test-data'
 import { getTestId } from './utils'
 import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { HomeTenancyTypes, RouteNames } from '@/enums'
+import { HomeTenancyTypes } from '@/enums'
 
 Vue.use(Vuetify)
 
@@ -27,16 +25,12 @@ const store = getVuexStore()
 function createComponent (): Wrapper<any> {
   const localVue = createLocalVue()
   localVue.use(Vuetify)
-  localVue.use(VueRouter)
-  const router = mockRouter.mock()
-  router.push({ name: RouteNames.MHR_REVIEW_CONFIRM })
 
   document.body.setAttribute('data-app', 'true')
   return mount(HomeOwners, {
     localVue,
     propsData: {},
     store,
-    router,
     vuetify
   })
 }

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
-import VueRouter from 'vue-router'
 import { getVuexStore } from '@/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 
@@ -21,9 +20,8 @@ import {
   mockedRemovedPerson, mockedRemovedOrganization
 } from './test-data'
 import { getTestId } from './utils'
-import mockRouter from './MockRouter'
-import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { HomeTenancyTypes, RouteNames } from '@/enums'
+import { MhrRegistrationHomeOwnerGroupIF } from '@/interfaces'
+
 
 Vue.use(Vuetify)
 
@@ -33,9 +31,6 @@ const store = getVuexStore()
 function createComponent (): Wrapper<any> {
   const localVue = createLocalVue()
   localVue.use(Vuetify)
-  localVue.use(VueRouter)
-  const router = mockRouter.mock()
-  router.push({ name: RouteNames.MHR_REVIEW_CONFIRM })
 
   document.body.setAttribute('data-app', 'true')
   return mount(HomeOwners, {
@@ -44,7 +39,6 @@ function createComponent (): Wrapper<any> {
       isMhrTransfer: true
     },
     store,
-    router,
     vuetify
   })
 }

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import VueRouter from 'vue-router'
 import { getVuexStore } from '@/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 
@@ -20,8 +21,9 @@ import {
   mockedRemovedPerson, mockedRemovedOrganization
 } from './test-data'
 import { getTestId } from './utils'
+import mockRouter from './MockRouter'
 import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { HomeTenancyTypes } from '@/enums'
+import { HomeTenancyTypes, RouteNames } from '@/enums'
 
 Vue.use(Vuetify)
 
@@ -31,6 +33,10 @@ const store = getVuexStore()
 function createComponent (): Wrapper<any> {
   const localVue = createLocalVue()
   localVue.use(Vuetify)
+  localVue.use(VueRouter)
+  const router = mockRouter.mock()
+  router.push({ name: RouteNames.MHR_REVIEW_CONFIRM })
+
   document.body.setAttribute('data-app', 'true')
   return mount(HomeOwners, {
     localVue,
@@ -38,6 +44,7 @@ function createComponent (): Wrapper<any> {
       isMhrTransfer: true
     },
     store,
+    router,
     vuetify
   })
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13727

*Description of changes:*
-UI fixes (see original ticket for specifics)
-homeOwners section now validates when review and confirm screen is reached. Will display error bar on table if no owners added and review screen was reached.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
