### PR TITLE
Added save dialog pop-up when save fails

### DIFF
--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -6,8 +6,13 @@
     </v-overlay>
 
     <base-dialog
-      :setOptions="options"
+      :setOptions="cancelOptions"
       :setDisplay="showCancelDialog"
+      @proceed="handleDialogResp($event)"
+    />
+    <base-dialog
+      :setOptions="saveOptions"
+      :setDisplay="showSaveDialog"
       @proceed="handleDialogResp($event)"
     />
     <div class="view-container px-15 py-0">
@@ -170,7 +175,7 @@ import { TransferDetails, TransferDetailsReview, ConfirmCompletion } from '@/com
 import { HomeOwners } from '@/views'
 import { BaseDialog } from '@/components/dialogs'
 import { BaseAddress } from '@/composables/address'
-import { unsavedChangesDialog } from '@/resources/dialogOptions'
+import { unsavedChangesDialog, registrationSaveDraftError } from '@/resources/dialogOptions'
 import { cloneDeep } from 'lodash'
 import AccountInfo from '@/components/common/AccountInfo.vue'
 import { AccountInfoIF } from '@/interfaces' // eslint-disable-line no-unused-vars
@@ -289,8 +294,10 @@ export default defineComponent({
       }),
       attentionReference: getMhrTransferAttentionReference.value,
       isCompletionConfirmed: false,
-      options: unsavedChangesDialog,
-      showCancelDialog: false
+      cancelOptions: unsavedChangesDialog,
+      saveOptions: registrationSaveDraftError,
+      showCancelDialog: false,
+      showSaveDialog: false
     })
 
     onMounted(async (): Promise<void> => {
@@ -394,10 +401,13 @@ export default defineComponent({
         ? await updateMhrDraft(getMhrInformation.value.draftNumber, apiData)
         : await createMhrTransferDraft(apiData)
       localState.loading = false
-      setUnsavedChanges(false)
-      !mhrTransferDraft.error
-        ? goToDash()
-        : console.log(mhrTransferDraft?.error) // Handle Schema or Api errors here..
+      if (!mhrTransferDraft.error) {
+        setUnsavedChanges(false)
+        goToDash()
+      } else {
+        localState.showSaveDialog = true
+        console.log(mhrTransferDraft?.error)
+      }
     }
 
     const goToDash = (): void => {
@@ -412,11 +422,14 @@ export default defineComponent({
     }
 
     const handleDialogResp = (val: boolean): void => {
-      localState.showCancelDialog = false
       if (!val) {
         setUnsavedChanges(false)
-        goToDash()
+        if (localState.showCancelDialog) {
+          goToDash()
+        }
       }
+      localState.showCancelDialog = false
+      localState.showSaveDialog = false
     }
 
     watch(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13749

*Description of changes:*
- Added save error pop-up for when transfer fails to save

When a save error happens:
![image](https://user-images.githubusercontent.com/112968185/200430776-90c95f31-c502-481e-bed9-3bb522d8fed3.png)

when user clicks 'OK' they are returned to the transfer to attempt to save again

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
