### PR TITLE
Added optional additional address to SSP modal

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.77",
+  "version": "0.3.78",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.3.77",
+      "version": "0.3.78",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.3.77",
+  "version": "0.3.78",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -69,8 +69,11 @@
                 party.personName.first+" "+party.personName.middle+" "+party.personName.last}}
               </div>
               <div :class="$style['addressText']">
-                {{ party.address.street }}, {{ party.address.city }}
-                {{ party.address.region }} , {{ party.address.postalCode }},
+                {{ party.address.street }},
+                {{ party.address.streetAdditional ? party.address.streetAdditional+"," : ""}}
+                {{ party.address.city }}
+                {{ party.address.region }},
+                {{ party.address.postalCode }},
                 {{ getCountryName(party.address.country) }}
               </div>
               <div>

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -70,7 +70,7 @@
               </div>
               <div :class="$style['addressText']">
                 {{ party.address.street }},
-                {{ party.address.streetAdditional ? party.address.streetAdditional+"," : ""}}
+                {{ party.address.streetAdditional ? `${party.address.streetAdditional},` : ""}}
                 {{ party.address.city }}
                 {{ party.address.region }},
                 {{ party.address.postalCode }},


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14937

*Description of changes:*
- Added "Address Line 2 (Optional)" info to Similar Secured Party modal if user inputs

With "Address Line 2 (Optional)" data
![image](https://user-images.githubusercontent.com/112968185/211910696-043648ae-9cc6-465f-9687-067171548915.png)
![image](https://user-images.githubusercontent.com/112968185/211910891-e939b1cd-b849-4e5d-892f-ed378e2ac3de.png)

Without
![image](https://user-images.githubusercontent.com/112968185/211911039-09799fc9-e2ce-4b22-b615-89ced825725e.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
