### PR TITLE
Do not show error dialog for PPR pdf download

### DIFF
--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -280,7 +280,8 @@ export default defineComponent({
         pdf = await searchMhrPDF(item.searchId)
       }
       if (pdf.error) {
-        if (isPprSearch(item)) emit('error', pdf.error)
+        // do not emit any error so dialog is not shown - #13980
+        // if (isPprSearch(item)) emit('error', pdf.error)
         item.loadingPDF = false
         return false
       } else {


### PR DESCRIPTION
*Issue #:* bcgov/entity#13980

*Description of changes:*
- Remove error modal for when trying to download PDF document for PPR (same as for MHR)

<img width="631" alt="Screen Shot 2022-12-13 at 12 53 02 PM" src="https://user-images.githubusercontent.com/2333290/207441172-0c5c45a6-cd26-4d51-95e3-3a8b24a6a8d7.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
