### PR TITLE
MHR API location type RESERVE updates.

### DIFF
--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.5.3
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.6.6#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.7#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.6.6#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.7#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/location.py
+++ b/mhr_api/src/mhr_api/models/db2/location.py
@@ -16,6 +16,7 @@ from flask import current_app
 
 from mhr_api.exceptions import DatabaseException
 from mhr_api.models import db, utils as model_utils
+from mhr_api.models.type_tables import MhrLocationTypes
 from mhr_api.utils.base import BaseEnum
 
 
@@ -193,7 +194,7 @@ class Db2Location(db.Model):
             'additionalDescription': self.additional_description
         }
         if self.tax_certificate_date:
-            location['taxCertificateDate'] = model_utils.format_local_date(self.tax_certificate_date)
+            location['taxExpiryDate'] = model_utils.format_local_date(self.tax_certificate_date)
         return location
 
     @property
@@ -238,7 +239,7 @@ class Db2Location(db.Model):
         if self.tax_certificate_date:
             tax_date = model_utils.format_local_date(self.tax_certificate_date)
             if tax_date:
-                location['taxCertificateDate'] = tax_date
+                location['taxExpiryDate'] = tax_date
         return location
 
     @property
@@ -284,7 +285,7 @@ class Db2Location(db.Model):
         if self.tax_certificate_date:
             tax_date = model_utils.format_local_date(self.tax_certificate_date)
             if tax_date:
-                location['taxCertificateDate'] = tax_date
+                location['taxExpiryDate'] = tax_date
         return location
 
     @staticmethod
@@ -320,8 +321,8 @@ class Db2Location(db.Model):
                                dealer_name=new_info.get('dealerName', ''),
                                additional_description=new_info.get('additionalDescription', ''))
 
-        if new_info.get('taxCertificateDate', None):
-            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxCertificateDate'))
+        if new_info.get('taxExpiryDate', None):
+            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxExpiryDate'))
 
         return location
 
@@ -338,6 +339,16 @@ class Db2Location(db.Model):
         else:  # Adjust; db table column length is 6.
             street_num = street[0:6]
             street_name = street[6:]
+        additional_desc = ''
+        if new_info.get('locationType') and new_info.get('locationType') == MhrLocationTypes.RESERVE:
+            if new_info.get('bandName'):
+                additional_desc += str(new_info.get('bandName')).strip().upper() + ' '
+            if new_info.get('reserveNumber'):
+                additional_desc += str(new_info.get('reserveNumber')).strip() + ' '
+        if new_info.get('additionalDescription'):
+            additional_desc += new_info.get('additionalDescription')
+        if additional_desc:
+            additional_desc = additional_desc[0:80]
         location = Db2Location(manuhome_id=registration.id,
                                location_id=1,
                                status=Db2Location.StatusTypes.ACTIVE,
@@ -366,15 +377,15 @@ class Db2Location(db.Model):
                                plan=new_info.get('plan', ''),
                                except_plan=new_info.get('exceptionPlan', ''),
                                dealer_name=new_info.get('dealerName', ''),
-                               additional_description=new_info.get('additionalDescription', ''),
+                               additional_description=additional_desc,
                                leave_bc='N',
                                tax_certificate='N')
         if new_info.get('leaveProvince'):
             location.leave_bc = 'Y'
         if new_info.get('taxCertificate'):
             location.tax_certificate = 'Y'
-        if new_info.get('taxCertificateDate', None):
-            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxCertificateDate'))
+        if new_info.get('taxExpiryDate', None):
+            location.tax_certificate_date = model_utils.date_from_iso_format(new_info.get('taxExpiryDate'))
         else:
             location.tax_certificate_date = model_utils.date_from_iso_format('0001-01-01')
         return location

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -482,6 +482,9 @@ class Report:  # pylint: disable=too-few-public-methods
                                    Report._to_report_datetime(detail['description']['engineerDate'], False)
                     else:
                         detail['description']['engineerDate'] = ''
+                    if detail.get('location') and detail['location'].get('taxExpiryDate'):
+                        detail['location']['taxExpiryDate'] =  \
+                                Report._to_report_datetime(detail['location']['taxExpiryDate'], False)
         elif self._report_key == ReportTypes.MHR_REGISTRATION:
             reg = self._report_data
             reg['createDateTime'] = Report._to_report_datetime(reg['createDateTime'])
@@ -501,6 +504,8 @@ class Report:  # pylint: disable=too-few-public-methods
                         Report._to_report_datetime(reg['description']['engineerDate'], False)
             else:
                 reg['description']['engineerDate'] = ''
+            if reg.get('location') and reg['location'].get('taxExpiryDate'):
+                reg['location']['taxExpiryDate'] = Report._to_report_datetime(reg['location']['taxExpiryDate'], False)
         elif self._report_key in (ReportTypes.MHR_TRANSFER, ReportTypes.MHR_EXEMPTION):
             reg = self._report_data
             reg['createDateTime'] = Report._to_report_datetime(reg['createDateTime'])

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -18,7 +18,7 @@ Validation includes verifying the data combination for various registrations/fil
 from flask import current_app
 
 from mhr_api.models import MhrRegistration, Db2Owngroup, registration_utils as reg_utils
-from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrDocumentTypes
+from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrDocumentTypes, MhrLocationTypes
 from mhr_api.models.db2.owngroup import NEW_TENANCY_LEGACY
 from mhr_api.models.utils import is_legacy
 from mhr_api.utils import valid_charset
@@ -48,6 +48,8 @@ VALIDATOR_ERROR = 'Error performing extra validation. '
 NOTE_DOC_TYPE_INVALID = 'The note document type is invalid for the registration type. '
 PPR_LIEN_EXISTS = 'This registration is not allowed to complete as an outstanding Personal Property Registry lien ' + \
     'exists on the manufactured home. '
+BAND_NAME_REQUIRED = 'The location Indian Reserve band name is required for this registration. '
+RESERVE_NUMBER_REQUIRED = 'The location Indian Reserve number is required for this registration. '
 
 
 def validate_registration(json_data, is_staff: bool = False):
@@ -323,6 +325,12 @@ def validate_location(json_data):
     error_msg += validate_text(location.get('dealerName'), desc + ' dealer name')
     error_msg += validate_text(location.get('additionalDescription'), desc + ' additional description')
     error_msg += validate_text(location.get('exceptionPlan'), desc + ' exception plan')
+    error_msg += validate_text(location.get('bandName'), desc + ' band name')
+    if location.get('locationType') and location['locationType'] == MhrLocationTypes.RESERVE:
+        if not location.get('bandName'):
+            error_msg += BAND_NAME_REQUIRED
+        if not location.get('reserveNumber'):
+            error_msg += RESERVE_NUMBER_REQUIRED
     return error_msg
 
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14616

*Description of changes:*
- With new MH registrations location type RESERVE save band name, reserve number as distinct data elements.
- Correct location tax certification date mapping/saving: use the API spec property name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
