### PR TITLE
Duplicate secured party fixes

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.42",
+  "version": "0.3.44",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/ButtonFooter.vue
+++ b/ppr-ui/src/components/common/ButtonFooter.vue
@@ -247,7 +247,7 @@ export default defineComponent({
     }
     const submitNext = () => {
       // Undetected Duplicate Secured Party API check to be implemented here.
-      // Use secured party dialog with isDuplicate prop to display error if found.
+      // Use secured party dialog with isDuplicate and isReview props to display error if found.
       if (
         localState.statementType.toUpperCase() ===
           StatementTypes.FINANCING_STATEMENT &&

--- a/ppr-ui/src/components/common/ButtonFooter.vue
+++ b/ppr-ui/src/components/common/ButtonFooter.vue
@@ -246,6 +246,8 @@ export default defineComponent({
       })
     }
     const submitNext = () => {
+      // Undetected Duplicate Secured Party API check to be implemented here.
+      // Use secured party dialog with isDuplicate prop to display error if found.
       if (
         localState.statementType.toUpperCase() ===
           StatementTypes.FINANCING_STATEMENT &&

--- a/ppr-ui/src/components/common/ErrorContact.vue
+++ b/ppr-ui/src/components/common/ErrorContact.vue
@@ -11,7 +11,7 @@
     </v-row>
   </v-container>
 </template>
-<script>
+<script lang="ts">
 // external
 import {
   defineComponent
@@ -30,12 +30,12 @@ export default defineComponent({
       {
         icon: 'mdi-phone',
         label: 'Victoria Office:',
-        value: '250-387-7878',
-        href: 'tel:+1-250-387-7878'
+        value: '250-952-0568',
+        href: 'tel:+1-250-952-0568'
       },
       {
         icon: 'mdi-email',
-        label: 'BC Registries Email:',
+        label: 'Email:',
         value: 'BCRegistries@gov.bc.ca',
         href: 'mailto:BCRegistries@gov.bc.ca'
       }

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -6,7 +6,7 @@
     attach="#app"
     content-class="secured-party-dialog"
   >
-    <v-card id="secured-party-dialog" class="pl-4 pr-1 pt-7 mt-7">
+    <v-card id="secured-party-dialog" :class="!duplicate && !review ? 'pl-4 pr-1 pt-7 mt-7' : 'pl-1 pr-1 pt-7 mt-7'">
       <v-row no-gutters>
         <v-col cols="11">
           <v-row no-gutters>
@@ -40,6 +40,10 @@
           existing {{ partyWord }} Party listed below or use your information to create
           a new {{ partyWord }} Party?
         </p>
+        <p v-else-if="!review" class="text-md-center px-6 pt-3" :class="$style['intro']">
+          Registrations cannot list a Secured Party with the same name and address more than once. This registration
+          already contains this Secured Party:
+        </p>
         <p v-else class="text-md-center px-6 pt-3" :class="$style['intro']">
           Duplicate Secured Parties have been detected in this registration.<br>
           Registrations cannot list a Secured Party with the same name and address more than once.<br>
@@ -52,7 +56,7 @@
         </div>
 
         <v-container class="currentParty">
-          <v-row :class="[$style['companyRow'], { 'primaryRow': showSelected }]">
+          <v-row :class="[$style[duplicate ? 'companyRowDuplicate' : 'companyRow'], { 'primaryRow': showSelected }]">
             <v-col cols="auto" :class="$style['iconColumn']">
               <v-icon :class="$style['companyIcon']">
                 {{party.businessName ? 'mdi-domain' : 'mdi-account'}}
@@ -127,7 +131,7 @@
             >
           </v-row>
         </v-container>
-        <div v-else >
+        <div v-else-if="review" >
           <p class="text-md-center px-6 pt-3" :class="$style['intro']">
             Cancelling and re-starting you registration may resolve this issue.<br>
             If you do not wish to proceed, contact BC registries staff:
@@ -136,13 +140,20 @@
         </div>
       </div>
       <v-card-actions class="pt-6 pb-8">
-        <v-btn
+        <v-btn v-if="!duplicate && !review"
           :class="$style['dialogButton']"
           id="dialog-cancel-button"
           color="primary"
           outlined
           @click="exit()"
           >Exit</v-btn
+        >
+        <v-btn v-else
+          :class="$style['dialogButton']"
+          class="primary dialog-btn"
+          color="primary"
+          @click="exit()"
+          >OK</v-btn
         >
       </v-card-actions>
     </v-card>
@@ -180,6 +191,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    isReview: {
+      type: Boolean,
+      default: false
+    },
     defaultIsRegisteringParty: Boolean
   },
   setup (props, context) {
@@ -187,6 +202,9 @@ export default defineComponent({
       showSelected: true,
       duplicate: computed((): boolean => {
         return props.isDuplicate
+      }),
+      review: computed((): boolean => {
+        return props.isReview
       }),
       party: computed((): PartyIF => {
         return props.defaultParty
@@ -270,6 +288,16 @@ export default defineComponent({
 }
 .companyText {
   font-weight: 700;
+}
+.companyRowDuplicate {
+  background-color: #f1f1f1;
+  border-radius: 4px 4px 4px 4px;
+  margin-bottom: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin-right: 10px;
+  margin-left: 10px;
+  border: 1px solid white;
 }
 
 .companyRow {

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -56,7 +56,8 @@
         </div>
 
         <v-container class="currentParty">
-          <v-row :class="[$style[duplicate ? 'companyRowDuplicate' : 'companyRow'], { 'primaryRow': showSelected }]">
+          <v-row :class="[$style[duplicate ? 'companyRowDuplicate' : 'companyRow'],
+            { 'primaryRow': showSelected && !duplicate }]">
             <v-col cols="auto" :class="$style['iconColumn']">
               <v-icon :class="$style['companyIcon']">
                 {{party.businessName ? 'mdi-domain' : 'mdi-account'}}

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -14,9 +14,14 @@
               <v-icon :class="$style['iconRed']">mdi-alert-circle-outline</v-icon>
             </v-col>
           </v-row>
-          <v-row no-gutters class="pt-5">
+          <v-row no-gutters v-if="!duplicate" class="pt-5">
             <v-col class="text-md-center ml-8">
               <h1 :class="$style['dialogTitle']">{{ totalParties }} Similar {{ partyWord }} Parties Found</h1>
+            </v-col>
+          </v-row>
+          <v-row v-else no-gutters class="pt-5">
+            <v-col class="text-md-center ml-8">
+              <h1 :class="$style['dialogTitle']">Duplicate Secured Parties</h1>
             </v-col>
           </v-row>
         </v-col>
@@ -30,25 +35,33 @@
       </v-row>
 
       <div>
-        <p class="text-md-center px-6 pt-3" :class="$style['intro']">
+        <p v-if="!duplicate" class="text-md-center px-6 pt-3" :class="$style['intro']">
           One or more similar {{ partyWord }} Parties were found. Do you want to use an
           existing {{ partyWord }} Party listed below or use your information to create
           a new {{ partyWord }} Party?
         </p>
+        <p v-else class="text-md-center px-6 pt-3" :class="$style['intro']">
+          Duplicate Secured Parties have been detected in this registration.<br>
+          Registrations cannot list a Secured Party with the same name and address more than once.<br>
+          <b>Note:</b> these duplicates may not be visible due to a system error.
+        </p>
       </div>
       <div :class="$style['partyWindow']">
-        <div class="text-md-center generic-label" id="create-new-party">
+        <div v-if="!duplicate" class="text-md-center generic-label" id="create-new-party">
           Use my information and create a new {{ partyWord }} Party:
         </div>
 
         <v-container class="currentParty">
           <v-row :class="[$style['companyRow'], { 'primaryRow': showSelected }]">
-            <v-col cols="auto" :class="$style['iconColumn']"
-              ><v-icon :class="$style['companyIcon']">mdi-domain</v-icon></v-col
-            >
+            <v-col cols="auto" :class="$style['iconColumn']">
+              <v-icon :class="$style['companyIcon']">
+                {{party.businessName ? 'mdi-domain' : 'mdi-account'}}
+              </v-icon>
+            </v-col>
             <v-col cols="9">
               <div :class="$style['companyText']" class="businessName">
-                {{ party.businessName }}
+                {{party.businessName ? party.businessName :
+                party.personName.first+" "+party.personName.middle+" "+party.personName.last}}
               </div>
               <div :class="$style['addressText']">
                 {{ party.address.street }}, {{ party.address.city }}
@@ -56,13 +69,14 @@
                 {{ getCountryName(party.address.country) }}
               </div>
               <div>
-                <v-chip x-small label color="primary" text-color="white"
+                <v-chip  x-small v-if="!duplicate" label color="primary" text-color="white"
                   >NEW</v-chip
                 >
               </div>
             </v-col>
             <v-col cols="2" class="pt-5"
               ><v-btn
+                v-if="!duplicate"
                 class="ml-auto float-right"
                 color="primary"
                 :class="$style['partyButton']"
@@ -74,10 +88,10 @@
           </v-row>
         </v-container>
 
-        <div class="text-md-center generic-label">
+        <div v-if="!duplicate" class="text-md-center generic-label">
           Use an existing {{ partyWord }} Party:
         </div>
-        <v-container>
+        <v-container v-if="!duplicate">
           <v-row
             class="searchResponse"
             :class="$style['companyRow']"
@@ -113,6 +127,13 @@
             >
           </v-row>
         </v-container>
+        <div v-else >
+          <p class="text-md-center px-6 pt-3" :class="$style['intro']">
+            Cancelling and re-starting you registration may resolve this issue.<br>
+            If you do not wish to proceed, contact BC registries staff:
+          </p>
+          <error-contact :class="$style['padLeft']"/>
+        </div>
       </div>
       <v-card-actions class="pt-6 pb-8">
         <v-btn
@@ -141,8 +162,12 @@ import {
   useCountriesProvinces
 } from '@/composables/address/factories'
 import { ActionTypes } from '@/enums'
+import ErrorContact from '@/components/common/ErrorContact.vue'
 
 export default defineComponent({
+  components: {
+    ErrorContact
+  },
   props: {
     defaultDialog: Boolean,
     defaultParty: {
@@ -151,11 +176,18 @@ export default defineComponent({
     defaultResults: {
       type: Array as () => Array<SearchPartyIF>
     },
+    isDuplicate: {
+      type: Boolean,
+      default: false
+    },
     defaultIsRegisteringParty: Boolean
   },
   setup (props, context) {
     const localState = reactive({
       showSelected: true,
+      duplicate: computed((): boolean => {
+        return props.isDuplicate
+      }),
       party: computed((): PartyIF => {
         return props.defaultParty
       }),
@@ -307,5 +339,9 @@ export default defineComponent({
 .dialogButton {
   margin-left: 330px;
   width: 75px;
+}
+.padLeft {
+  margin-left: 225px;
+  width: 400px;
 }
 </style>

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -6,7 +6,7 @@
     attach="#app"
     content-class="secured-party-dialog"
   >
-    <v-card id="secured-party-dialog" :class="!duplicate && !review ? 'pl-4 pr-1 pt-7 mt-7' : 'pl-1 pr-1 pt-7 mt-7'">
+    <v-card id="secured-party-dialog" :class="!isDuplicate && !isReview ? 'pl-4 pr-1 pt-7 mt-7' : 'pl-1 pr-1 pt-7 mt-7'">
       <v-row no-gutters>
         <v-col cols="11">
           <v-row no-gutters>
@@ -14,7 +14,7 @@
               <v-icon :class="$style['iconRed']">mdi-alert-circle-outline</v-icon>
             </v-col>
           </v-row>
-          <v-row no-gutters v-if="!duplicate" class="pt-5">
+          <v-row no-gutters v-if="!isDuplicate" class="pt-5">
             <v-col class="text-md-center ml-8">
               <h1 :class="$style['dialogTitle']">{{ totalParties }} Similar {{ partyWord }} Parties Found</h1>
             </v-col>
@@ -35,12 +35,12 @@
       </v-row>
 
       <div>
-        <p v-if="!duplicate" class="text-md-center px-6 pt-3" :class="$style['intro']">
+        <p v-if="!isDuplicate" class="text-md-center px-6 pt-3" :class="$style['intro']">
           One or more similar {{ partyWord }} Parties were found. Do you want to use an
           existing {{ partyWord }} Party listed below or use your information to create
           a new {{ partyWord }} Party?
         </p>
-        <p v-else-if="!review" class="text-md-center px-6 pt-3" :class="$style['intro']">
+        <p v-else-if="!isReview" class="text-md-center px-6 pt-3" :class="$style['intro']">
           Registrations cannot list a Secured Party with the same name and address more than once. This registration
           already contains this Secured Party:
         </p>
@@ -51,13 +51,13 @@
         </p>
       </div>
       <div :class="$style['partyWindow']">
-        <div v-if="!duplicate" class="text-md-center generic-label" id="create-new-party">
+        <div v-if="!isDuplicate" class="text-md-center generic-label" id="create-new-party">
           Use my information and create a new {{ partyWord }} Party:
         </div>
 
         <v-container class="currentParty">
-          <v-row :class="[$style[duplicate ? 'companyRowDuplicate' : 'companyRow'],
-            { 'primaryRow': showSelected && !duplicate }]">
+          <v-row :class="[$style[isDuplicate ? 'companyRowDuplicate' : 'companyRow'],
+            { 'primaryRow': showSelected && !isDuplicate }]">
             <v-col cols="auto" :class="$style['iconColumn']">
               <v-icon :class="$style['companyIcon']">
                 {{party.businessName ? 'mdi-domain' : 'mdi-account'}}
@@ -74,29 +74,28 @@
                 {{ getCountryName(party.address.country) }}
               </div>
               <div>
-                <v-chip  x-small v-if="!duplicate" label color="primary" text-color="white"
-                  >NEW</v-chip
-                >
+                <v-chip  x-small v-if="!isDuplicate" label color="primary" text-color="white">
+                  NEW
+                </v-chip>
               </div>
             </v-col>
             <v-col cols="2" class="pt-5"
               ><v-btn
-                v-if="!duplicate"
+                v-if="!isDuplicate"
                 class="ml-auto float-right"
                 color="primary"
                 :class="$style['partyButton']"
                 @click="createParty()"
               >
                 Select
-              </v-btn></v-col
-            >
+              </v-btn></v-col>
           </v-row>
         </v-container>
 
-        <div v-if="!duplicate" class="text-md-center generic-label">
+        <div v-if="!isDuplicate" class="text-md-center generic-label">
           Use an existing {{ partyWord }} Party:
         </div>
-        <v-container v-if="!duplicate">
+        <v-container v-if="!isDuplicate">
           <v-row
             class="searchResponse"
             :class="$style['companyRow']"
@@ -105,8 +104,8 @@
             @mouseover="onHover"
           >
             <v-col cols="auto" :class="$style['iconColumn']"
-              ><v-icon :class="$style['companyIcon']">mdi-domain</v-icon></v-col
-            >
+              ><v-icon :class="$style['companyIcon']">mdi-domain</v-icon>
+            </v-col>
             <v-col cols="9">
               <div :class="$style['companyText']" class="businessName">
                 {{ result.businessName }}
@@ -128,11 +127,11 @@
                 @click="selectParty(i)"
               >
                 Select
-              </v-btn></v-col
-            >
+              </v-btn>
+            </v-col>
           </v-row>
         </v-container>
-        <div v-else-if="review" >
+        <div v-else-if="isReview" >
           <p class="text-md-center px-6 pt-3" :class="$style['intro']">
             Cancelling and re-starting you registration may resolve this issue.<br>
             If you do not wish to proceed, contact BC registries staff:
@@ -141,21 +140,19 @@
         </div>
       </div>
       <v-card-actions class="pt-6 pb-8">
-        <v-btn v-if="!duplicate && !review"
+        <v-btn v-if="!isDuplicate && !isReview"
           :class="$style['dialogButton']"
           id="dialog-cancel-button"
           color="primary"
           outlined
           @click="exit()"
-          >Exit</v-btn
-        >
+          >Exit</v-btn>
         <v-btn v-else
           :class="$style['dialogButton']"
           class="primary dialog-btn"
           color="primary"
           @click="exit()"
-          >OK</v-btn
-        >
+          >OK</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -201,12 +198,6 @@ export default defineComponent({
   setup (props, context) {
     const localState = reactive({
       showSelected: true,
-      duplicate: computed((): boolean => {
-        return props.isDuplicate
-      }),
-      review: computed((): boolean => {
-        return props.isReview
-      }),
       party: computed((): PartyIF => {
         return props.defaultParty
       }),

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -6,7 +6,7 @@
     attach="#app"
     content-class="secured-party-dialog"
   >
-    <v-card id="secured-party-dialog" :class="!isDuplicate && !isReview ? 'pl-4 pr-1 pt-7 mt-7' : 'pl-1 pr-1 pt-7 mt-7'">
+    <v-card id="secured-party-dialog" class="pr-1 pt-7 mt-7" :class="!isDuplicate && !isReview ? 'pl-4 ' : 'pl-1'">
       <v-row no-gutters>
         <v-col cols="11">
           <v-row no-gutters>

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -368,7 +368,7 @@ export default defineComponent({
   margin-left: 330px;
   width: 75px;
 }
-.padLeft {
+.pad-left {
   margin-left: 225px;
   width: 400px;
 }

--- a/ppr-ui/src/components/parties/composables/useSecuredParty.ts
+++ b/ppr-ui/src/components/parties/composables/useSecuredParty.ts
@@ -95,6 +95,22 @@ export const useSecuredParty = (props, context) => {
     return idx !== -1
   }
 
+  const hasMatchingSecuredParty = (addedParty: PartyIF): boolean => {
+    // store state without newly added party
+    const parties = cloneDeep(getAddSecuredPartiesAndDebtors.value.securedParties)
+    if (localState.partyBusiness === 'I') {
+      return parties.some(party =>
+        JSON.stringify(party.personName) === JSON.stringify(addedParty.personName) &&
+        JSON.stringify(party.address) === JSON.stringify(addedParty.address)
+      )
+    } else {
+      return parties.some(party =>
+        party.businessName === addedParty.businessName &&
+        JSON.stringify(party.address) === JSON.stringify(addedParty.address)
+      )
+    }
+  }
+
   const removeSecuredParty = (): void => {
     context.emit('removeSecuredParty', props.activeIndex)
     resetFormAndData(true)
@@ -170,6 +186,7 @@ export const useSecuredParty = (props, context) => {
     RegistrationFlowType,
     ActionTypes,
     setRegisteringParty,
+    hasMatchingSecuredParty,
     ...toRefs(localState)
   }
 }

--- a/ppr-ui/src/components/parties/composables/useSecuredParty.ts
+++ b/ppr-ui/src/components/parties/composables/useSecuredParty.ts
@@ -100,13 +100,13 @@ export const useSecuredParty = (props, context) => {
     const parties = cloneDeep(getAddSecuredPartiesAndDebtors.value.securedParties)
     if (localState.partyBusiness === 'I') {
       return parties.some(party =>
-        JSON.stringify(party.personName) === JSON.stringify(addedParty.personName) &&
-        JSON.stringify(party.address) === JSON.stringify(addedParty.address)
+        isEqual(party.personName, addedParty.personName) &&
+        isEqual(party.address, addedParty.address)
       )
     } else {
       return parties.some(party =>
         party.businessName === addedParty.businessName &&
-        JSON.stringify(party.address) === JSON.stringify(addedParty.address)
+        isEqual(party.address, addedParty.address)
       )
     }
   }

--- a/ppr-ui/src/components/parties/composables/useSecuredParty.ts
+++ b/ppr-ui/src/components/parties/composables/useSecuredParty.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs, computed } from '@vue/composition-api'
 import { PartyIF, AddressIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { useGetters, useActions } from 'vuex-composition-helpers'
 import { PartyAddressSchema } from '@/schemas'
-import { ActionTypes, APIRegistrationTypes, RegistrationFlowType } from '@/enums'
+import { ActionTypes, APIRegistrationTypes, RegistrationFlowType, SecuredPartyTypes } from '@/enums'
 import { checkAddress, formatAddress } from '@/composables/address/factories/address-factory'
 import { cloneDeep, isEqual } from 'lodash'
 import { useParty } from '@/composables/useParty'
@@ -34,7 +34,7 @@ export const useSecuredParty = (props, context) => {
       address: initAddress
     } as PartyIF,
     currentIsBusiness: null,
-    partyBusiness: null,
+    partyType: SecuredPartyTypes.NONE,
     registrationFlowType: getRegistrationFlowType.value,
     originalSecuredParty: null
   })
@@ -48,10 +48,10 @@ export const useSecuredParty = (props, context) => {
       localState.currentSecuredParty = JSON.parse(JSON.stringify(registeringParty))
       localState.currentSecuredParty.address = checkAddress(localState.currentSecuredParty.address, PartyAddressSchema)
       localState.currentIsBusiness = false
-      localState.partyBusiness = 'I'
+      localState.partyType = SecuredPartyTypes.INDIVIDUAL
       if (localState.currentSecuredParty.businessName) {
         localState.currentIsBusiness = true
-        localState.partyBusiness = 'B'
+        localState.partyType = SecuredPartyTypes.BUSINESS
         localState.currentSecuredParty.personName = Object.assign({}, initPerson)
       }
     } else if (props.activeIndex >= 0) {
@@ -59,14 +59,14 @@ export const useSecuredParty = (props, context) => {
       localState.currentSecuredParty = JSON.parse(JSON.stringify(securedParties[props.activeIndex]))
       localState.currentSecuredParty.address = checkAddress(localState.currentSecuredParty.address, PartyAddressSchema)
       localState.currentIsBusiness = false
-      localState.partyBusiness = 'I'
+      localState.partyType = SecuredPartyTypes.INDIVIDUAL
       if (localState.currentSecuredParty.businessName) {
         localState.currentIsBusiness = true
-        localState.partyBusiness = 'B'
+        localState.partyType = SecuredPartyTypes.BUSINESS
         localState.currentSecuredParty.personName = Object.assign({}, initPerson)
       }
     } else {
-      localState.partyBusiness = null
+      localState.partyType = SecuredPartyTypes.NONE
       const blankSecuredParty = {
         businessName: '',
         personName: Object.assign({}, initPerson),
@@ -98,7 +98,7 @@ export const useSecuredParty = (props, context) => {
   const hasMatchingSecuredParty = (addedParty: PartyIF): boolean => {
     // store state without newly added party
     const parties = cloneDeep(getAddSecuredPartiesAndDebtors.value.securedParties)
-    if (localState.partyBusiness === 'I') {
+    if (localState.partyType === SecuredPartyTypes.INDIVIDUAL) {
       return parties.some(party =>
         isEqual(party.personName, addedParty.personName) &&
         isEqual(party.address, addedParty.address)

--- a/ppr-ui/src/components/parties/composables/useSecuredPartyValidation.ts
+++ b/ppr-ui/src/components/parties/composables/useSecuredPartyValidation.ts
@@ -2,6 +2,7 @@ import { ref } from '@vue/composition-api'
 import { createDefaultValidationResult } from '@lemoncode/fonk'
 import { formValidation } from './securedPartyFormValidator'
 import { useValidation } from '@/utils/validators/use-validation'
+import { SecuredPartyTypes } from '@/enums'
 const {
   validateName
 } = useValidation()
@@ -24,8 +25,8 @@ export const useSecuredPartyValidation = () => {
     })
   }
 
-  const validateSecuredPartyForm = (partyBusiness, currentParty, isRegisteringParty): boolean => {
-    const currentIsBusiness = partyBusiness === 'B'
+  const validateSecuredPartyForm = (partyType, currentParty, isRegisteringParty): boolean => {
+    const currentIsBusiness = partyType === SecuredPartyTypes.BUSINESS
     validateName(currentIsBusiness, currentParty.value, errors)
     if (isRegisteringParty) {
       if (currentParty.value.emailAddress.length === 0) {

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -373,21 +373,20 @@ export default defineComponent({
           currentSecuredParty.value.personName.last = ''
         }
 
-        if (props.activeIndex === -1) {
-          if ((currentSecuredParty.value.businessName) && (partyBusiness.value === 'B')) {
-            // go to the service and see if there are similar secured parties
-            const response: [SearchPartyIF] = await partyCodeSearch(
-              currentSecuredParty.value.businessName, false
-            )
-            // check if any results
-            if (response?.length > 0) {
-              // show secured party selection popup
-              showDialog()
-              localState.dialogResults = response?.slice(0, 50)
-              return
-            }
+        if ((currentSecuredParty.value.businessName) && (partyBusiness.value === 'B')) {
+          // go to the service and see if there are similar secured parties
+          const response: [SearchPartyIF] = await partyCodeSearch(
+            currentSecuredParty.value.businessName, false
+          )
+          // check if any results
+          if (response?.length > 0) {
+            // show secured party selection popup
+            showDialog()
+            localState.dialogResults = response?.slice(0, 50)
+            return
           }
         }
+
         if (localState.isRegisteringParty) {
           setRegisteringParty(currentSecuredParty.value)
           context.emit('resetEvent')

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -37,7 +37,7 @@
             <v-row class="pb-6" no-gutters>
               <v-col cols="12">
                 <v-radio-group
-                  v-model="partyBusiness"
+                  v-model="partyType"
                   class="mt-0"
                   row
                   hide-details="true"
@@ -48,7 +48,7 @@
                       $style['party-radio-individual'],
                     ]"
                     label="Individual Person"
-                    value="I"
+                    :value=SecuredPartyTypes.INDIVIDUAL
                     id="party-individual"
                   >
                   </v-radio>
@@ -56,7 +56,7 @@
                   <v-radio
                     :class="['business-radio', $style['party-radio-business']]"
                     label="Business"
-                    value="B"
+                    :value=SecuredPartyTypes.BUSINESS
                     id="party-business"
                   >
                   </v-radio>
@@ -64,9 +64,9 @@
               </v-col>
             </v-row>
             <v-divider class="pb-4" />
-            <v-row no-gutters v-if="isPartyType">
+            <v-row no-gutters v-if="partyType !== SecuredPartyTypes.NONE">
               <v-col cols="12">
-                <v-row v-if="partyBusiness === 'B'" no-gutters class="pb-4">
+                <v-row v-if="partyType === SecuredPartyTypes.BUSINESS" no-gutters class="pb-4">
                   <v-col>
                     <label class="generic-label">Business Name</label>
                   </v-col>
@@ -76,7 +76,7 @@
                     <label class="generic-label">Person's Name</label>
                   </v-col>
                 </v-row>
-                <v-row v-if="partyBusiness === 'B'" no-gutters>
+                <v-row v-if="partyType === SecuredPartyTypes.BUSINESS" no-gutters>
                   <v-col>
                     <v-text-field
                       filled
@@ -205,7 +205,7 @@
                     id="done-btn-party"
                     class="ml-auto"
                     color="primary"
-                    :disabled="!isPartyType"
+                    :disabled="partyType === SecuredPartyTypes.NONE"
                     @click="onSubmitForm()"
                   >
                     Done
@@ -244,6 +244,7 @@ import {
 import { SecuredPartyDialog } from '@/components/dialogs'
 import { AutoComplete } from '@/components/search'
 import { BaseAddress } from '@/composables/address'
+import { SecuredPartyTypes } from '@/enums'
 // local helpers / types / etc.
 import { useSecuredParty } from '@/components/parties/composables/useSecuredParty'
 import { useSecuredPartyValidation } from '@/components/parties/composables/useSecuredPartyValidation'
@@ -281,7 +282,7 @@ export default defineComponent({
     const {
       currentSecuredParty,
       currentIsBusiness,
-      partyBusiness,
+      partyType,
       getSecuredParty,
       resetFormAndData,
       removeSecuredParty,
@@ -317,12 +318,6 @@ export default defineComponent({
       hideDetails: false,
       toggleDialog: false,
       dialogResults: [],
-      isPartyType: computed((): boolean => {
-        if (!partyBusiness.value) {
-          return false
-        }
-        return true
-      }),
       showAllAddressErrors: false,
       currentIndex: computed((): number => {
         return props.activeIndex
@@ -359,12 +354,12 @@ export default defineComponent({
       }
       if (
         validateSecuredPartyForm(
-          partyBusiness.value,
+          partyType.value,
           currentSecuredParty,
           localState.isRegisteringParty
         ) === true
       ) {
-        if (partyBusiness.value === 'I') {
+        if (partyType.value === SecuredPartyTypes.INDIVIDUAL) {
           currentSecuredParty.value.businessName = ''
           // localState.searchValue = ''
         } else {
@@ -373,7 +368,7 @@ export default defineComponent({
           currentSecuredParty.value.personName.last = ''
         }
 
-        if ((currentSecuredParty.value.businessName) && (partyBusiness.value === 'B')) {
+        if (currentSecuredParty.value.businessName && partyType.value === SecuredPartyTypes.BUSINESS) {
           // go to the service and see if there are similar secured parties
           const response: [SearchPartyIF] = await partyCodeSearch(
             currentSecuredParty.value.businessName, false
@@ -446,7 +441,8 @@ export default defineComponent({
     return {
       currentSecuredParty,
       currentIsBusiness,
-      partyBusiness,
+      partyType,
+      SecuredPartyTypes,
       resetFormAndData,
       removeSecuredParty,
       onSubmitForm,

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -2,6 +2,7 @@
   <div id="edit-party" class="white pa-6" :class="{ 'border-error-left': showErrorBar }">
     <secured-party-dialog
       attach="#app"
+      :isDuplicate="foundDuplicate"
       :defaultDialog="toggleDialog"
       :defaultParty="currentSecuredParty"
       :defaultResults="dialogResults"
@@ -290,7 +291,8 @@ export default defineComponent({
       updateAddress,
       ActionTypes,
       setRegisteringParty,
-      addressSchema
+      addressSchema,
+      hasMatchingSecuredParty
     } = useSecuredParty(props, context)
 
     const {
@@ -310,6 +312,7 @@ export default defineComponent({
     const localState = reactive({
       autoCompleteIsActive: true,
       autoCompleteSearchValue: '',
+      foundDuplicate: false,
       searchValue: '',
       hideDetails: false,
       toggleDialog: false,
@@ -347,6 +350,13 @@ export default defineComponent({
 
     const onSubmitForm = async () => {
       currentSecuredParty.value.address = formatAddress(currentSecuredParty.value.address)
+      // check for duplicate
+      if (hasMatchingSecuredParty(currentSecuredParty.value)) {
+        // trigger duplicate secured party dialog
+        localState.foundDuplicate = true
+        showDialog()
+        return
+      }
       if (
         validateSecuredPartyForm(
           partyBusiness.value,

--- a/ppr-ui/src/components/parties/party/PartyAutocomplete.vue
+++ b/ppr-ui/src/components/parties/party/PartyAutocomplete.vue
@@ -14,18 +14,27 @@
             <v-list-item
               v-for="(result, i) in autoCompleteResults"
               :key="i"
-              :class="['pt-0', 'pb-0', 'pl-1', $style['auto-complete-item'], $style[wasSelected(result)]]"
+              :ripple="!isExistingSecuredParty(result.code)"
+              :class="[
+                'pt-0', 'pb-0', 'pl-1',
+                $style[!isExistingSecuredParty(result.code) ? 'auto-complete-item' : 'auto-complete-added-item'],
+                $style[wasSelected(result)]
+              ]"
+              :active-class="{'added-color' : isExistingSecuredParty(result.code)}"
               @mouseover="mouseOver = true"
               @mouseleave="mouseOver = false"
             >
               <v-list-item-content
-                :class="[$style['auto-complete-item'], 'pt-2', 'pb-2']"
-                @click="addResult(result, i)"
+                :disabled="isExistingSecuredParty(result.code)"
+                :class="[
+                  $style[isExistingSecuredParty(result.code) ? 'auto-complete-added-item' : ''], 'pt-2', 'pb-2'
+                ]"
+                @click="!isExistingSecuredParty(result.code) ? addResult(result, i) : ''"
               >
                 <v-list-item-subtitle>
                   <v-row :class="[
                     $style['auto-complete-row'],
-                    $style[mouseOver? '' : wasSelected(result)]
+                    $style[mouseOver ? '' : wasSelected(result)]
                     ]
                   ">
                     <v-col cols="2" :class="$style['title-size']">
@@ -45,6 +54,7 @@
                 </v-list-item-subtitle>
               </v-list-item-content>
               <v-list-item-action
+                :disabled="isExistingSecuredParty(result.code)"
                 v-if="!isMhrPartySearch"
                 :class="[$style['auto-complete-action'], 'mt-n1']"
               >
@@ -217,9 +227,20 @@ export default defineComponent({
   color: $primary-blue !important;
   background-color: $gray1 !important;
 }
-
 .auto-complete-item:hover .auto-complete-row{
   color: $primary-blue !important;
+}
+
+.added-color {
+  color : $gray7 !important;
+}
+
+.auto-complete-added-item:hover {
+  background-color: $gray1 !important;
+}
+
+.auto-complete-added-item:hover .auto-complete-row{
+  color: $gray7 !important;
 }
 
 .auto-complete-item[aria-selected='true'] {

--- a/ppr-ui/src/enums/index.ts
+++ b/ppr-ui/src/enums/index.ts
@@ -23,6 +23,7 @@ export * from './homeCertificationOptions'
 export * from './homeLocationTypes'
 export * from './homeTenancyTypes'
 export * from './submittingPartyTypes'
+export * from './securedPartyTypes'
 export * from './business-statuses'
 export * from './business-types'
 

--- a/ppr-ui/src/enums/securedPartyTypes.ts
+++ b/ppr-ui/src/enums/securedPartyTypes.ts
@@ -1,0 +1,5 @@
+export enum SecuredPartyTypes {
+  INDIVIDUAL = 'individual',
+  BUSINESS = 'business',
+  NONE = 'none'
+}

--- a/ppr-ui/tests/unit/EditSecuredParty.spec.ts
+++ b/ppr-ui/tests/unit/EditSecuredParty.spec.ts
@@ -10,6 +10,7 @@ import sinon from 'sinon'
 
 // Components
 import { EditParty } from '@/components/parties/party'
+import { SecuredPartyTypes } from '@/enums'
 
 Vue.use(Vuetify)
 
@@ -51,7 +52,7 @@ describe('Secured Party add individual tests', () => {
   it('renders with default values', async () => {
     expect(wrapper.findComponent(EditParty).exists()).toBe(true)
     // radio button value is blank
-    expect(wrapper.vm.partyBusiness).toBe(null)
+    expect(wrapper.vm.partyType).toBe(SecuredPartyTypes.NONE)
   })
 
   it('shows buttons on the form and remove button is disabled', async () => {

--- a/ppr-ui/tests/unit/ErrorContact.spec.ts
+++ b/ppr-ui/tests/unit/ErrorContact.spec.ts
@@ -39,8 +39,8 @@ describe('Error Contact component', () => {
     expect(contactItems.at(0).find('.contact-key').text()).toContain('Canada')
     expect(contactItems.at(0).find('.contact-value').text()).toBe('1-877-526-1526')
     expect(contactItems.at(1).find('.contact-key').text()).toContain('Victoria')
-    expect(contactItems.at(1).find('.contact-value').text()).toBe('250-387-7878')
-    expect(contactItems.at(2).find('.contact-key').text()).toContain('BC Registries')
+    expect(contactItems.at(1).find('.contact-value').text()).toBe('250-952-0568')
+    expect(contactItems.at(2).find('.contact-key').text()).toContain('Email')
     expect(contactItems.at(2).find('.contact-value').text()).toBe('BCRegistries@gov.bc.ca')
 
     wrapper.destroy()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14175

*Description of changes:*

- A few UI fixes in the autocomplete list when searching to add existing secured parties:
           - Added parties cannot be interacted with in the list
           - Parties that were already added now have different coloring and don't change when clicked
           - Changed mouse rollover actions on added parties
           
- Updated contact info phone number and text, used by error dialogs

- When a user manually enters a secured party (individual or business), that party is compared with the current secured parties to ensure no exact matches of first, middle and last names, as well as address.
- If such a match is found, an error dialogue will be displayed to the user and the party will not be added to the table.
![image](https://user-images.githubusercontent.com/112968185/201166671-3a5fe654-7e64-4a55-b71d-018b48ed38c3.png)

- SecuredPartyDialog component with isDuplicate prop will be used to display undetected Duplicate Party error in review and confirm once API check is implemented

*** #14177 Similar secured party check for edit: Made a small change to complete this ticket. Similar parties are now detected when a Secured Party is edited.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
