### PR TITLE
14806 Add new account type and auth for SBC Staff

### DIFF
--- a/ppr-ui/src/enums/accountTypes.ts
+++ b/ppr-ui/src/enums/accountTypes.ts
@@ -1,4 +1,5 @@
 export enum AccountTypes {
   PREMIUM = 'PREMIUM',
-  BASIC = 'BASIC'
+  BASIC = 'BASIC',
+  SBC_STAFF = 'SBC_STAFF'
 }

--- a/ppr-ui/src/utils/auth-helper.ts
+++ b/ppr-ui/src/utils/auth-helper.ts
@@ -5,7 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 // Interfaces, Enums
-import { AccountProductCodes, AccountProductMemberships, AccountProductRoles } from '@/enums'
+import { AccountProductCodes, AccountProductMemberships, AccountProductRoles, AccountTypes } from '@/enums'
 import {
   AccountProductSubscriptionIF, AddressIF, PartyIF, SearchPartyIF, UserProductSubscriptionIF
 } from '@/interfaces'
@@ -181,8 +181,7 @@ export async function getSbcFromAuth (): Promise<boolean> {
         if (!data) {
           return false
         }
-        const branchName = data?.branchName
-        if (branchName?.includes('Service BC')) {
+        if (data.orgType === AccountTypes.SBC_STAFF) {
           return true
         }
         return false

--- a/ppr-ui/tests/unit/RegistrationTable.spec.ts
+++ b/ppr-ui/tests/unit/RegistrationTable.spec.ts
@@ -278,9 +278,9 @@ describe('Test registration table with results', () => {
           startDate: null,
           status: ''
         })
-      }, 1000)
+      }, 3000)
       expect(wrapper.findAll('.v-btn.registration-action').length).toBe(0)
-    }, 1000)
+    }, 3000)
   })
 
   it('renders and displays the typeahead dropdown', async () => {

--- a/ppr-ui/tests/unit/test-data/mock-user-profile-responses.ts
+++ b/ppr-ui/tests/unit/test-data/mock-user-profile-responses.ts
@@ -1,6 +1,6 @@
 import { SettingOptions } from '@/enums'
 import { UserSettingsIF } from '@/interfaces'
-import {mhRegistrationTableHeaders, registrationTableHeaders} from '@/resources'
+import { mhRegistrationTableHeaders, registrationTableHeaders } from '@/resources'
 
 export const mockedDefaultUserSettingsResponse: UserSettingsIF = {
   [SettingOptions.PAYMENT_CONFIRMATION_DIALOG]: true,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14806

*Description of changes:*
- Add SBC_STAFF to AccountTypes
- Change method of authenticating SBC_STAFF to use AccountType
- Change timeout on RegistrationTable.spec.ts to 3000. Was timing out.
- Minor linting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
