### PR TITLE
use compact to trim address objects

### DIFF
--- a/ppr-ui/src/components/parties/composables/useSecuredParty.ts
+++ b/ppr-ui/src/components/parties/composables/useSecuredParty.ts
@@ -4,7 +4,7 @@ import { useGetters, useActions } from 'vuex-composition-helpers'
 import { PartyAddressSchema } from '@/schemas'
 import { ActionTypes, APIRegistrationTypes, RegistrationFlowType, SecuredPartyTypes } from '@/enums'
 import { checkAddress, formatAddress } from '@/composables/address/factories/address-factory'
-import { cloneDeep, isEqual } from 'lodash'
+import { cloneDeep, isEqual, compact } from 'lodash'
 import { useParty } from '@/composables/useParty'
 
 const initPerson = { first: '', middle: '', last: '' }
@@ -106,7 +106,7 @@ export const useSecuredParty = (props, context) => {
     } else {
       return parties.some(party =>
         party.businessName === addedParty.businessName &&
-        isEqual(party.address, addedParty.address)
+        isEqual(compact(party.address), compact(addedParty.address))
       )
     }
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14175

*Description of changes:*
- Fix for when a user manually enters the same secured party as one added from the autocomplete search/dropdown
- The address objects from the search do not have the optional fields, so this fix removes the optional fields (if empty) from the manually added party to allow them to be compared.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
