### PR TITLE
MHR api complete postgres data model changes.

### DIFF
--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -32,6 +32,7 @@ from .db2.owngroup import Db2Owngroup
 from .event_tracking import EventTracking
 from .financing_statement import FinancingStatement
 from .general_collateral import GeneralCollateral
+from .mhr_description import MhrDescription
 from .mhr_document import MhrDocument
 from .mhr_draft import MhrDraft
 from .mhr_extra_registration import MhrExtraRegistration
@@ -41,6 +42,7 @@ from .mhr_owner_group import MhrOwnerGroup
 from .mhr_party import MhrParty
 from .mhr_registration import MhrRegistration
 from .mhr_registration_report import MhrRegistrationReport
+from .mhr_section import MhrSection
 from .party import Party
 from .registration import Registration
 from .search_request import SearchRequest
@@ -73,10 +75,10 @@ __all__ = ('db',
            'Db2Cmpserno', 'Db2Descript', 'Db2Docdes', 'Db2Document', 'Db2Location', 'Db2Manufact', 'Db2Manuhome',
            'Db2Mhomnote', 'Db2Owner', 'Db2Owngroup',
            'EventTracking', 'EventTrackingType', 'FinancingStatement', 'GeneralCollateral', 'MhrDraft', 'MhrDocument',
-           'MhrExtraRegistration', 'MhrLocation', 'MhrNote', 'MhrParty', 'MhrRegistration', 'MhrRegistrationReport',
-           'MhrDocumentType', 'MhrLocationType', 'MhrNoteStatusType', 'MhrOwnerGroup', 'MhrOwnerStatusType',
-           'MhrPartyType',
-           'MhrRegistrationStatusType', 'MhrRegistrationType', 'MhrStatusType', 'MhrTenancyType',
+           'MhrDescription', 'MhrExtraRegistration', 'MhrLocation', 'MhrNote', 'MhrParty', 'MhrRegistration',
+           'MhrRegistrationReport', 'MhrDocumentType', 'MhrLocationType', 'MhrNoteStatusType', 'MhrOwnerGroup',
+           'MhrOwnerStatusType', 'MhrPartyType',
+           'MhrRegistrationStatusType', 'MhrRegistrationType', 'MhrSection', 'MhrStatusType', 'MhrTenancyType',
            'Party', 'PartyType', 'ProvinceType', 'Registration', 'RegistrationType',
            'RegistrationTypeClass', 'SearchRequest', 'SearchResult', 'SearchType', 'StateType', 'SerialType',
            'TrustIndenture', 'VehicleCollateral')

--- a/mhr_api/src/mhr_api/models/mhr_description.py
+++ b/mhr_api/src/mhr_api/models/mhr_description.py
@@ -1,0 +1,148 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for MHR descriptions."""
+
+# from flask import current_app
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+
+from mhr_api.models import utils as model_utils
+
+from .db import db
+from .type_tables import MhrStatusTypes
+
+
+class MhrDescription(db.Model):  # pylint: disable=too-many-instance-attributes
+    """This class manages all of the MHR description information."""
+
+    __tablename__ = 'mhr_descriptions'
+
+    id = db.Column('id', db.Integer, db.Sequence('mhr_description_id_seq'), primary_key=True)
+    csa_number = db.Column('csa_number', db.String(10), nullable=True)
+    csa_standard = db.Column('csa_standard', db.String(4), nullable=True)
+    number_of_sections = db.Column('number_of_sections', db.Integer, nullable=False)
+    square_feet = db.Column('square_feet', db.Integer, nullable=True)
+    year_made = db.Column('year_made', db.Integer, nullable=True)
+    circa = db.Column('circa', db.String(1), nullable=True)
+    engineer_date = db.Column('engineer_date', db.DateTime, nullable=True)
+    engineer_name = db.Column('engineer_name', db.String(150), nullable=True)
+    manufacturer_name = db.Column('manufacturer_name', db.String(150), nullable=True)
+    make = db.Column('make', db.String(60), nullable=True)
+    model = db.Column('model', db.String(60), nullable=True)
+    rebuilt_remarks = db.Column('rebuilt_remarks', db.String(300), nullable=True)
+    other_remarks = db.Column('other_remarks', db.String(150), nullable=True)
+
+    # parent keys
+    registration_id = db.Column('registration_id', db.Integer, db.ForeignKey('mhr_registrations.id'), nullable=False,
+                                index=True)
+    change_registration_id = db.Column('change_registration_id', db.Integer, nullable=False, index=True)
+    status_type = db.Column('status_type', PG_ENUM(MhrStatusTypes),
+                            db.ForeignKey('mhr_status_types.status_type'), nullable=False)
+
+    # Relationships - MhrRegistration
+    registration = db.relationship('MhrRegistration', foreign_keys=[registration_id],
+                                   back_populates='descriptions', cascade='all, delete', uselist=False)
+
+    @property
+    def json(self) -> dict:  # pylint: disable=too-many-branches
+        """Return the description as a json object."""
+        description = {
+            'status': self.status_type,
+            'sectionCount': self.number_of_sections,
+            'baseInformation': {
+                'make': '',
+                'model': '',
+                'circa': False
+            }
+        }
+        if self.csa_number:
+            description['csaNumber'] = self.csa_number
+        if self.csa_standard:
+            description['csaStandard'] = self.csa_standard
+        if self.square_feet:
+            description['squareFeet'] = self.square_feet
+        if self.year_made:
+            description['baseInformation']['year'] = self.year_made
+        if self.circa and self.circa == 'Y':
+            description['baseInformation']['circa'] = True
+        if self.manufacturer_name:
+            description['manufacturer'] = self.manufacturer_name
+        if self.make:
+            description['baseInformation']['make'] = self.make
+        if self.model:
+            description['baseInformation']['model'] = self.model
+        if self.engineer_name:
+            description['engineerName'] = self.engineer_name
+        if self.engineer_date:
+            description['engineerDate'] = model_utils.format_ts(self.engineer_date)
+        if self.rebuilt_remarks:
+            description['rebuiltRemarks'] = self.rebuilt_remarks
+        if self.other_remarks:
+            description['otherRemarks'] = self.other_remarks
+        return description
+
+    @classmethod
+    def find_by_id(cls, description_id: int = None):
+        """Return a description object by location ID."""
+        description = None
+        if description_id:
+            description = cls.query.get(description_id)
+
+        return description
+
+    @classmethod
+    def find_by_registration_id(cls, registration_id: int = None):
+        """Return a list of description objects by registration id."""
+        descriptions = None
+        if registration_id:
+            descriptions = cls.query.filter(MhrDescription.registration_id == registration_id) \
+                                    .order_by(MhrDescription.id).all()
+
+        return descriptions
+
+    @classmethod
+    def find_by_change_registration_id(cls, registration_id: int = None):
+        """Return a description object by change registration id."""
+        description = None
+        if registration_id:
+            description = cls.query.filter(MhrDescription.change_registration_id == registration_id).one_or_none()
+        return description
+
+    @staticmethod
+    def create_from_json(json_data, registration_id: int = None):
+        """Create a description object from a json schema object: map json to db."""
+        # current_app.logger.info(json_data)
+        base_info = json_data['baseInformation']
+        # sections = new_info['sections']
+        description: MhrDescription = MhrDescription(status_type=MhrStatusTypes.ACTIVE,
+                                                     csa_number=json_data.get('csaNumber', None),
+                                                     csa_standard=json_data.get('csaStandard', None),
+                                                     number_of_sections=json_data.get('sectionCount', 0),
+                                                     square_feet=json_data.get('squareFeet', None),
+                                                     year_made=base_info.get('year', None),
+                                                     circa='N',
+                                                     manufacturer_name=json_data.get('manufacturer', ''),
+                                                     make=base_info.get('make', None),
+                                                     model=base_info.get('model', None),
+                                                     engineer_name=json_data.get('engineerName', None),
+                                                     rebuilt_remarks=json_data.get('rebuiltRemarks', None),
+                                                     other_remarks=json_data.get('otherRemarks', None))
+        if registration_id:
+            description.registration_id = registration_id
+            description.change_registration_id = registration_id
+        if base_info.get('circa'):
+            description.circa = 'Y'
+        if json_data.get('engineerDate', None):
+            description.engineer_date = model_utils.ts_from_iso_format(json_data.get('engineerDate'))
+
+        return description

--- a/mhr_api/src/mhr_api/models/mhr_owner_group.py
+++ b/mhr_api/src/mhr_api/models/mhr_owner_group.py
@@ -115,7 +115,7 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
                                              group_id=reg_json.get('groupId'),
                                              status_type=MhrOwnerStatusTypes.ACTIVE,
                                              tenancy_type=reg_json.get('type'),
-                                             tenancy_specified='N')
+                                             tenancy_specified='Y')
         group.change_registration_id = registration_id
         if reg_json.get('status'):
             group.status_type = reg_json['status']
@@ -125,8 +125,8 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
             group.interest_denominator = reg_json.get('interestDenominator', 0)
         if group.tenancy_type == MhrTenancyTypes.COMMON and not group.interest:
             group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
-        if reg_json.get('tenancySpecified'):
-            group.tenancy_specified = 'Y'
+        if not reg_json.get('tenancySpecified'):
+            group.tenancy_specified = 'N'
         group.owners = []
         return group
 
@@ -138,7 +138,7 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
                                              group_id=group_id,
                                              status_type=MhrOwnerStatusTypes.ACTIVE,
                                              tenancy_type=reg_json.get('type'),
-                                             tenancy_specified='N')
+                                             tenancy_specified='Y')
         if reg_json.get('status'):
             group.status_type = reg_json['status']
         if group.tenancy_type != MhrTenancyTypes.SOLE:
@@ -147,8 +147,8 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
             group.interest_denominator = reg_json.get('interestDenominator', 0)
         if group.tenancy_type == MhrTenancyTypes.COMMON and not group.interest:
             group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
-        if reg_json.get('tenancySpecified'):
-            group.tenancy_specified = 'Y'
+        if not reg_json.get('tenancySpecified'):
+            group.tenancy_specified = 'N'
         group.owners = []
         group.modified = True
         return group

--- a/mhr_api/src/mhr_api/models/mhr_section.py
+++ b/mhr_api/src/mhr_api/models/mhr_section.py
@@ -1,0 +1,115 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for MH home section information."""
+
+# from flask import current_app
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+
+from .db import db
+from .type_tables import MhrStatusTypes
+
+
+KEY_STATEMENT = "SELECT searchkey_vehicle(:serial_number) AS search_key"  # noqa: Q000
+
+
+class MhrSection(db.Model):  # pylint: disable=too-many-instance-attributes
+    """This class manages all of the MH section information."""
+
+    __tablename__ = 'mhr_sections'
+
+    id = db.Column('id', db.Integer, db.Sequence('mhr_section_id_seq'), primary_key=True)
+    compressed_key = db.Column('compressed_key', db.String(6), nullable=False, index=True)
+    serial_number = db.Column('serial_number', db.String(20), nullable=False)
+    length_feet = db.Column('length_feet', db.Integer, nullable=False)
+    width_feet = db.Column('width_feet', db.Integer, nullable=False)
+    length_inches = db.Column('length_inches', db.Integer, nullable=True)
+    width_inches = db.Column('width_inches', db.Integer, nullable=True)
+
+    # parent keys
+    registration_id = db.Column('registration_id', db.Integer, db.ForeignKey('mhr_registrations.id'), nullable=False,
+                                index=True)
+    change_registration_id = db.Column('change_registration_id', db.Integer, nullable=False, index=True)
+    status_type = db.Column('status_type', PG_ENUM(MhrStatusTypes),
+                            db.ForeignKey('mhr_status_types.status_type'), nullable=False)
+
+    # Relationships - MhrRegistration
+    registration = db.relationship('MhrRegistration', foreign_keys=[registration_id],
+                                   back_populates='sections', cascade='all, delete', uselist=False)
+
+    @property
+    def json(self) -> dict:  # pylint: disable=too-many-branches
+        """Return the section as a json object."""
+        section = {
+            'serialNumber': self.serial_number,
+            'lengthFeet': self.length_feet,
+            'widthFeet': self.width_feet
+        }
+        if self.length_inches:
+            section['lengthInches'] = self.length_inches
+        if self.width_inches:
+            section['widthInches'] = self.width_inches
+        return section
+
+    @classmethod
+    def find_by_id(cls, section_id: int = None):
+        """Return a section object by section ID."""
+        section = None
+        if section_id:
+            section = cls.query.get(section_id)
+
+        return section
+
+    @classmethod
+    def find_by_registration_id(cls, registration_id: int = None):
+        """Return a list of section objects by registration id."""
+        sections = None
+        if registration_id:
+            sections = cls.query.filter(MhrSection.registration_id == registration_id) \
+                                    .order_by(MhrSection.id).all()
+
+        return sections
+
+    @classmethod
+    def find_by_change_registration_id(cls, registration_id: int = None):
+        """Return a list of section objects by change registration id."""
+        sections = None
+        if registration_id:
+            sections = cls.query.filter(MhrSection.change_registration_id == registration_id) \
+                                    .order_by(MhrSection.id).all()
+
+        return sections
+
+    @staticmethod
+    def create_from_json(json_data, registration_id: int = None):
+        """Create a description object from a json schema object: map json to db."""
+        # current_app.logger.info(json_data)
+        # sections = new_info['sections']
+        section: MhrSection = MhrSection(status_type=MhrStatusTypes.ACTIVE,
+                                         serial_number=json_data.get('serialNumber'),
+                                         length_feet=json_data.get('lengthFeet'),
+                                         width_feet=json_data.get('widthFeet'),
+                                         length_inches=json_data.get('lengthInches', None),
+                                         width_inches=json_data.get('widthInches', None))
+        if registration_id:
+            section.registration_id = registration_id
+            section.change_registration_id = registration_id
+        section.compressed_key = MhrSection.get_compressed_key(section.serial_number)
+        return section
+
+    @staticmethod
+    def get_compressed_key(serial_number: str):
+        """Generate the serial number compressed key value from a database function."""
+        result = db.session.execute(KEY_STATEMENT, {'serial_number': serial_number})
+        row = result.first()
+        return str(row[0])

--- a/mhr_api/src/mhr_api/services/authz.py
+++ b/mhr_api/src/mhr_api/services/authz.py
@@ -32,6 +32,7 @@ PUBLIC_USER = 'public_user'
 USER_ORGS_PATH = 'users/orgs'
 GOV_ACCOUNT_ROLE = 'gov_account_user'
 BCOL_HELP = 'mhr_helpdesk'
+ASSETS_HELP = 'helpdesk'  # Share single account id for search, registration history.
 # MH keycloak roles for registrations/filings
 REGISTER_MH = 'mhr_register'
 REQUEST_TRANSPORT_PERMIT = 'mhr_transport'
@@ -274,7 +275,7 @@ def is_gov_account(jwt: JwtManager) -> bool:
 
 def is_all_staff_account(account_id: str) -> bool:
     """Return True if the account id is any staff role."""
-    return account_id is not None and account_id in (STAFF_ROLE, BCOL_HELP)
+    return account_id is not None and account_id in (STAFF_ROLE, ASSETS_HELP)
 
 
 def get_group(jwt: JwtManager) -> str:  # pylint: disable=too-many-return-statements

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.4'  # pylint: disable=invalid-name
+__version__ = '1.1.5'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_mhr_description.py
+++ b/mhr_api/tests/unit/models/test_mhr_description.py
@@ -1,0 +1,148 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the MHR description Model.
+
+Test-Suite to ensure that the MHR description Model is working as expected.
+"""
+import copy
+
+import pytest
+from registry_schemas.example_data.mhr import DESCRIPTION
+
+from mhr_api.models import MhrDescription
+from mhr_api.models.type_tables import MhrStatusTypes
+
+
+# testdata pattern is ({id}, {has_results})
+TEST_ID_DATA = [
+    (200000000, True),
+    (300000000, False)
+]
+TEST_DESCRIPTION = MhrDescription(id=1,
+                                  registration_id=1,
+                                  change_registration_id=1,
+                                  status_type=MhrStatusTypes.ACTIVE,
+                                  csa_number='77777',
+                                  csa_standard='1234',
+                                  number_of_sections=1,
+                                  square_feet=2000,
+                                  year_made=2015,
+                                  circa='N',
+                                  manufacturer_name='manufacturer',
+                                  make='make',
+                                  model='model',
+                                  engineer_name='engineerName',
+                                  rebuilt_remarks='rebuiltRemarks',
+                                  other_remarks='otherRemarks')
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_id(session, id, has_results):
+    """Assert that find description by description ID contains all expected elements."""
+    description: MhrDescription = MhrDescription.find_by_id(id)
+    if has_results:
+        assert description
+        assert description.id == 200000000
+        assert description.registration_id == 200000000
+        assert description.change_registration_id == 200000000
+        assert description.status_type == MhrStatusTypes.ACTIVE
+        assert description.csa_number == '7777700000'
+        assert description.csa_standard == '1234'
+        assert description.number_of_sections == 1
+        assert description.circa == 'Y'
+        assert description.square_feet == 2000
+        assert description.year_made == 2015
+        assert description.engineer_name == 'engineer name'
+        assert description.engineer_date
+        assert description.make == 'make'
+        assert description.model == 'model'
+        assert description.manufacturer_name == 'manufacturer'
+        assert description.rebuilt_remarks == 'rebuilt'
+        assert description.other_remarks == 'other'
+    else:
+        assert not description
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_registration_id(session, id, has_results):
+    """Assert that find descriptions by registration id contains all expected elements."""
+    descriptions = MhrDescription.find_by_registration_id(id)
+    if has_results:
+        assert descriptions
+        assert len(descriptions) == 1
+        assert descriptions[0].id == 200000000
+        assert descriptions[0].registration_id == 200000000
+        assert descriptions[0].change_registration_id == 200000000
+        assert descriptions[0].status_type == MhrStatusTypes.ACTIVE
+    else:
+        assert not descriptions
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_change_registration_id(session, id, has_results):
+    """Assert that find description by change registration id contains all expected elements."""
+    description = MhrDescription.find_by_change_registration_id(id)
+    if has_results:
+        assert description
+        assert description.id == 200000000
+        assert description.registration_id == 200000000
+        assert description.change_registration_id == 200000000
+        assert description.status_type == MhrStatusTypes.ACTIVE
+    else:
+        assert not description
+
+
+def test_description_json(session):
+    """Assert that the description model renders to a json format correctly."""
+    description: MhrDescription = TEST_DESCRIPTION
+    description_json = {
+        'status': description.status_type,
+        'sectionCount': description.number_of_sections,
+        'baseInformation': {
+            'make': description.make,
+            'model': description.model,
+            'circa': False,
+            'year': description.year_made
+        },
+        'csaNumber': description.csa_number,
+        'csaStandard': description.csa_standard,
+        'squareFeet': description.square_feet,
+        'manufacturer': description.manufacturer_name,
+        'engineerName': description.engineer_name,
+        'rebuiltRemarks': description.rebuilt_remarks,
+        'otherRemarks': description.other_remarks
+    }
+    assert description.json == description_json
+
+
+def test_create_from_json(session):
+    """Assert that the new MHR description is created from json data correctly."""
+    json_data = copy.deepcopy(DESCRIPTION)
+    description: MhrDescription = MhrDescription.create_from_json(json_data, 1000)
+    assert description
+    assert description.registration_id == 1000
+    assert description.change_registration_id == 1000
+    assert description.status_type == MhrStatusTypes.ACTIVE
+    assert description.number_of_sections
+    assert description.csa_number
+    assert description.csa_standard
+    assert description.engineer_date
+    assert description.engineer_name
+    assert description.manufacturer_name
+    assert description.rebuilt_remarks
+    assert description.other_remarks
+    assert description.year_made
+    assert description.make
+    assert description.model

--- a/mhr_api/tests/unit/models/test_mhr_owner_group.py
+++ b/mhr_api/tests/unit/models/test_mhr_owner_group.py
@@ -119,11 +119,11 @@ def test_group_json(session):
 def test_create_from_json(session):
     """Assert that the new MHR group is created from MH registration json data correctly."""
     json_data = copy.deepcopy(OWNER_GROUP)
-    group: MhrOwnerGroup = MhrOwnerGroup.create_from_json(json_data, 1000, 3000)
+    group: MhrOwnerGroup = MhrOwnerGroup.create_from_json(json_data, 1000)
     assert group
     assert group.group_id == 1
     assert group.registration_id == 1000
-    assert group.change_registration_id == 3000
+    assert group.change_registration_id == 1000
     assert group.tenancy_specified == 'Y'
     assert group.tenancy_type == MhrTenancyTypes.COMMON
     assert group.status_type == MhrOwnerStatusTypes.ACTIVE

--- a/mhr_api/tests/unit/models/test_mhr_section.py
+++ b/mhr_api/tests/unit/models/test_mhr_section.py
@@ -1,0 +1,122 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the MHR section Model.
+
+Test-Suite to ensure that the MHR section Model is working as expected.
+"""
+import copy
+
+import pytest
+from registry_schemas.example_data.mhr import DESCRIPTION
+
+from mhr_api.models import MhrSection
+from mhr_api.models.type_tables import MhrStatusTypes
+
+
+# testdata pattern is ({id}, {has_results})
+TEST_ID_DATA = [
+    (200000000, True),
+    (300000000, False)
+]
+TEST_SECTION = MhrSection(id=1,
+                          registration_id=1,
+                          change_registration_id=1,
+                          status_type=MhrStatusTypes.ACTIVE,
+                          compressed_key='002783',
+                          serial_number='003000ZA002783A',
+                          length_feet=60,
+                          width_feet=14,
+                          length_inches=10,
+                          width_inches=11)
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_id(session, id, has_results):
+    """Assert that find section by section ID contains all expected elements."""
+    section: MhrSection = MhrSection.find_by_id(id)
+    if has_results:
+        assert section
+        assert section.id == 200000000
+        assert section.registration_id == 200000000
+        assert section.change_registration_id == 200000000
+        assert section.status_type == MhrStatusTypes.ACTIVE
+        assert section.compressed_key == '002783'
+        assert section.serial_number == '003000ZA002783A'
+        assert section.length_feet == 60
+        assert section.width_feet == 14
+        assert section.length_inches == 10
+        assert section.width_inches == 11
+    else:
+        assert not section
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_registration_id(session, id, has_results):
+    """Assert that find sections by registration id contains all expected elements."""
+    sections = MhrSection.find_by_registration_id(id)
+    if has_results:
+        assert sections
+        assert len(sections) == 1
+        assert sections[0].id == 200000000
+        assert sections[0].registration_id == 200000000
+        assert sections[0].change_registration_id == 200000000
+        assert sections[0].status_type == MhrStatusTypes.ACTIVE
+    else:
+        assert not sections
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_change_registration_id(session, id, has_results):
+    """Assert that find sections by change registration id contains all expected elements."""
+    sections = MhrSection.find_by_change_registration_id(id)
+    if has_results:
+        assert sections
+        assert len(sections) == 1
+        assert sections[0].id == 200000000
+        assert sections[0].registration_id == 200000000
+        assert sections[0].change_registration_id == 200000000
+        assert sections[0].status_type == MhrStatusTypes.ACTIVE
+    else:
+        assert not sections
+
+
+def test_section_json(session):
+    """Assert that the section model renders to a json format correctly."""
+    section: MhrSection = TEST_SECTION
+    test_json = {
+        'serialNumber': section.serial_number,
+        'lengthFeet': section.length_feet,
+        'widthFeet': section.width_feet,
+        'lengthInches': section.length_inches,
+        'widthInches': section.width_inches
+    }
+    assert section.json == test_json
+
+
+def test_create_from_json(session):
+    """Assert that the new MHR section is created from json data correctly."""
+    json_data = copy.deepcopy(DESCRIPTION)
+    section_data = json_data.get('sections')
+    section: MhrSection = MhrSection.create_from_json(section_data[0], 1000)
+    assert section
+    assert section.registration_id == 1000
+    assert section.change_registration_id == 1000
+    assert section.status_type == MhrStatusTypes.ACTIVE
+    assert section.serial_number == '52D70556'
+    assert section.length_feet == 52
+    assert section.width_feet == 12
+    assert section.length_inches == 0
+    assert section.width_inches == 0
+    assert section.compressed_key == '070556'


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
- MHR registration, transfer, exemption now save all entities to postgres as well as db2.
- Add mhr_sections, mhr_descriptions models.
- Minor fix to save user id to db2 document table for new registrations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
