### PR TITLE
Enhance UX for Large PDF Search Reports

### DIFF
--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -74,7 +74,7 @@
                 </td>
                 <td>
                   <v-btn
-                    v-if="item.searchId !== 'PENDING' &&
+                    v-if="!item.isPending &&
                     !item.inProgress && isPDFAvailable(item) && isMhrReportReady(item)"
                     :id="`pdf-btn-${item.searchId}`"
                     class="pdf-btn px-0 mt-n3"
@@ -169,11 +169,12 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { SearchCriteriaIF, SearchResponseIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { MHRSearchTypes, searchHistoryTableHeaders, searchHistoryTableHeadersStaff, SearchTypes } from '@/resources'
-import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF } from '@/utils'
+import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF, delayActions } from '@/utils'
 import { ErrorContact } from '../common'
 import { useSearch } from '@/composables/useSearch'
 import { cloneDeep } from 'lodash' // eslint-disable-line
 import _ from 'lodash' // eslint-disable-line
+import { ErrorCategories } from '@/enums'
 
 export default defineComponent({
   components: {
@@ -216,12 +217,7 @@ export default defineComponent({
       }),
       searchHistory: computed(
         (): Array<SearchResponseIF> => {
-          let searchHistory = null
-          searchHistory = getSearchHistory.value
-          if (!searchHistory) {
-            return []
-          }
-          return searchHistory
+          return getSearchHistory.value || []
         }
       ),
       isSearchHistory: computed((): boolean => {
@@ -273,14 +269,23 @@ export default defineComponent({
     const downloadPDF = async (item: SearchResponseIF): Promise<boolean> => {
       item.loadingPDF = true
       let pdf:any = null
+      if (item.isPending) {
+        item.loadingPDF = true
+        await delayActions(5000)
+      }
       if (isPprSearch(item)) {
         pdf = await searchPDF(item.searchId)
       } else {
         pdf = await searchMhrPDF(item.searchId)
       }
       if (pdf.error) {
-        // do not emit any error so dialog is not shown - #13980
-        // if (isPprSearch(item)) emit('error', pdf.error)
+        if (pdf.error.statusCode === 500) {
+          // emit and show modal for a server error
+          emit('error', pdf.error)
+        } else if (pdf.error.statusCode === 400 && pdf.error.category === ErrorCategories.REPORT_GENERATION) {
+          // log to console if pdf report is still pending
+          console.log('PDF Report is not ready yet')
+        }
         item.loadingPDF = false
         return false
       } else {
@@ -313,6 +318,7 @@ export default defineComponent({
         }
       }
       item.loadingPDF = false
+      item.isPending = false
       return true
     }
     const generateReport = _.throttle(async (item: SearchResponseIF): Promise<void> => {
@@ -328,17 +334,20 @@ export default defineComponent({
           // set to pending if submit was not finished
           if (item.inProgress) {
             item.loadingPDF = false
-            item.searchId = 'PENDING'
+            // item.searchId = 'PENDING'
+            item.isPending = true
           }
         }, 5000)
         const statusCode = await submitSelected(searchId, [], callBack, true)
         // FUTURE: add error handling, for now just ignore so they can try again
         if (successfulPPRResponses.includes(statusCode)) {
-          if (item.selectedResultsSize >= 75) item.searchId = 'PENDING'
-          else item.searchId = searchId
+          if (item.selectedResultsSize >= 75) {
+            item.isPending = true
+          } else item.searchId = searchId
           item.inProgress = false
         }
         item.loadingPDF = false
+        item.isPending = false
       }, 1000)
     }, 250, { trailing: false })
     const getTooltipTxtPdf = (item: SearchResponseIF): string => {
@@ -355,8 +364,9 @@ export default defineComponent({
       if (!isPDFAvailable(item)) {
         return 'This document PDF is no longer available.'
       }
-      return '<p class="ma-0">This document PDF is still being generated. Reload this page to ' +
-        'see if your PDF is ready to download.</p>' +
+      return '<p class="ma-0">This document PDF is still being generated. Click the ' +
+        '<i class="v-icon notranslate mdi mdi-information-outline" style="font-size:18px; margin-bottom:4px;"></i> ' +
+        'icon to see if your PDF is ready to download. </p>' +
         '<p class="ma-0 mt-2">Note: Large documents may take up to 20 minutes to generate.</p>'
     }
     const isPDFAvailable = (item: SearchResponseIF): Boolean => {

--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -334,7 +334,6 @@ export default defineComponent({
           // set to pending if submit was not finished
           if (item.inProgress) {
             item.loadingPDF = false
-            // item.searchId = 'PENDING'
             item.isPending = true
           }
         }, 5000)

--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -95,19 +95,13 @@
                   >
                     <template v-slot:activator="{ on, attrs }">
                       <v-btn
+                        icon
                         v-if="!item.inProgress"
-                        :icon="item.isPdfRequested"
-                        :depressed="!item.isPdfRequested"
-                        :color="item.isPdfRequested ? 'primary' : ''"
-                        :class="{ 'pdf-btn px-0 mt-n3' : !item.isPdfRequested }"
+                        color="primary"
                         :loading="item.loadingPDF"
                         @click="refreshRow(item)"
                       >
-                        <div v-if="!item.isPdfRequested" style="display: flex">
-                          <img src="@/assets/svgs/pdf-icon-blue.svg" />
-                          <span class="pl-1">PDF</span>
-                        </div>
-                        <v-icon v-else color="primary" v-bind="attrs" v-on="on">
+                        <v-icon color="primary" v-bind="attrs" v-on="on">
                           mdi-information-outline
                         </v-icon>
                       </v-btn>
@@ -175,7 +169,7 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { SearchCriteriaIF, SearchResponseIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { MHRSearchTypes, searchHistoryTableHeaders, searchHistoryTableHeadersStaff, SearchTypes } from '@/resources'
-import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF, delayActions } from '@/utils'
+import { convertDate, searchPDF, submitSelected, successfulPPRResponses, searchMhrPDF } from '@/utils'
 import { ErrorContact } from '../common'
 import { useSearch } from '@/composables/useSearch'
 import { cloneDeep } from 'lodash' // eslint-disable-line
@@ -222,7 +216,12 @@ export default defineComponent({
       }),
       searchHistory: computed(
         (): Array<SearchResponseIF> => {
-          return getSearchHistory.value || []
+          let searchHistory = null
+          searchHistory = getSearchHistory.value
+          if (!searchHistory) {
+            return []
+          }
+          return searchHistory
         }
       ),
       isSearchHistory: computed((): boolean => {
@@ -356,9 +355,8 @@ export default defineComponent({
       if (!isPDFAvailable(item)) {
         return 'This document PDF is no longer available.'
       }
-      return '<p class="ma-0">This document PDF is still being generated. Click the ' +
-        '<i class="v-icon notranslate mdi mdi-information-outline" style="font-size:18px; margin-bottom:4px;"></i> ' +
-        'icon to see if your PDF is ready to download. </p>' +
+      return '<p class="ma-0">This document PDF is still being generated. Reload this page to ' +
+        'see if your PDF is ready to download.</p>' +
         '<p class="ma-0 mt-2">Note: Large documents may take up to 20 minutes to generate.</p>'
     }
     const isPDFAvailable = (item: SearchResponseIF): Boolean => {
@@ -390,13 +388,6 @@ export default defineComponent({
       }
     }
     const refreshRow = async (item): Promise<void> => {
-      // once PDF icon is clicked, reset the flag to Info icon
-      item.isPdfRequested = true
-      // for large searches that are still pending, delay any actions for better user experience
-      if (item.searchId === 'PENDING') {
-        item.loadingPDF = true
-        await delayActions(5000)
-      }
       const pdf = await downloadPDF(item)
       if (pdf) {
         // Update unique key value of table row to refresh singular component

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
@@ -14,7 +14,6 @@ export interface SearchResponseIF {
   error?: ErrorIF,
   inProgress?: boolean,
   loadingPDF?: boolean,
-  isPdfRequested?: boolean, // UX flag for large searches (to display PDF icon on first load)
   userId?: string,
   username?: string
 }

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/search-response-interface.ts
@@ -13,6 +13,7 @@ export interface SearchResponseIF {
   results: SearchResultIF[],
   error?: ErrorIF,
   inProgress?: boolean,
+  isPending?: boolean,
   loadingPDF?: boolean,
   userId?: string,
   username?: string

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -169,7 +169,12 @@ export const setSearchDebtorName: ActionIF = ({ commit }, debtorName: Individual
 export const setSearchHistory: ActionIF = ({ commit }, searchHistory: Array<SearchResponseIF>): void => {
   // need to set .loadingPDF so that the loader circle triggers when set
   //  - if it starts as undefined it wont trigger on change
-  for (let i = 0; i < searchHistory?.length || 0; i++) { searchHistory[i].loadingPDF = false }
+  for (let i = 0; i < searchHistory?.length || 0; i++) {
+    searchHistory[i].loadingPDF = false
+    // parse the response from API to check if searchId has Pending suffix (for large reports)
+    searchHistory[i].isPending = searchHistory[i].searchId.endsWith('PENDING')
+    searchHistory[i].searchId = searchHistory[i].searchId.split('_')[0]
+  }
   commit('mutateSearchHistory', searchHistory)
 }
 

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -169,10 +169,7 @@ export const setSearchDebtorName: ActionIF = ({ commit }, debtorName: Individual
 export const setSearchHistory: ActionIF = ({ commit }, searchHistory: Array<SearchResponseIF>): void => {
   // need to set .loadingPDF so that the loader circle triggers when set
   //  - if it starts as undefined it wont trigger on change
-  for (let i = 0; i < searchHistory?.length || 0; i++) {
-    searchHistory[i].loadingPDF = false
-    searchHistory[i].isPdfRequested = false
-  }
+  for (let i = 0; i < searchHistory?.length || 0; i++) { searchHistory[i].loadingPDF = false }
   commit('mutateSearchHistory', searchHistory)
 }
 

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -574,8 +574,3 @@ export async function deleteMhrDraft (draftID: string): Promise<ErrorIF> {
       return { statusCode: response?.status as StatusCodes }
     })
 }
-
-// UX util function to delay any actions for defined number of milliseconds
-export function delayActions (milliseconds: number): Promise<any> {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
-}

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -574,3 +574,8 @@ export async function deleteMhrDraft (draftID: string): Promise<ErrorIF> {
       return { statusCode: response?.status as StatusCodes }
     })
 }
+
+// UX util function to delay any actions for defined number of milliseconds
+export function delayActions (milliseconds: number): Promise<any> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}

--- a/ppr-ui/tests/unit/SearchHistory.spec.ts
+++ b/ppr-ui/tests/unit/SearchHistory.spec.ts
@@ -117,13 +117,16 @@ describe('Test result table with results', () => {
       expect(rows.at(i + 1).text()).toContain(totalResultsSize)
       expect(rows.at(i + 1).text()).toContain(exactResultsSize)
       expect(rows.at(i + 1).text()).toContain(selectedResultsSize)
-      // PDF icon should show up for small and large results #13980
-      expect(rows.at(i + 1).text()).toContain('PDF')
-      if (wrapper.vm.isPDFAvailable(mockedSearchHistory.searches[i])) {
-        expect(rows.at(i + 1).text()).toContain('PDF')
-        wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
-        await Vue.nextTick()
-        expect(downloadMock).toHaveBeenCalledWith(mockedSearchHistory.searches[i])
+      // PDF only shows for selected result size < 76
+      if (selectedResultsSize < 76) {
+        if (!wrapper.vm.isPDFAvailable(mockedSearchHistory.searches[i])) {
+          expect(rows.at(i + 1).text()).not.toContain('PDF')
+        } else {
+          expect(rows.at(i + 1).text()).toContain('PDF')
+          wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
+          await Vue.nextTick()
+          expect(downloadMock).toHaveBeenCalledWith(mockedSearchHistory.searches[i])
+        }
       }
     }
   })
@@ -148,7 +151,7 @@ describe('Test result table with results', () => {
     wrapper.destroy()
   })
 
-  it('renders and displays correct elements with results for MHR Search History', async () => {
+  it('renders and displays correct elements with results', async () => {
     expect(wrapper.findComponent(SearchHistory).exists()).toBe(true)
     expect(wrapper.vm.historyLength).toBe(mockedMHRSearchHistory.searches.length)
     expect(wrapper.vm.searchHistory).toStrictEqual(mockedMHRSearchHistory.searches)
@@ -181,12 +184,16 @@ describe('Test result table with results', () => {
       expect(rows.at(i + 1).text()).toContain(wrapper.vm.displayDate(searchDate))
       expect(rows.at(i + 1).text()).toContain(totalResultsSize)
       expect(rows.at(i + 1).text()).toContain(selectedResultsSize)
-      // PDF icon should show up for small and large results #13980
-      expect(rows.at(i + 1).text()).toContain('PDF')
-      if (wrapper.vm.isPDFAvailable(mockedMHRSearchHistory.searches[i])) {
-        wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
-        await Vue.nextTick()
-        expect(downloadMock).toHaveBeenCalledWith(mockedMHRSearchHistory.searches[i])
+      // PDF only shows for selected result size < 76
+      if (selectedResultsSize < 76) {
+        if (!wrapper.vm.isPDFAvailable(mockedMHRSearchHistory.searches[i])) {
+          expect(rows.at(i + 1).text()).not.toContain('PDF')
+        } else {
+          expect(rows.at(i + 1).text()).toContain('PDF')
+          wrapper.find(`#pdf-btn-${searchId}`).trigger('click')
+          await Vue.nextTick()
+          expect(downloadMock).toHaveBeenCalledWith(mockedMHRSearchHistory.searches[i])
+        }
       }
     }
   })

--- a/ppr-ui/tests/unit/test-data/mock-search-responses.ts
+++ b/ppr-ui/tests/unit/test-data/mock-search-responses.ts
@@ -34,7 +34,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1234K'
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.SERIAL_NUMBER]
   },
   [UISearchTypes.INDIVIDUAL_DEBTOR]: {
@@ -55,7 +54,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '123'
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.INDIVIDUAL_DEBTOR]
   },
   [UISearchTypes.BUSINESS_DEBTOR]: {
@@ -75,7 +73,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1233333332221'
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.BUSINESS_DEBTOR]
   },
   [UISearchTypes.MHR_NUMBER]: {
@@ -93,7 +90,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: ''
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.MHR_NUMBER]
   },
   [UISearchTypes.AIRCRAFT]: {
@@ -111,7 +107,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: 'abcd-123-rrr'
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.AIRCRAFT]
   },
   [UISearchTypes.REGISTRATION_NUMBER]: {
@@ -129,7 +124,6 @@ export const mockedSearchResponse: mockedSearchResponse = {
       },
       clientReferenceId: '1q'
     },
-    isPdfRequested: false,
     results: mockedSearchResults[UISearchTypes.REGISTRATION_NUMBER]
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13980
*Issue #:* /bcgov/entity#14757

*Description of changes:*

- Update UX for large search results, where we display 'i' icon for Pending reports, delay spinner for 5 seconds and only after make a request do download PDF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
