### PR TITLE
Par api fix reg report header

### DIFF
--- a/ppr-api/report-templates/static/v2/header_registration.html
+++ b/ppr-api/report-templates/static/v2/header_registration.html
@@ -68,14 +68,14 @@
         .registration-header-table td:nth-child(1) {
             padding-left: 20px;
             margin-right: 0px;
-            width: 53%;
+            width: 55%;
         }
 
         .registration-header-table td:nth-child(2) {
             text-align: left;
             margin-left: 0px;
             padding-bottom: 0px;
-            width: 47%;
+            width: 45%;
         }
 
         .report-type {

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.6'  # pylint: disable=invalid-name
+__version__ = '1.0.7'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Fix registration report not displaying the base registration number when the number is too long.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
