### PR TITLE
14426 Duplicate Secured Party modal instead of error message under 'Business Legal Name'

### DIFF
--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -351,20 +351,8 @@ export default defineComponent({
     const onSubmitForm = async () => {
       localState.foundDuplicate = false
       currentSecuredParty.value.address = formatAddress(currentSecuredParty.value.address)
-      // check for duplicate
-      if (hasMatchingSecuredParty(currentSecuredParty.value, props.isEditMode)) {
-        // trigger duplicate secured party dialog
-        localState.foundDuplicate = true
-        showDialog()
-        return
-      }
-      if (
-        validateSecuredPartyForm(
-          partyType.value,
-          currentSecuredParty,
-          localState.isRegisteringParty
-        ) === true
-      ) {
+
+      if (validateSecuredPartyForm(partyType.value, currentSecuredParty, localState.isRegisteringParty)) {
         if (partyType.value === SecuredPartyTypes.INDIVIDUAL) {
           currentSecuredParty.value.businessName = ''
           // localState.searchValue = ''
@@ -373,7 +361,13 @@ export default defineComponent({
           currentSecuredParty.value.personName.middle = ''
           currentSecuredParty.value.personName.last = ''
         }
-
+        // check for duplicate
+        if (hasMatchingSecuredParty(currentSecuredParty.value, props.isEditMode)) {
+          // trigger duplicate secured party dialog
+          localState.foundDuplicate = true
+          showDialog()
+          return
+        }
         if (currentSecuredParty.value.businessName && partyType.value === SecuredPartyTypes.BUSINESS) {
           // go to the service and see if there are similar secured parties
           const response: [SearchPartyIF] = await partyCodeSearch(

--- a/ppr-ui/src/utils/validation-helper.ts
+++ b/ppr-ui/src/utils/validation-helper.ts
@@ -343,13 +343,10 @@ export function normalizeObject (convertObject: any): any {
   return convertObject
 }
 
-export function isObjectEqual (object1: any, object2: any): boolean {
+export function isObjectEqual (object1: any = null, object2: any = null): boolean {
   //
   // Does an equality between 2 objects
   //
-  if (object1 === undefined) object1 = null
-  if (object2 === undefined) object2 = null
-  // these ifs as Object.create() needs null or defined object
   const workObject1 = Object.create(object1)
   const workObject2 = Object.create(object2)
   const objectEqual = isEqual(normalizeObject(workObject1), normalizeObject(workObject2))

--- a/ppr-ui/src/utils/validation-helper.ts
+++ b/ppr-ui/src/utils/validation-helper.ts
@@ -347,6 +347,9 @@ export function isObjectEqual (object1: any, object2: any): boolean {
   //
   // Does an equality between 2 objects
   //
+  if (object1 === undefined) object1 = null
+  if (object2 === undefined) object2 = null
+  // these ifs as Object.create() needs null or defined object
   const workObject1 = Object.create(object1)
   const workObject2 = Object.create(object2)
   const objectEqual = isEqual(normalizeObject(workObject1), normalizeObject(workObject2))


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14426

*Description of changes:*
- Moved duplicate secured party check after validation check so that invalid parties cannot be compared.
- Fixed bug Divya found in 14175 regarding amendments being blocked. Made changes to IsObjectEqual to handle undefined inputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
