### PR TITLE
MHR API add reg summary lienRegistrationType

### DIFF
--- a/mhr_api/src/database/postgres_views/mhr_lien_check_vw.sql
+++ b/mhr_api/src/database/postgres_views/mhr_lien_check_vw.sql
@@ -1,0 +1,26 @@
+-- 14527 view to check if there is an outstanding PPR lien on a manufactured home searching by MHR number.
+CREATE OR REPLACE VIEW public.mhr_lien_check_vw AS
+SELECT sc.mhr_number, r.registration_type, r.registration_ts AS base_registration_ts,
+       r.registration_number AS base_registration_num,
+       cc.id AS client_code_id, cc.name AS secured_party_name
+  FROM registrations r, financing_statements fs, serial_collateral sc, parties p, client_codes cc
+ WHERE r.financing_id = fs.id
+   AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
+   AND r.registration_type IN ('SG', 'SA', 'LT', 'FR', 'MH')
+   AND (fs.expire_date IS NULL OR fs.expire_date > ((now() at time zone 'utc') - interval '30 days'))
+   AND NOT EXISTS (SELECT r3.id 
+                     FROM registrations r3
+                    WHERE r3.financing_id = fs.id
+                      AND r3.registration_type_cl = 'DISCHARGE'
+                      AND r3.registration_ts < ((now() at time zone 'utc') - interval '30 days'))
+   AND sc.financing_id = fs.id
+   AND sc.registration_id_end IS NULL
+   AND sc.mhr_number IS NOT NULL
+   AND sc.mhr_number != 'NR'
+   AND p.financing_id = fs.id
+   AND p.party_type = 'SP'
+   AND p.registration_id_end IS NULL
+   AND p.branch_id IS NOT NULL
+   AND p.branch_id = cc.id
+   AND (cc.name like 'HER MAJESTY%' OR cc.name like '%TAX DEFERME%')
+;

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -115,6 +115,8 @@ def test_get_account_registrations(session, client, jwt, desc, roles, status, ha
             assert registration['clientReferenceId'] is not None
             assert registration['ownerNames'] is not None
             assert registration['path'] is not None
+            if registration['registrationDescription'] == 'REGISTER NEW UNIT':
+                assert 'lienRegistrationType' in registration
 
 
 @pytest.mark.parametrize('desc,has_submitting,roles,status,has_account', TEST_CREATE_DATA)

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -90,6 +90,8 @@ def test_find_account_registrations(session, account_id, has_results):
             assert registration['path'] is not None
             assert registration['documentId'] is not None
             assert not registration.get('inUserList')
+            if registration['registrationDescription'] == 'REGISTER NEW UNIT':
+                assert 'lienRegistrationType' in registration
     else:
         assert not reg_list
 

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -241,6 +241,8 @@ def test_find_account_registrations(session, account_id, has_results):
             assert registration['path'] is not None
             assert registration['documentId'] is not None
             assert not registration.get('inUserList')
+            if registration['registrationDescription'] == REG_DESCRIPTION:
+                assert 'lienRegistrationType' in registration
     else:
         assert not reg_list
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14330

*Description of changes:*
Add lienRegistration to API get account summary registration info for MHR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
