### PR TITLE
14937 ssp modal fixes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -235,7 +235,12 @@ export default defineComponent({
 
     const countryProvincesHelpers = useCountriesProvinces()
 
-    const { addSecuredParty, setRegisteringParty, isExistingSecuredParty } = useSecuredParty(props, context)
+    const {
+      setRegisteringParty,
+      isExistingSecuredParty,
+      addEditSecuredParty,
+      currentSecuredParty
+    } = useSecuredParty(props, context)
 
     const selectParty = (idx: number) => {
       const selectedResult = localState.results[idx]
@@ -249,7 +254,8 @@ export default defineComponent({
         newParty.action = ActionTypes.EDITED
         setRegisteringParty(newParty)
       } else {
-        addSecuredParty(newParty, props.activeIndex)
+        currentSecuredParty.value = newParty
+        addEditSecuredParty()
       }
       context.emit('emitResetClose')
     }
@@ -259,7 +265,8 @@ export default defineComponent({
         localState.party.action = ActionTypes.EDITED
         setRegisteringParty(localState.party)
       } else {
-        addSecuredParty(localState.party, props.activeIndex)
+        currentSecuredParty.value = localState.party
+        addEditSecuredParty()
       }
       context.emit('emitResetClose')
     }

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -253,6 +253,7 @@ import { formatAddress } from '@/composables/address/factories'
 import { SearchPartyIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { partyCodeSearch } from '@/utils'
 import { useValidation } from '@/utils/validators/use-validation'
+import { isEqual } from 'lodash'
 
 export default defineComponent({
   components: {
@@ -298,7 +299,8 @@ export default defineComponent({
       ActionTypes,
       setRegisteringParty,
       addressSchema,
-      hasMatchingSecuredParty
+      hasMatchingSecuredParty,
+      originalSecuredParty
     } = useSecuredParty(props, context)
 
     const {
@@ -369,16 +371,18 @@ export default defineComponent({
           return
         }
         if (currentSecuredParty.value.businessName && partyType.value === SecuredPartyTypes.BUSINESS) {
-          // go to the service and see if there are similar secured parties
-          const response: [SearchPartyIF] = await partyCodeSearch(
-            currentSecuredParty.value.businessName, false
-          )
-          // check if any results
-          if (response?.length > 0) {
-            // show secured party selection popup
-            showDialog()
-            localState.dialogResults = response?.slice(0, 50)
-            return
+          if (!isEqual(currentSecuredParty, originalSecuredParty)) {
+            // go to the service and see if there are similar secured parties
+            const response: [SearchPartyIF] = await partyCodeSearch(
+              currentSecuredParty.value.businessName, false
+            )
+            // check if any results
+            if (response?.length > 0) {
+              // show secured party selection popup
+              showDialog()
+              localState.dialogResults = response?.slice(0, 50)
+              return
+            }
           }
         }
 

--- a/ppr-ui/src/components/parties/party/SecuredParties.vue
+++ b/ppr-ui/src/components/parties/party/SecuredParties.vue
@@ -174,7 +174,8 @@
                   >
                   <v-list-item
                     v-if="(registrationFlowType === RegistrationFlowType.AMENDMENT
-                      && row.item.action === ActionTypes.REMOVED && !isSecuredPartyRestrictedList(registrationType))
+                      && (row.item.action === ActionTypes.REMOVED || row.item.action === ActionTypes.EDITED) &&
+                      !isSecuredPartyRestrictedList(registrationType))
                       || (isSecuredPartyRestrictedList(registrationType) && row.item.action === ActionTypes.ADDED
                       && registrationFlowType === RegistrationFlowType.AMENDMENT)"
                       class="v-remove"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14937

Refactors from UXA/QA

*Description of changes:*
- Similar Secured Party modal will now only appear on amend if changes have been made to the form.
- Changed the badge displayed for an amended SSP


In the Amendment of a registration:
![image](https://user-images.githubusercontent.com/112968185/212994887-7cc909ba-b8c9-4816-b025-4ca6393a1c7b.png)
After clicking "Amend" and making changes, then selecting the new Secured Party from the SSP modal:
![image](https://user-images.githubusercontent.com/112968185/212995235-bdbd20ff-c508-4c36-ba95-59ccf612a4a7.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
