### PR TITLE
Undo Group Removal + Misc UX Fixes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.50",
+      "version": "0.3.51",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerGroups.vue
@@ -96,6 +96,7 @@ export default defineComponent({
     const {
       showGroups,
       getGroupDropdownItems,
+      hasUndefinedGroupInterest,
       getTransferOrRegistrationHomeOwnerGroups
     } = useHomeOwners(props.isMhrTransfer)
 
@@ -104,7 +105,9 @@ export default defineComponent({
       removeGroupDropdownValidation: false,
       groupItems: computed(() => getGroupDropdownItems(props.isAddingHomeOwner, props.groupId)),
       groupRules: computed(() => {
-        return showGroups.value && localState.groupItems.length >= 2
+        return (showGroups.value && localState.groupItems.length >= 2 &&
+        !hasUndefinedGroupInterest(getTransferOrRegistrationHomeOwnerGroups())) || // Default state
+        localState.groupItems.length >= 3 // Safety check, to catch undefined groups after marking groups for removal
           ? required('Select a group for this owner')
           : []
       }),

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -413,7 +413,7 @@ export default defineComponent({
       }
 
       // @ts-ignore - function exists
-      await context.refs.transferDetailsComponent.validateDetailsForm()
+      await context.refs.transferDetailsComponent?.validateDetailsForm()
 
       // If transfer is valid, enter review mode
       if (localState.isValidTransfer) {
@@ -437,7 +437,7 @@ export default defineComponent({
           addedReg: String(mhrDraft.draftNumber),
           addedRegParent: apiData.mhrNumber,
           addedRegSummary: null,
-          prevDraft: String(getMhrInformation.value.changes[0].documentId) || ''
+          prevDraft: (getMhrInformation.value.changes && String(getMhrInformation.value.changes[0].documentId)) || ''
         }
         setRegTableNewItem(newItem)
       }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13964

*Description of changes:*
* Implements functionality to undo group removals
* fix edit of new owner groups ownership allocation bug
* fix hide/show fee summary bug - /bcgov/entity#14298
* misc template clean up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
