### PR TITLE
Clear Transfer Details data on Undo

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.45",
+      "version": "0.3.46",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrTransfers/TransferDetails.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferDetails.vue
@@ -195,6 +195,14 @@ export default defineComponent({
       return localState.isTransferDetailsFormValid
     }
 
+    // Clear the data when hiding Transfer Details (e.g. in Undo)
+    const clearTransferDetailsData = () => {
+      setMhrTransferDeclaredValue('')
+      setMhrTransferConsideration('')
+      setMhrTransferDate(null)
+      setMhrTransferOwnLand(false)
+    }
+
     watch(
       () => localState.declaredValue,
       async (val: string) => {
@@ -235,6 +243,7 @@ export default defineComponent({
       considerationRules,
       updateConsideration,
       validateDetailsForm,
+      clearTransferDetailsData,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -492,7 +492,7 @@ export default defineComponent({
     watch(
       () => hasUnsavedChanges.value,
       (val: boolean) => {
-        if (val === false && context.refs.transferDetailsComponent) {
+        if (!val && context.refs.transferDetailsComponent) {
           (context.refs.transferDetailsComponent as any).clearTransferDetailsData()
         }
         localState.showTransferDetails = val

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -127,7 +127,7 @@
                   :validateTransfer="validate"
                   @isValidTransferOwners="isValidTransferOwners = $event"
                 />
-                <TransferDetails v-if="hasUnsavedChanges" ref="transferDetailsComponent" />
+                <TransferDetails v-if="showTransferDetails" ref="transferDetailsComponent" />
               </template>
             </section>
           </v-col>
@@ -264,6 +264,7 @@ export default defineComponent({
       isReviewMode: false,
       validate: false,
       isTransferDetailsFormValid: false,
+      showTransferDetails: false,
       refNumValid: false,
       authorizationValid: false,
       validateConfirmCompletion: false,
@@ -485,6 +486,16 @@ export default defineComponent({
       () => localState.isCompletionConfirmed,
       (isValid: boolean) => {
         localState.validateConfirmCompletion = !isValid
+      }
+    )
+
+    watch(
+      () => hasUnsavedChanges.value,
+      (val: boolean) => {
+        if (val === false && context.refs.transferDetailsComponent) {
+          (context.refs.transferDetailsComponent as any).clearTransferDetailsData()
+        }
+        localState.showTransferDetails = val
       }
     )
 


### PR DESCRIPTION
*Description of changes:*

- The requirement is to erase Transfer Details data/fields when the component gets hidden (for instance via Undo button click).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
