### PR TITLE
Remove duplicate interest fraction for the TC tenancy type.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/owngroup.py
+++ b/mhr_api/src/mhr_api/models/db2/owngroup.py
@@ -200,8 +200,8 @@ class Db2Owngroup(db.Model):
             interest_json = interest_json.replace(fraction, '')
             if self.interest != interest_json:
                 owngroup['interest'] = interest_json.strip()
-            if self.tenancy_specified == 'N':
-                owngroup['tenancySpecified'] = False
+        if self.tenancy_specified == 'N':
+            owngroup['tenancySpecified'] = False
         return owngroup
 
     @property

--- a/mhr_api/src/mhr_api/models/db2/owngroup.py
+++ b/mhr_api/src/mhr_api/models/db2/owngroup.py
@@ -15,7 +15,7 @@
 from flask import current_app
 
 from mhr_api.exceptions import DatabaseException
-from mhr_api.models import db
+from mhr_api.models import db, utils as model_utils
 from mhr_api.models.db2.owner import Db2Owner
 from mhr_api.utils.base import BaseEnum
 
@@ -181,18 +181,27 @@ class Db2Owngroup(db.Model):
             'groupId': self.group_id,
             'copyId': self.copy_id,
             'sequenceNumber': self.sequence_number,
-            'status': self.status,
+            'status': LEGACY_STATUS_NEW.get(self.status),
             'pendingFlag': self.pending_flag,
             'registrationDocumentId': self.reg_document_id,
             'canDocumentId': self.can_document_id,
-            'tenancyType': self.tenancy_type,
+            'type': LEGACY_TENANCY_NEW.get(self.tenancy_type),
             'lessee': self.lessee,
             'lessor': self.lessor,
             'interest': self.interest,
             'interestNumerator': self.get_interest_fraction(True),
             'interestDenominator': self.get_interest_fraction(False),
-            'tenancySpecified': self.tenancy_specified
+            'tenancySpecified': True
         }
+        # Remove fraction from interest description for UI.
+        if self.tenancy_type == self.TenancyTypes.COMMON and self.interest:
+            fraction: str = str(owngroup.get('interestNumerator')) + '/' + str(owngroup.get('interestDenominator'))
+            interest_json: str = owngroup.get('interest')
+            interest_json = interest_json.replace(fraction, '')
+            if self.interest != interest_json:
+                owngroup['interest'] = interest_json.strip()
+            if self.tenancy_specified == 'N':
+                owngroup['tenancySpecified'] = False
         return owngroup
 
     @property
@@ -208,6 +217,13 @@ class Db2Owngroup(db.Model):
             'interestDenominator': self.get_interest_fraction(False),
             'tenancySpecified': True
         }
+        # Remove fraction from interest description for UI.
+        if self.tenancy_type == self.TenancyTypes.COMMON and self.interest:
+            fraction: str = str(group.get('interestNumerator')) + '/' + str(group.get('interestDenominator'))
+            interest_json: str = group.get('interest')
+            interest_json = interest_json.replace(fraction, '')
+            if self.interest != interest_json:
+                group['interest'] = interest_json.strip()
         if self.tenancy_specified == 'N':
             group['tenancySpecified'] = False
         owners = []
@@ -261,7 +277,14 @@ class Db2Owngroup(db.Model):
         """Create a new owner group object from a new MH registration."""
         # current_app.logger.info('group group id=' + str(group_id))
         # current_app.logger.info(new_info)
-        tenancy = new_info.get('type', Db2Owngroup.TenancyTypes.SOLE)
+        tenancy: str = new_info.get('type', Db2Owngroup.TenancyTypes.SOLE)
+        tenancy_type: str = NEW_TENANCY_LEGACY.get(tenancy)
+        interest: str = new_info.get('interest', '')
+        if tenancy_type == Db2Owngroup.TenancyTypes.COMMON:
+            if not interest:  # This should never happen.
+                interest = model_utils.OWNER_INTEREST_UNDIVIDED
+            elif interest and len(interest) <= 10 and not interest.startswith(model_utils.OWNER_INTEREST_UNDIVIDED):
+                interest = model_utils.OWNER_INTEREST_UNDIVIDED + ' ' + interest
         owngroup = Db2Owngroup(manuhome_id=registration.id,
                                group_id=group_id,
                                copy_id=0,
@@ -270,10 +293,10 @@ class Db2Owngroup(db.Model):
                                pending_flag='',
                                reg_document_id=new_info.get('documentId', ''),
                                can_document_id='',
-                               tenancy_type=NEW_TENANCY_LEGACY.get(tenancy),
+                               tenancy_type=tenancy_type,
                                lessee=new_info.get('lessee', ''),
                                lessor=new_info.get('lessor', ''),
-                               interest=new_info.get('interest', ''),
+                               interest=interest,
                                interest_numerator=new_info.get('interestNumerator', 0),
                                tenancy_specified=new_info.get('tenancySpecified', 'Y'))
         owngroup.interest_denominator = new_info.get('interestDenominator', 0)

--- a/mhr_api/src/mhr_api/models/mhr_owner_group.py
+++ b/mhr_api/src/mhr_api/models/mhr_owner_group.py
@@ -123,8 +123,15 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
             group.interest = reg_json.get('interest', None)
             group.interest_numerator = reg_json.get('interestNumerator', 0)
             group.interest_denominator = reg_json.get('interestDenominator', 0)
-        if group.tenancy_type == MhrTenancyTypes.COMMON and not group.interest:
-            group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
+        if group.tenancy_type == MhrTenancyTypes.COMMON:
+            if not group.interest:
+                group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
+            elif group.interest_numerator and group.interest_denominator:
+                ratio: str = f'{group.interest_numerator}/{group.interest_denominator}'
+                if group.interest.find(ratio) > -1:
+                    group.interest = group.interest.replace(ratio, '').strip()
+                if not group.interest:
+                    group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
         if not reg_json.get('tenancySpecified'):
             group.tenancy_specified = 'N'
         group.owners = []
@@ -145,8 +152,15 @@ class MhrOwnerGroup(db.Model):  # pylint: disable=too-many-instance-attributes
             group.interest = reg_json.get('interest', None)
             group.interest_numerator = reg_json.get('interestNumerator', 0)
             group.interest_denominator = reg_json.get('interestDenominator', 0)
-        if group.tenancy_type == MhrTenancyTypes.COMMON and not group.interest:
-            group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
+        if group.tenancy_type == MhrTenancyTypes.COMMON:
+            if not group.interest:
+                group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
+            elif group.interest_numerator and group.interest_denominator:
+                ratio: str = f'{group.interest_numerator}/{group.interest_denominator}'
+                if group.interest.find(ratio) > -1:
+                    group.interest = group.interest.replace(ratio, '').strip()
+                if not group.interest:
+                    group.interest = model_utils.OWNER_INTEREST_UNDIVIDED
         if not reg_json.get('tenancySpecified'):
             group.tenancy_specified = 'N'
         group.owners = []

--- a/mhr_api/tests/unit/models/db2/test_owngroup.py
+++ b/mhr_api/tests/unit/models/db2/test_owngroup.py
@@ -128,15 +128,15 @@ def test_owngroup_json(session):
     owngroup = Db2Owngroup(manuhome_id=1,
                            group_id=1,
                            copy_id=0,
-                           status=5,
+                           status='5',
                            sequence_number=1,
                            reg_document_id='REG22911',
                            can_document_id='42400339',
-                           tenancy_type='SO',
+                           tenancy_type='TC',
                            lessee='',
                            lessor='',
-                           interest='interest',
-                           interest_numerator=0,
+                           interest='UNDIVIDED 1/2',
+                           interest_numerator=1,
                            tenancy_specified='Y')
 
     test_json = {
@@ -144,16 +144,45 @@ def test_owngroup_json(session):
         'groupId': owngroup.group_id,
         'copyId': owngroup.copy_id,
         'sequenceNumber': owngroup.sequence_number,
-        'status': owngroup.status,
+        'status': 'PREVIOUS',
         'pendingFlag': owngroup.pending_flag,
         'registrationDocumentId': owngroup.reg_document_id,
         'canDocumentId': owngroup.can_document_id,
-        'tenancyType': owngroup.tenancy_type,
+        'type': 'COMMON',
         'lessee': owngroup.lessee,
         'lessor': owngroup.lessor,
-        'interest': owngroup.interest,
+        'interest': 'UNDIVIDED',
         'interestNumerator': owngroup.interest_numerator,
-        'interestDenominator': 0,
-        'tenancySpecified': owngroup.tenancy_specified
+        'interestDenominator': 2,
+        'tenancySpecified': True
     }
     assert owngroup.json == test_json
+
+
+def test_owngroup_reg_json(session):
+    """Assert that the owngroup renders to a registration json format correctly."""
+    owngroup = Db2Owngroup(manuhome_id=1,
+                           group_id=1,
+                           copy_id=0,
+                           status='3',
+                           sequence_number=1,
+                           reg_document_id='REG22911',
+                           can_document_id='42400339',
+                           tenancy_type='TC',
+                           lessee='',
+                           lessor='',
+                           interest='UNDIVIDED 1/2',
+                           interest_numerator=1,
+                           tenancy_specified='Y')
+
+    test_json = {
+        'groupId': owngroup.group_id,
+        'type': 'COMMON',
+        'status': 'ACTIVE',
+        'interest': 'UNDIVIDED',
+        'interestNumerator': owngroup.interest_numerator,
+        'interestDenominator': 2,
+        'tenancySpecified': True,
+        'owners': []
+    }
+    assert owngroup.registration_json == test_json

--- a/mhr_api/tests/unit/models/test_mhr_owner_group.py
+++ b/mhr_api/tests/unit/models/test_mhr_owner_group.py
@@ -127,6 +127,6 @@ def test_create_from_json(session):
     assert group.tenancy_specified == 'Y'
     assert group.tenancy_type == MhrTenancyTypes.COMMON
     assert group.status_type == MhrOwnerStatusTypes.ACTIVE
-    assert group.interest == 'UNDIVIDED 4/5'
+    assert group.interest == 'UNDIVIDED'
     assert group.interest_numerator == 4
     assert group.interest_denominator == 5

--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -399,7 +399,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                     # Signal UI report pending if async report is not yet available.
                     if callback_url is not None and callback_url.lower() != 'none' and\
                             (doc_storage_url is None or doc_storage_url.lower() == 'none'):
-                        search_id = REPORT_STATUS_PENDING
+                        search_id += '_' + REPORT_STATUS_PENDING
                     search = {
                         'searchId': search_id,
                         'searchDateTime': model_utils.format_ts(search_ts),

--- a/ppr-api/src/ppr_api/resources/search_results.py
+++ b/ppr-api/src/ppr_api/resources/search_results.py
@@ -28,6 +28,7 @@ from ppr_api.exceptions import BusinessException, DatabaseException
 from ppr_api.services.authz import authorized
 from ppr_api.services.queue_service import GoogleQueueService
 from ppr_api.models import EventTracking, SearchResult, SearchRequest, utils as model_utils
+from ppr_api.models.search_request import REPORT_STATUS_PENDING
 from ppr_api.resources import utils as resource_utils
 from ppr_api.reports import ReportTypes, get_pdf
 from ppr_api.callback.reports.report_service import get_search_report
@@ -165,7 +166,9 @@ class SearchResultsResource(Resource):
             # Verify request JWT and account ID
             if not authorized(account_id, jwt):
                 return resource_utils.unauthorized_error_response(account_id)
-            # Try to fetch search detail by search id.
+            # Try to fetch search detail by search id. Remove _PENDING if it is in the id.
+            if search_id.find(('_' + REPORT_STATUS_PENDING)) != -1:
+                search_id = search_id.replace(('_' + REPORT_STATUS_PENDING), '')
             current_app.logger.info(f'Fetching search detail for {search_id}.')
             search_detail: SearchResult = SearchResult.find_by_search_id(search_id, True)
             if not search_detail:

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.4'  # pylint: disable=invalid-name
+__version__ = '1.0.5'  # pylint: disable=invalid-name


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14706
                 /bcgov/entity#14758

*Description of changes:*
- 14706 Remove the duplication fraction from the legacy interest description in the API registration response.
- 14758 PPR API update get search history endpoint results search id when a large report is pending.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
