### PR TITLE
Remove delay for MHR reports generation

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.68",
+      "version": "0.3.69",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.69",
+      "version": "0.3.70",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13980
*Issue #:* /bcgov/entity#14757

*Description of changes:*

- MHR search reports have a delay of 30 seconds that is not needed anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
