### PR TITLE
Add reg other account by doc reg number.

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_location.py
+++ b/mhr_api/src/mhr_api/models/mhr_location.py
@@ -187,6 +187,8 @@ class MhrLocation(db.Model):  # pylint: disable=too-many-instance-attributes
             location.parcel = json_data['parcel'].strip()
         if json_data.get('block'):
             location.block = json_data['block'].strip()
+        if json_data.get('lot'):
+            location.lot = json_data['lot'].strip()
         if json_data.get('districtLot'):
             location.district_lot = json_data['districtLot'].strip()
         if json_data.get('partOf'):

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -285,12 +285,21 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def find_summary_by_mhr_number(cls, account_id: str, mhr_number: str, staff: bool = False):
-        """Return the MHR registration summary information matching the registration number."""
+        """Return the MHR registration summary information matching the MH registration number."""
         formatted_mhr = model_utils.format_mhr_number(mhr_number)
         current_app.logger.debug(f'Account_id={account_id}, mhr_number={formatted_mhr}')
         if model_utils.is_legacy():
             return legacy_utils.find_summary_by_mhr_number(account_id, formatted_mhr, staff)
         raise DatabaseException('MhrRegistration.find_summary_by_mhr_number PosgreSQL not yet implemented.')
+
+    @classmethod
+    def find_summary_by_doc_reg_number(cls, account_id: str, doc_reg_number: str, staff: bool = False):
+        """Return the MHR registration summary information matching the document registration number."""
+        formatted_reg_num = model_utils.format_doc_reg_number(doc_reg_number)
+        current_app.logger.debug(f'Account_id={account_id}, doc_reg_number={formatted_reg_num}')
+        if model_utils.is_legacy():
+            return legacy_utils.find_summary_by_doc_reg_number(account_id, formatted_reg_num, staff)
+        raise DatabaseException('MhrRegistration.find_summary_by_doc_reg_number PosgreSQL not yet implemented.')
 
     @classmethod
     def find_all_by_account_id(cls, params: AccountRegistrationParams):

--- a/mhr_api/src/mhr_api/models/search_request.py
+++ b/mhr_api/src/mhr_api/models/search_request.py
@@ -416,7 +416,7 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
                     doc_storage_url = str(mapping['doc_storage_url'])
                     if callback_url is not None and callback_url.lower() != 'none' and \
                             (doc_storage_url is None or doc_storage_url.lower() == 'none'):
-                        search_id = REPORT_STATUS_PENDING
+                        search_id += '_' + REPORT_STATUS_PENDING
                     search = {
                         'searchId': search_id,
                         'searchDateTime': model_utils.format_ts(mapping['search_ts']),

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -312,6 +312,8 @@ def ts_from_date_iso_format(date_iso: str):
 
 def date_from_iso_format(date_iso: str):
     """Create a date object from a date string in the ISO format."""
+    if len(date_iso) > 10:
+        return date.fromisoformat(date_iso[0:10])
     return date.fromisoformat(date_iso)
 
 
@@ -716,8 +718,14 @@ def to_db2_ind_name(name_json):
 
 
 def format_mhr_number(mhr_number: str):
-    """Trim and pad with zeroes search query mhr number query."""
+    """Trim and pad with zeroes mhr number to use in search queries."""
     formatted = mhr_number.strip().rjust(6, '0')
+    return formatted
+
+
+def format_doc_reg_number(doc_reg_number: str):
+    """Trim and pad with zeroes document registration number to use in queries."""
+    formatted = doc_reg_number.strip().rjust(8, '0')
     return formatted
 
 

--- a/mhr_api/src/mhr_api/resources/v1/search_results.py
+++ b/mhr_api/src/mhr_api/resources/v1/search_results.py
@@ -23,11 +23,9 @@ from registry_schemas import utils as schema_utils
 
 from mhr_api.exceptions import BusinessException, DatabaseException
 from mhr_api.models import EventTracking, SearchRequest, SearchResult
+from mhr_api.models.search_request import REPORT_STATUS_PENDING
 from mhr_api.resources import utils as resource_utils
 from mhr_api.services.authz import authorized, is_bcol_help, is_gov_account, is_staff_account
-# from mhr_api.reports import ReportTypes, get_pdf
-# from mhr_api.callback.reports.report_service import get_search_report
-# from mhr_api.callback.utils.exceptions import ReportException, ReportDataException, StorageException
 from mhr_api.services.document_storage.storage_service import GoogleStorageService
 from mhr_api.services.payment.exceptions import SBCPaymentException
 from mhr_api.services.payment.payment import Payment
@@ -207,7 +205,9 @@ def get_search_results(search_id: str):
         if not authorized(account_id, jwt):
             return resource_utils.unauthorized_error_response(account_id)
 
-        # Try to fetch search detail by search id.
+        # Try to fetch search detail by search id. Remove _PENDING if it is in the id.
+        if search_id.find(('_' + REPORT_STATUS_PENDING)) != -1:
+            search_id = search_id.replace(('_' + REPORT_STATUS_PENDING), '')
         current_app.logger.info(f'Fetching search detail for {search_id}.')
         search_detail = SearchResult.find_by_search_id(search_id, True)
         if not search_detail:

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.8'  # pylint: disable=invalid-name
+__version__ = '1.1.9'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/api/test_other_registrations.py
+++ b/mhr_api/tests/unit/api/test_other_registrations.py
@@ -27,13 +27,15 @@ from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
 from tests.unit.services.utils import create_header, create_header_account
 
 
-# testdata pattern is ({desc}, {roles}, {status}, {has_account}, {mhr_number})
+# testdata pattern is ({desc}, {roles}, {status}, {has_account}, {identifier}, is_mhr)
 TEST_GET_DATA = [
-    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '077741'),
-    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '077741'),
-    ('Valid request', [MHR_ROLE], HTTPStatus.OK, True, '077741'),
-    ('Invalid MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXX'),
-    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '077741')
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '077741', True),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '077741', True),
+    ('Valid request MHR', [MHR_ROLE], HTTPStatus.OK, True, '077741', True),
+    ('Valid request Doc Reg parent', [MHR_ROLE], HTTPStatus.OK, True, '00195878', False),
+    ('Valid request Doc Reg child', [MHR_ROLE], HTTPStatus.OK, True, '221961', False),
+    ('Invalid MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXX', True),
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '077741', True)
 ]
 TEST_POST_DATA = [
     ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '077741'),
@@ -53,8 +55,8 @@ TEST_DELETE_DATA = [
 ]
 
 
-@pytest.mark.parametrize('desc,roles,status,has_account, mhr_number', TEST_GET_DATA)
-def test_get_mhr_summary(session, client, jwt, desc, roles, status, has_account, mhr_number):
+@pytest.mark.parametrize('desc,roles,status,has_account, identifier, is_mhr', TEST_GET_DATA)
+def test_get_mhr_summary(session, client, jwt, desc, roles, status, has_account, identifier, is_mhr):
     """Assert that a get MH registration summary info by MHR number works as expected."""
     headers = None
     # setup
@@ -63,15 +65,20 @@ def test_get_mhr_summary(session, client, jwt, desc, roles, status, has_account,
     else:
         headers = create_header(jwt, roles)
     # test
-    rv = client.get('/api/v1/other-registrations/' + mhr_number,
-                    headers=headers)
+    request_uri = '/api/v1/other-registrations/' + identifier
+    if not is_mhr:
+        request_uri += '?identifierType=documentRegistrationNumber'
+    rv = client.get(request_uri, headers=headers)
 
     # check
     # print(rv.json)
     assert rv.status_code == status
     if rv.status_code == HTTPStatus.OK:
         registration = rv.json
-        assert registration['mhrNumber'] == mhr_number
+        if is_mhr:
+            assert registration['mhrNumber'] == identifier
+        else:
+            assert registration.get('mhrNumber')
         assert registration['registrationDescription']
         assert registration['statusType'] is not None
         assert registration['createDateTime'] is not None
@@ -81,6 +88,7 @@ def test_get_mhr_summary(session, client, jwt, desc, roles, status, has_account,
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
         assert registration['inUserList'] is not None
+        assert registration.get('documentRegistrationNumber')
 
 
 @pytest.mark.parametrize('desc,roles,status,has_account, mhr_number', TEST_POST_DATA)
@@ -111,6 +119,7 @@ def test_post_other_account_reg(session, client, jwt, desc, roles, status, has_a
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
         assert not registration['inUserList']
+        assert registration.get('documentRegistrationNumber')
 
 
 @pytest.mark.parametrize('desc,roles,status,has_account, mhr_number', TEST_DELETE_DATA)

--- a/mhr_api/tests/unit/models/test_mhr_location.py
+++ b/mhr_api/tests/unit/models/test_mhr_location.py
@@ -167,8 +167,27 @@ def test_create_from_json(session, location_type):
     loc_json = json_data.get('location')
     loc_json['locationType'] = location_type
     loc_json['legalDescription'] = LTSA_DESCRIPTION
-    loc_json['bandName'] = 'band name'
+    loc_json['bandName'] = 'BAND NAME'
     loc_json['reserveNumber'] = 'test num'
+    loc_json['parkName'] = TEST_LOCATION.park_name
+    loc_json['pad'] = TEST_LOCATION.park_pad
+    loc_json['pidNumber'] = TEST_LOCATION.pid_number
+    loc_json['lot'] = TEST_LOCATION.lot
+    loc_json['parcel'] = TEST_LOCATION.parcel
+    loc_json['block'] = TEST_LOCATION.block
+    loc_json['districtLot'] = TEST_LOCATION.district_lot
+    loc_json['partOf'] = TEST_LOCATION.part_of
+    loc_json['section'] = TEST_LOCATION.section
+    loc_json['township'] = TEST_LOCATION.township
+    loc_json['range'] = TEST_LOCATION.range
+    loc_json['meridian'] = TEST_LOCATION.meridian
+    loc_json['landDistrict'] = TEST_LOCATION.land_district
+    loc_json['plan'] = TEST_LOCATION.plan
+    loc_json['exceptionPlan'] = TEST_LOCATION.exception_plan
+    loc_json['dealerName'] = TEST_LOCATION.dealer_name
+    loc_json['additionalDescription'] = TEST_LOCATION.additional_description
+    loc_json['leaveProvince'] = True
+    loc_json['taxCertificate'] = True
     location: MhrLocation = MhrLocation.create_from_json(loc_json, 1000)
     assert location
     assert location.registration_id == 1000
@@ -177,12 +196,30 @@ def test_create_from_json(session, location_type):
     assert location.status_type == MhrStatusTypes.ACTIVE
     assert location.ltsa_description == LTSA_DESCRIPTION
     assert location.address
-    assert location.dealer_name
+    assert location.park_name == TEST_LOCATION.park_name
+    assert location.park_pad == TEST_LOCATION.park_pad
+    assert location.pid_number == TEST_LOCATION.pid_number
+    assert location.lot == TEST_LOCATION.lot
+    assert location.parcel == TEST_LOCATION.parcel
+    assert location.block == TEST_LOCATION.block
+    assert location.district_lot == TEST_LOCATION.district_lot
+    assert location.part_of == TEST_LOCATION.part_of
+    assert location.section == TEST_LOCATION.section
+    assert location.township == TEST_LOCATION.township
+    assert location.range == TEST_LOCATION.range
+    assert location.meridian == TEST_LOCATION.meridian
+    assert location.land_district == TEST_LOCATION.land_district
+    assert location.plan == TEST_LOCATION.plan
+    assert location.exception_plan == TEST_LOCATION.exception_plan
+    assert location.dealer_name == TEST_LOCATION.dealer_name
+    assert location.additional_description == TEST_LOCATION.additional_description
+    assert location.leave_province == 'Y'
+    assert location.tax_certification == 'Y'
     if location_type == MhrLocationTypes.MH_PARK:
         assert location.park_name
         assert location.park_pad
         assert not location.band_name
         assert not location.reserve_number
     elif location_type == MhrLocationTypes.RESERVE:
-        assert location.band_name
-        assert location.reserve_number
+        assert location.band_name == 'BAND NAME'
+        assert location.reserve_number == 'test num'

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -145,6 +145,18 @@ TEST_SUMMARY_REG_DATA = [
     ('PS12345', '045349', True, CONV_DESCRIPTION, True),
     ('2523', '150062', True, REG_DESCRIPTION, True)
 ]
+# testdata pattern is ({account_id}, {doc_reg_num}, {mhr_number}, {result_count}, {reg_desc}, {in_list})
+TEST_SUMMARY_DOC_REG_DATA = [
+    ('PS12345', '077741', '077741', 3, CONV_DESCRIPTION, False),
+    ('PS12345', 'TESTXX', None, 0, None, False),
+    ('PS12345', '00045349', '045349', 3, CONV_DESCRIPTION, True),
+    ('PS12345', '009301', '009301', 1, CONV_DESCRIPTION, False),
+    ('ppr_staff', '196123', '087219', 5, REG_DESCRIPTION, False),
+    ('ppr_staff', '221961', '087219', 5, REG_DESCRIPTION, False)
+]
+TEST_SUMMARY_DOC_REG_DATA2 = [
+    ('PS12345', '077741', '077741', 3, CONV_DESCRIPTION, False)
+]
 # testdata pattern is ({account_id}, {has_results})
 TEST_ACCOUNT_REG_DATA = [
     ('PS12345', True),
@@ -199,6 +211,7 @@ TEST_DATA_NEW_GROUP = [
     ('COMMON', 2, 2, 10, COMMON_OWNER_GROUP)
 ]
 
+
 @pytest.mark.parametrize('account_id,mhr_num,exists,reg_desc,in_list', TEST_SUMMARY_REG_DATA)
 def test_find_summary_by_mhr_number(session, account_id, mhr_num, exists, reg_desc, in_list):
     """Assert that finding summary MHR registration information works as expected."""
@@ -216,6 +229,32 @@ def test_find_summary_by_mhr_number(session, account_id, mhr_num, exists, reg_de
         assert registration['path'] is not None
         assert registration['documentId'] is not None
         assert registration['inUserList'] == in_list
+    else:
+        assert not registration
+
+
+@pytest.mark.parametrize('account_id,doc_reg_num,mhr_num,result_count,reg_desc,in_list', TEST_SUMMARY_DOC_REG_DATA)
+def test_find_summary_by_doc_reg_number(session, account_id, doc_reg_num, mhr_num, result_count, reg_desc, in_list):
+    """Assert that finding summary MHR registration information by a document registration number works as expected."""
+    registration = MhrRegistration.find_summary_by_doc_reg_number(account_id, doc_reg_num)
+    if result_count > 0:
+        current_app.logger.info(registration)
+        assert registration['mhrNumber'] == mhr_num
+        assert registration['registrationDescription'] == reg_desc
+        assert registration['statusType'] is not None
+        assert registration['createDateTime'] is not None
+        assert registration['username'] is not None
+        assert registration['submittingParty'] is not None
+        assert registration['clientReferenceId'] is not None
+        assert registration['ownerNames'] is not None
+        assert registration['path'] is not None
+        assert registration['documentId'] is not None
+        assert registration['inUserList'] == in_list
+        if result_count == 1:
+            assert not registration.get('changes')
+        else:
+            assert registration.get('changes')
+            assert len(registration['changes']) >= (result_count - 1)
     else:
         assert not registration
 


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14741 /bcgov/entity#14804 /bcgov/entity#14763

*Description of changes:*
- 14741 Add registration parent/child created by another account by document registration number.
- 14804 Return/accept {search_id}_PENDING in account MHR search summary list when report is pending.
- 14763 bug fix to save location lot and include in reports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
