### PR TITLE
Duplicate PPR Registration Safety Check

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.55",
+      "version": "0.3.56",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -906,6 +906,9 @@ export default defineComponent({
             setRegTableTotalRowCount(getRegTableTotalRowCount.value + 1)
           }
         } else {
+          // Safety check: Prevent duplicate Registrations in UI
+          if (baseRegs.some(reg => reg.registrationNumber === newRegSummary.registrationNumber)) return
+
           // new base reg
           baseRegs.unshift(newRegSummary)
           setRegTableBaseRegs([...baseRegs])

--- a/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
+++ b/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
@@ -32,8 +32,8 @@
                 </p>
               </li>
               <li class="pl-3 pb-3 mb-7">
-                <strong>Search of the Corporate Register</strong> has been completed if one or more of the current or
-                future owners is an incorporated company, society or cooperative association.
+                <p><strong>Search of the Corporate Register</strong> has been completed if one or more of the current or
+                future owners is an incorporated company, society or cooperative association.</p>
                 <p class="confirm-completion-note">
                   <span>Note: </span> For current registered owners the incorporated business must have been active on
                   the Corporate Register at the time the bill of sale was signed. Future owners must be in active status
@@ -41,8 +41,8 @@
                 </p>
               </li>
               <li class="pl-3 pb-3 mb-0">
-                <strong>Personal Property Registry lien search</strong> has been completed and there are no liens on the
-                home that stop the transfer.
+                <p><strong>Personal Property Registry lien search</strong> has been completed and there are no liens
+                on the home that stop the transfer.</p>
                 <p class="confirm-completion-note">
                   <span>Note: </span> Liens that stop the transfer include Family Maintenance Enforcement Act, Family
                   Relations Act, BC Second Mortgage, Land Tax Deferment Act.


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14424

*Description of changes:*
* Added safety check return if UI attempts to duplicate PPR registration entries into the Registration Table
* Misc UX update on Confirm Completion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
