### PR TITLE
UX updates to PDF download button

### DIFF
--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -95,13 +95,19 @@
                   >
                     <template v-slot:activator="{ on, attrs }">
                       <v-btn
-                        icon
                         v-if="!item.inProgress"
-                        color="primary"
+                        :icon="item.isPdfRequested"
+                        :depressed="!item.isPdfRequested"
+                        :color="item.isPdfRequested ? 'primary' : ''"
+                        :class="{ 'pdf-btn px-0 mt-n3' : !item.isPdfRequested }"
                         :loading="item.loadingPDF"
                         @click="refreshRow(item)"
                       >
-                        <v-icon color="primary" v-bind="attrs" v-on="on">
+                        <div v-if="!item.isPdfRequested" style="display: flex">
+                          <img src="@/assets/svgs/pdf-icon-blue.svg" />
+                          <span class="pl-1">PDF</span>
+                        </div>
+                        <v-icon v-else color="primary" v-bind="attrs" v-on="on">
                           mdi-information-outline
                         </v-icon>
                       </v-btn>
@@ -169,7 +175,7 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { SearchCriteriaIF, SearchResponseIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { MHRSearchTypes, searchHistoryTableHeaders, searchHistoryTableHeadersStaff, SearchTypes } from '@/resources'
-import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF } from '@/utils'
+import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF, delayActions } from '@/utils'
 import { ErrorContact } from '../common'
 import { useSearch } from '@/composables/useSearch'
 import { cloneDeep } from 'lodash' // eslint-disable-line
@@ -216,12 +222,7 @@ export default defineComponent({
       }),
       searchHistory: computed(
         (): Array<SearchResponseIF> => {
-          let searchHistory = null
-          searchHistory = getSearchHistory.value
-          if (!searchHistory) {
-            return []
-          }
-          return searchHistory
+          return getSearchHistory.value || []
         }
       ),
       isSearchHistory: computed((): boolean => {
@@ -354,8 +355,9 @@ export default defineComponent({
       if (!isPDFAvailable(item)) {
         return 'This document PDF is no longer available.'
       }
-      return '<p class="ma-0">This document PDF is still being generated. Reload this page to ' +
-        'see if your PDF is ready to download.</p>' +
+      return '<p class="ma-0">This document PDF is still being generated. Click the ' +
+        '<i class="v-icon notranslate mdi mdi-information-outline" style="font-size:18px; margin-bottom:4px;"></i> ' +
+        'icon to see if your PDF is ready to download. </p>' +
         '<p class="ma-0 mt-2">Note: Large documents may take up to 20 minutes to generate.</p>'
     }
     const isPDFAvailable = (item: SearchResponseIF): Boolean => {
@@ -387,6 +389,13 @@ export default defineComponent({
       }
     }
     const refreshRow = async (item): Promise<void> => {
+      // once PDF icon is clicked, reset the flag to Info icon
+      item.isPdfRequested = true
+      // for large searches that are still pending, delay any actions for better user experience
+      if (item.searchId === 'PENDING') {
+        item.loadingPDF = true
+        await delayActions(5000)
+      }
       const pdf = await downloadPDF(item)
       if (pdf) {
         // Update unique key value of table row to refresh singular component

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
@@ -14,6 +14,7 @@ export interface SearchResponseIF {
   error?: ErrorIF,
   inProgress?: boolean,
   loadingPDF?: boolean,
+  isPdfRequested?: boolean, // UX flag for large searches (to display PDF icon on first load)
   userId?: string,
   username?: string
 }

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -169,7 +169,10 @@ export const setSearchDebtorName: ActionIF = ({ commit }, debtorName: Individual
 export const setSearchHistory: ActionIF = ({ commit }, searchHistory: Array<SearchResponseIF>): void => {
   // need to set .loadingPDF so that the loader circle triggers when set
   //  - if it starts as undefined it wont trigger on change
-  for (let i = 0; i < searchHistory?.length || 0; i++) { searchHistory[i].loadingPDF = false }
+  (searchHistory || []).forEach(item => {
+    item.loadingPDF = false
+    item.isPdfRequested = false
+  })
   commit('mutateSearchHistory', searchHistory)
 }
 

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -169,10 +169,10 @@ export const setSearchDebtorName: ActionIF = ({ commit }, debtorName: Individual
 export const setSearchHistory: ActionIF = ({ commit }, searchHistory: Array<SearchResponseIF>): void => {
   // need to set .loadingPDF so that the loader circle triggers when set
   //  - if it starts as undefined it wont trigger on change
-  (searchHistory || []).forEach(item => {
-    item.loadingPDF = false
-    item.isPdfRequested = false
-  })
+  for (let i = 0; i < searchHistory?.length || 0; i++) {
+    searchHistory[i].loadingPDF = false
+    searchHistory[i].isPdfRequested = false
+  }
   commit('mutateSearchHistory', searchHistory)
 }
 

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -569,3 +569,8 @@ export async function deleteMhrDraft (draftID: string): Promise<ErrorIF> {
       return { statusCode: response?.status as StatusCodes }
     })
 }
+
+// UX util function to delay any actions for defined number of milliseconds
+export function delayActions (milliseconds: number): Promise<any> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}

--- a/ppr-ui/tests/unit/SearchHistory.spec.ts
+++ b/ppr-ui/tests/unit/SearchHistory.spec.ts
@@ -117,16 +117,13 @@ describe('Test result table with results', () => {
       expect(rows.at(i + 1).text()).toContain(totalResultsSize)
       expect(rows.at(i + 1).text()).toContain(exactResultsSize)
       expect(rows.at(i + 1).text()).toContain(selectedResultsSize)
-      // PDF only shows for selected result size < 76
-      if (selectedResultsSize < 76) {
-        if (!wrapper.vm.isPDFAvailable(mockedSearchHistory.searches[i])) {
-          expect(rows.at(i + 1).text()).not.toContain('PDF')
-        } else {
-          expect(rows.at(i + 1).text()).toContain('PDF')
-          wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
-          await Vue.nextTick()
-          expect(downloadMock).toHaveBeenCalledWith(mockedSearchHistory.searches[i])
-        }
+      // PDF icon should show up for small and large results #13980
+      expect(rows.at(i + 1).text()).toContain('PDF')
+      if (wrapper.vm.isPDFAvailable(mockedSearchHistory.searches[i])) {
+        expect(rows.at(i + 1).text()).toContain('PDF')
+        wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
+        await Vue.nextTick()
+        expect(downloadMock).toHaveBeenCalledWith(mockedSearchHistory.searches[i])
       }
     }
   })
@@ -151,7 +148,7 @@ describe('Test result table with results', () => {
     wrapper.destroy()
   })
 
-  it('renders and displays correct elements with results', async () => {
+  it('renders and displays correct elements with results for MHR Search History', async () => {
     expect(wrapper.findComponent(SearchHistory).exists()).toBe(true)
     expect(wrapper.vm.historyLength).toBe(mockedMHRSearchHistory.searches.length)
     expect(wrapper.vm.searchHistory).toStrictEqual(mockedMHRSearchHistory.searches)
@@ -184,16 +181,12 @@ describe('Test result table with results', () => {
       expect(rows.at(i + 1).text()).toContain(wrapper.vm.displayDate(searchDate))
       expect(rows.at(i + 1).text()).toContain(totalResultsSize)
       expect(rows.at(i + 1).text()).toContain(selectedResultsSize)
-      // PDF only shows for selected result size < 76
-      if (selectedResultsSize < 76) {
-        if (!wrapper.vm.isPDFAvailable(mockedMHRSearchHistory.searches[i])) {
-          expect(rows.at(i + 1).text()).not.toContain('PDF')
-        } else {
-          expect(rows.at(i + 1).text()).toContain('PDF')
-          wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
-          await Vue.nextTick()
-          expect(downloadMock).toHaveBeenCalledWith(mockedMHRSearchHistory.searches[i])
-        }
+      // PDF icon should show up for small and large results #13980
+      expect(rows.at(i + 1).text()).toContain('PDF')
+      if (wrapper.vm.isPDFAvailable(mockedMHRSearchHistory.searches[i])) {
+        wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
+        await Vue.nextTick()
+        expect(downloadMock).toHaveBeenCalledWith(mockedMHRSearchHistory.searches[i])
       }
     }
   })

--- a/ppr-ui/tests/unit/test-data/mock-search-responses.ts
+++ b/ppr-ui/tests/unit/test-data/mock-search-responses.ts
@@ -34,6 +34,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1234K'
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.SERIAL_NUMBER]
   },
   [UISearchTypes.INDIVIDUAL_DEBTOR]: {
@@ -54,6 +55,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '123'
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.INDIVIDUAL_DEBTOR]
   },
   [UISearchTypes.BUSINESS_DEBTOR]: {
@@ -73,6 +75,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1233333332221'
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.BUSINESS_DEBTOR]
   },
   [UISearchTypes.MHR_NUMBER]: {
@@ -90,6 +93,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: ''
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.MHR_NUMBER]
   },
   [UISearchTypes.AIRCRAFT]: {
@@ -107,6 +111,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: 'abcd-123-rrr'
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.AIRCRAFT]
   },
   [UISearchTypes.REGISTRATION_NUMBER]: {
@@ -124,6 +129,7 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1q'
     },
+    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.REGISTRATION_NUMBER]
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13980

*Description of changes:*

- Update the way we display PDF and 'i' icons for large results in the Search History table

#### The change
PDF icon will be displayed only once, before the user clicks and tries to download large search report. After that, 'i' will be shown (with a updated tooltip) util report is available

#### The flow
1. PDF icon is displayed for all search results (small and large)
2. Clicking on large search results, will change the icon to a loading/spinner state for 5 seconds
3. If the report is still not available, the icon will switch to 'i' (instead of PDF)
4. Subsequent clicks will still show 'i' icon until PDF is ready for download

#### Screenshots
 
<img width="1429" alt="Screen Shot 2022-12-06 at 8 37 03 PM" src="https://user-images.githubusercontent.com/2333290/206303393-899708c7-99c4-4151-a496-7afa607e66e7.png">

<img width="1413" alt="Screen Shot 2022-12-06 at 8 37 09 PM" src="https://user-images.githubusercontent.com/2333290/206303436-05205518-f961-4dae-a57c-b4bfbb521363.png">

<img width="1389" alt="Screen Shot 2022-12-06 at 8 37 25 PM" src="https://user-images.githubusercontent.com/2333290/206303457-a7d8c279-2bd7-45f1-b54c-361ed551fd49.png">

<img width="1422" alt="Screen Shot 2022-12-06 at 8 37 34 PM" src="https://user-images.githubusercontent.com/2333290/206303471-dd101066-da7a-437a-a2c1-52106fe23b82.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
