### PR TITLE
14393 mhr business look up updates

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.60",
+  "version": "0.3.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.60",
+      "version": "0.3.61",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.60",
+  "version": "0.3.61",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
@@ -240,12 +240,6 @@ export default defineComponent({
       locationInfo: {},
       legalDescription: '',
       additionalDescription: '',
-      isLotOption: computed((): boolean => {
-        return localState.locationTypeOption === HomeLocationTypes.LOT
-      }),
-      isHomeParkOption: computed((): boolean => {
-        return localState.locationTypeOption === HomeLocationTypes.HOME_PARK
-      }),
       dealerManufacturerLotRules: computed(() => {
         return localState.locationTypeOption as any === HomeLocationTypes.LOT
           ? customRules(required('Enter a dealer or manufacturer name'), maxLength(60))
@@ -293,9 +287,9 @@ export default defineComponent({
     const validateForms = async () => {
       if (props.validate) {
         // @ts-ignore - function exists
-        if (localState.isLotOption) await context.refs.lotForm?.validate()
+        await context.refs.lotForm?.validate()
         // @ts-ignore - function exists
-        if (localState.isHomeParkOption) await context.refs.homeParkForm?.validate()
+        await context.refs.homeParkForm?.validate()
       }
     }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
@@ -240,6 +240,12 @@ export default defineComponent({
       locationInfo: {},
       legalDescription: '',
       additionalDescription: '',
+      isLotOption: computed((): boolean => {
+        return localState.locationTypeOption === HomeLocationTypes.LOT
+      }),
+      isHomeParkOption: computed((): boolean => {
+        return localState.locationTypeOption === HomeLocationTypes.HOME_PARK
+      }),
       dealerManufacturerLotRules: computed(() => {
         return localState.locationTypeOption as any === HomeLocationTypes.LOT
           ? customRules(required('Enter a dealer or manufacturer name'), maxLength(60))
@@ -284,12 +290,12 @@ export default defineComponent({
       localState.legalDescription = pidInfo.legalDescription
     }
 
-    const validateForms = (): void => {
+    const validateForms = async () => {
       if (props.validate) {
         // @ts-ignore - function exists
-        if (props.validate) context.refs.lotForm.validate()
+        if (localState.isLotOption) await context.refs.lotForm?.validate()
         // @ts-ignore - function exists
-        if (props.validate) context.refs.homeParkForm.validate()
+        if (localState.isHomeParkOption) await context.refs.homeParkForm?.validate()
       }
     }
 
@@ -323,6 +329,9 @@ export default defineComponent({
     })
     watch(() => localState.isLocationTypeValid, (val: boolean) => {
       setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, val)
+    })
+    watch(() => props.validate, async (val: boolean) => {
+      await validateForms()
     })
 
     /** Clear/reset forms when select option changes. **/

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -54,11 +54,8 @@
             <v-row>
               <v-col>
                 <p>
-                  You can look-up a B.C. business by entering the name of the
-                  business or the incorporation number (including Societies and
-                  extra-provincial companies registered in B.C.). If the name of
-                  the organization does not appear in the look-up, enter the
-                  full legal name of the
+                  You can find the full legal name of an active B.C. business by entering the name or incorporation
+                  number of the business, or you can type the full legal name of other types of
                   <v-tooltip
                     top
                     content-class="top-tooltip pa-5"
@@ -69,7 +66,7 @@
                       <span
                         v-bind="attrs"
                         v-on="on"
-                      ><u>organization.</u></span>
+                      ><u> organizations.</u></span>
                     </template>
                     Organizations, other than active B.C. businesses, that can be listed as owners
                     include the following:<br><br>
@@ -81,7 +78,7 @@
                 </p>
 
                 <simple-help-toggle
-                  toggleButtonTitle="Help with Sole Proprietorships and Partnerships"
+                  toggleButtonTitle="Help with Business and Organization Owners"
                 >
                   <h3 class="text-center mb-2">
                     Business and Organization Owners
@@ -155,6 +152,8 @@
                   v-model="searchValue"
                   :rules="orgNameRules"
                   persistent-hint
+                  :clearable="showClear"
+                  @click:clear="showClear = false"
                 >
                   <template v-slot:append>
                     <v-progress-circular
@@ -486,6 +485,7 @@ export default defineComponent({
         maxLength(5, true)
       ),
       loadingSearchResults: false,
+      showClear: false,
       autoCompleteIsActive: true,
       autoCompleteSearchValue: '',
       searchValue: props.editHomeOwner?.organizationName,
@@ -560,6 +560,7 @@ export default defineComponent({
       localState.autoCompleteIsActive = false
       localState.searchValue = searchValueTyped
       localState.owner.organizationName = searchValueTyped
+      localState.showClear = true
     }
 
     const setCloseAutoComplete = () => {

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -54,8 +54,8 @@
             <v-row>
               <v-col>
                 <p>
-                  You can find the full legal name of an active B.C. business by entering the name or incorporation
-                  number of the business, or you can type the full legal name of other types of
+                  You can find the full legal name of an active B.C. business by entering the name
+                   or incorporation number of the business, or you can type the full legal name of other types of
                   <v-tooltip
                     top
                     content-class="top-tooltip pa-5"
@@ -105,8 +105,8 @@
                   </h3>
                   <p>
                     Registered owners of a manufactured home <b>cannot</b> be a sole proprietorship, partnership,
-                    or limited partnership. The owners of the proprietorship or partnership must be added as a person
-                    or as an organization.
+                    or limited partnership. The owners of the proprietorship or partnership must be added as a
+                    person or as an organization.
                   </p>
                   <hr class="mt-3 mb-5"/>
                   <h3 class="text-center mb-2">
@@ -114,13 +114,13 @@
                   </h3>
                   <p><b>New owners:</b> Must be active at the time of registration.</p>
                   <p>
-                    If you are adding a B.C. based business as a new owner, the business
-                    <b>must be active on the B.C Corporate Register at the time of the registration.</b>
+                    If you are adding a B.C. based business as a new owner, the business <b>must be active on the
+                    B.C Corporate Register at the time of the registration.</b>
                   </p><br>
                   <p><b>Existing owners:</b> Must be active at the time the bill of sale was signed.</p>
                   <p>
-                    If you are including a business that is already an owner of the home, the business
-                    <b>must have been active on the B.C Corporate Register at the time the bill of sale was signed</b>
+                    If you are including a business that is already an owner of the home, the business <b>must have
+                    been active on the B.C Corporate Register at the time the bill of sale was signed</b>
                   </p>
                   <hr class="mt-3 mb-5" />
                   <h3 class="text-center mb-2">
@@ -131,9 +131,9 @@
                     select the business from the look-up list.
                   </p>
                   <p>
-                    If you enter the name of a B.C. based business and the name does not appear in the business look-up,
-                    the business is not active in the B.C. Corporate Register. In this case, please contact the
-                    Manufactured Home Registry.
+                    If you enter the name of a B.C. based business and the name does not appear in the business
+                    look-up, the business is not active in the B.C. Corporate Register. In this case, please contact
+                    the Manufactured Home Registry.
                   </p>
                   <p>
                     If you enter the name of another type of organization, the name will not appear in the look-up.

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -58,20 +58,89 @@
                   business or the incorporation number (including Societies and
                   extra-provincial companies registered in B.C.). If the name of
                   the organization does not appear in the look-up, enter the
-                  full legal name of the organization.
+                  full legal name of the
+                  <v-tooltip
+                    top
+                    content-class="top-tooltip pa-5"
+                    transition="fade-transition"
+                    data-test-id="suffix-tooltip"
+                  >
+                    <template v-slot:activator="{ on, attrs }">
+                      <span
+                        v-bind="attrs"
+                        v-on="on"
+                      ><u>organization.</u></span>
+                    </template>
+                    Organizations, other than active B.C. businesses, that can be listed as owners
+                    include the following:<br><br>
+                    <li>Indian Bands,</li>
+                    <li>Public Bodies, or</li>
+                    <li>Organizations not registered in B.C.</li><br>
+                    Refer to "Help with Business and Organization Owners" for more details.
+                  </v-tooltip>
                 </p>
 
                 <simple-help-toggle
                   toggleButtonTitle="Help with Sole Proprietorships and Partnerships"
                 >
                   <h3 class="text-center mb-2">
-                    Help with Sole Proprietorships and Partnerships
+                    Business and Organization Owners
                   </h3>
                   <p>
-                    Registered owners of a manufactured home cannot be a sole
-                    proprietorship, partnership or limited partnership. The home
-                    must be registered in the name of the sole proprietor or
-                    partner (person or business).
+                    Businesses and organizations that <b>can</b> own a manufactured home include the following:
+                  </p>
+                  <h3 class="mb-2">
+                    B.C. Based Businesses
+                  </h3>
+                  <li>B.C. corporations</li>
+                  <li>B.C. societies</li>
+                  <li>B.C. cooperatives</li>
+                  <li>Extra-provincial companies registered in B.C. (corporations, societies and cooperatives)</li><br>
+                  <h3 class="mb-2">
+                    Other Businesses and Organizations
+                  </h3>
+                  <li>Indian Bands</li>
+                  <li>Public Bodies</li>
+                  <li>Businesses and Organizations not registered in B.C.</li><br>
+                  <p>Businesses and organizations that <b>cannot</b> own a manufactured home:</p>
+                  <h3 class="mb-2">
+                    Sole Proprietorships / Partnerships
+                  </h3>
+                  <p>
+                    Registered owners of a manufactured home <b>cannot</b> be a sole proprietorship, partnership,
+                    or limited partnership. The owners of the proprietorship or partnership must be added as a person
+                    or as an organization.
+                  </p>
+                  <hr class="mt-3 mb-5"/>
+                  <h3 class="text-center mb-2">
+                    When B.C. Based Businesses Must be in Active Status
+                  </h3>
+                  <p><b>New owners:</b> Must be active at the time of registration.</p>
+                  <p>
+                    If you are adding a B.C. based business as a new owner, the business
+                    <b>must be active on the B.C Corporate Register at the time of the registration.</b>
+                  </p><br>
+                  <p><b>Existing owners:</b> Must be active at the time the bill of sale was signed.</p>
+                  <p>
+                    If you are including a business that is already an owner of the home, the business
+                    <b>must have been active on the B.C Corporate Register at the time the bill of sale was signed</b>
+                  </p>
+                  <hr class="mt-3 mb-5" />
+                  <h3 class="text-center mb-2">
+                    My Business Isn't Listed
+                  </h3>
+                  <p>
+                    The business look-up displays the list of all active businesses in B.C. If your business is listed,
+                    select the business from the look-up list.
+                  </p>
+                  <p>
+                    If you enter the name of a B.C. based business and the name does not appear in the business look-up,
+                    the business is not active in the B.C. Corporate Register. In this case, please contact the
+                    Manufactured Home Registry.
+                  </p>
+                  <p>
+                    If you enter the name of another type of organization, the name will not appear in the look-up.
+                    In this case, type the full legal name of the organization.
                   </p>
                 </simple-help-toggle>
               </v-col>
@@ -82,7 +151,7 @@
                   filled
                   id="org-name"
                   ref="orgNameSearchField"
-                  label="Full Legal Name of Business or Organization"
+                  label="Find or enter the Full Legal Name of the Business or Organization"
                   v-model="searchValue"
                   :rules="orgNameRules"
                   persistent-hint
@@ -531,8 +600,17 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
+u {
+    border-bottom: 1px dotted #000;
+    text-decoration: none;
+}
+
 #addHomeOwnerForm {
   p {
+    color: $gray7;
+    line-height: 24px;
+  }
+  li {
     color: $gray7;
     line-height: 24px;
   }

--- a/ppr-ui/src/components/mhrTransfers/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/mhrTransfers/BusinessSearchAutocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card
-    v-if="showAutoComplete && !searching"
+    v-if="searchValue.length >= 3 && !searching"
     id="business-search-autocomplete"
     class="auto-complete-card"
     elevation="5"
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
+import { defineComponent, reactive, toRefs, watch, computed } from '@vue/composition-api'
 import { SearchResponseI } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { useSearch } from '@/composables/useSearch'
 import { BusinessTypes } from '@/enums/business-types'

--- a/ppr-ui/src/components/mhrTransfers/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/mhrTransfers/BusinessSearchAutocomplete.vue
@@ -8,6 +8,11 @@
     <v-row no-gutters justify="center">
       <v-col no-gutters cols="12">
         <v-list v-if="autoCompleteResults && autoCompleteResults.length > 0" class="pt-0 results-list">
+          <v-list-item disabled>
+            <v-row class="auto-complete-sticky-row">
+              <v-col cols="24">Active B.C. Businesses</v-col>
+            </v-row>
+          </v-list-item>
           <v-list-item-group v-model="autoCompleteSelected">
             <div v-for="(result, i) in autoCompleteResults" :key="i">
               <div class="info-tooltip" v-if="isBusinessTypeSPGP(result.legalType)">
@@ -44,9 +49,12 @@
           </v-list-item-group>
         </v-list>
         <div v-else-if="hasNoMatches" id="no-party-matches" class="pa-5">
+          <p class="auto-complete-sticky-row">
+            Active B.C. Businesses
+          </p>
           <p>
             <strong>
-              No matches found.
+              No active B.C. businesses found.
             </strong>
           </p>
           Ensure you have entered the correct, full legal name of the organization before entering the phone number and
@@ -58,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
+import { defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
 import { SearchResponseI } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { useSearch } from '@/composables/useSearch'
 import { BusinessTypes } from '@/enums/business-types'
@@ -84,7 +92,6 @@ export default defineComponent({
       autoCompleteIsActive: props.setAutoCompleteIsActive,
       autoCompleteResults: null,
       autoCompleteSelected: null,
-      showAutoComplete: computed((): boolean => props.searchValue.length >= 3),
       searching: false,
       isSearchResultSelected: false,
       hasNoMatches: computed(
@@ -164,6 +171,10 @@ export default defineComponent({
   min-height: 0;
 }
 
+.auto-complete-sticky-row{
+  color: #465057 !important;
+  font-size: 14px;
+}
 .auto-complete-row {
   color: $gray7 !important;
   font-size: 16px;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14383

*Description of changes:*
- Text addition for "Help with Owners" section in step 3 
- Some other text changes in this step, tooltip added on intro text
- Verified that spinner and blue select text links were on the business search autocomplete
- Added clear text field functionality when user adds a business from the autocomplete dropdown
- Added sticky header to dropdown, updated message for when no businesses found

Fixed bug #14324 in this ticket as well, validation issue for PAD section https://app.zenhub.com/workspaces/assets-team-space-61426544e7e2ea001d079597/issues/bcgov/entity/14324


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
