### PR TITLE
13905 show hide transfer details if owners changed

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -351,6 +351,11 @@ export default defineComponent({
       }
     )
 
+    // When a change is made to homeOwners, check if any actions have changed, if so set flag
+    watch(() => props.homeOwners, () => {
+      setUnsavedChanges(props.homeOwners.some(owner => !!owner.action))
+    })
+
     return {
       ActionTypes,
       addressSchema,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -115,7 +115,7 @@
               <!-- MHR Information Section -->
               <template v-else>
                 <HomeOwners isMhrTransfer class="mt-n2" />
-                <TransferDetails :validateTransferDetails="validateTransferDetails" />
+                <TransferDetails v-if="hasUnsavedChanges" :validateTransferDetails="validateTransferDetails" />
               </template>
             </section>
           </v-col>
@@ -448,6 +448,7 @@ export default defineComponent({
     )
 
     return {
+      hasUnsavedChanges,
       goToReview,
       onSave,
       goToDash,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -47,6 +47,7 @@
                   />
                 </section>
                 <section>
+                  <v-divider class="mx-7 ma-0"></v-divider>
                   <TransferDetailsReview class="py-6 pt-4 px-8"/>
                 </section>
                 <section id="transfer-submitting-party" class="submitting-party">

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -165,7 +165,7 @@
       </v-row>
 
       <!-- Read Only Template -->
-      <v-card v-else class="review-table" id="read-only-owners">
+      <v-card v-else class="review-table" flat id="read-only-owners">
         <v-row class="my-6 px-7 pt-10" no-gutters>
           <v-col cols="12">
             <span class="generic-label">Home Owners </span>

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -285,6 +285,18 @@ describe('Mhr Information', () => {
     expect(wrapper.vm.$data.getMhrTransferCurrentHomeOwners.length).toBe(1)
     expect(wrapper.vm.$data.getMhrTransferHomeOwners.length).toBe(1)
 
+    expect(wrapper.findComponent(MhrInformation).findComponent(TransferDetails).exists()).toBeFalsy()
+    expect(wrapper.findComponent(MhrInformation).findComponent(HomeOwnersTable).exists()).toBeTruthy()
+
+    // Add some owners so Transfer Details will display
+    const owners = [mockedAddedPerson, mockedRemovedPerson] as MhrRegistrationHomeOwnerIF[] // same IF for Transfer and Registration
+    const homeOwnerGroup = [
+      mockMhrTransferCurrentHomeOwner,
+      { groupId: 1, owners: owners }
+    ] as MhrRegistrationHomeOwnerGroupIF[]
+
+    await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
+
     expect(wrapper.findComponent(MhrInformation).exists()).toBe(true)
 
     const mhrTransferDetailsComponent = wrapper.findComponent(MhrInformation).findComponent(TransferDetails)
@@ -415,6 +427,21 @@ describe('Mhr Information', () => {
     setupCurrentHomeOwners()
     wrapper.vm.$data.dataLoaded = true
     await Vue.nextTick()
+
+    // Should hide transfer details if no changes made
+    expect(wrapper.findComponent(MhrInformation).findComponent(TransferDetails).exists()).toBeFalsy()
+
+     // Add some owners so Transfer Details will display
+     const owners = [mockedAddedPerson, mockedRemovedPerson] as MhrRegistrationHomeOwnerIF[] // same IF for Transfer and Registration
+     const homeOwnerGroup = [
+       mockMhrTransferCurrentHomeOwner,
+       { groupId: 1, owners: owners }
+     ] as MhrRegistrationHomeOwnerGroupIF[]
+ 
+     await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
+
+    // Should show transfer details once changes made
+    expect(wrapper.findComponent(MhrInformation).findComponent(TransferDetails).exists()).toBeTruthy()
 
     // set some test values for transfer details fields
     const mhrTransferDetailsComponent = wrapper.findComponent(MhrInformation).findComponent(TransferDetails)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13905

*Description of changes:*
- Made TransferDetails only display when changes have been made to the owners.
- Some minor UI fixes 

When no changes made to owners:
![image](https://user-images.githubusercontent.com/112968185/200409327-8689721d-4243-4d5c-a1c7-6c4ffcf444c2.png)

After a change is made (action type):
![image](https://user-images.githubusercontent.com/112968185/200409466-cb151173-ab2d-45ca-861d-4e0e80f1274d.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
