### PR TITLE
Fix for mainframe serial search key issue, MHR reg filter updates.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -536,7 +536,7 @@ class Db2Manuhome(db.Model):
                     if num > 0 and den > 0:
                         if den != common_denominator:
                             group.interest_denominator = common_denominator
-                            group.interest_numerator = (common_denominator/den * num)
+                            group.interest_numerator = int((common_denominator/den * num))
                     if group.interest.upper().startswith(model_utils.OWNER_INTEREST_UNDIVIDED):
                         group.interest = model_utils.OWNER_INTEREST_UNDIVIDED + ' '
                     else:

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -62,8 +62,8 @@ class AccountRegistrationParams():
     filter_mhr_number: str = None
     filter_registration_type: str = None
     filter_registration_date: str = None
-    # start_date_time: str = None
-    # end_date_time: str = None
+    filter_reg_start_date: str = None
+    filter_reg_end_date: str = None
     filter_status_type: str = None
     filter_client_reference_id: str = None
     filter_submitting_name: str = None
@@ -90,7 +90,7 @@ class AccountRegistrationParams():
     def has_filter(self) -> bool:
         """Check if filter criteria provided."""
         return self.filter_client_reference_id or self.filter_mhr_number or self.filter_registration_type or \
-            self.filter_registration_date or self.filter_status_type or self.filter_submitting_name or \
+            self.filter_reg_start_date or self.filter_status_type or self.filter_submitting_name or \
             self.filter_username
 
     def get_filter_values(self):  # pylint: disable=too-many-return-statements
@@ -99,8 +99,8 @@ class AccountRegistrationParams():
             return MHR_NUMBER_PARAM, self.filter_mhr_number
         if self.filter_registration_type:
             return REG_TYPE_PARAM, self.filter_registration_type
-        if self.filter_registration_date:
-            return REG_TS_PARAM, self.filter_registration_date
+        if self.filter_reg_start_date:
+            return START_TS_PARAM, self.filter_reg_start_date
         if self.filter_status_type:
             return STATUS_PARAM, self.filter_status_type
         if self.filter_client_reference_id:

--- a/mhr_api/src/mhr_api/resources/utils.py
+++ b/mhr_api/src/mhr_api/resources/utils.py
@@ -281,7 +281,8 @@ def get_account_registration_params(req: request, params: AccountRegistrationPar
     params.filter_client_reference_id = req.args.get(reg_utils.CLIENT_REF_PARAM, None)
     params.filter_submitting_name = req.args.get(reg_utils.SUBMITTING_NAME_PARAM, None)
     params.filter_username = req.args.get(reg_utils.USER_NAME_PARAM, None)
-    params.filter_registration_date = req.args.get(reg_utils.REG_TS_PARAM, None)
+    params.filter_reg_start_date = req.args.get(reg_utils.START_TS_PARAM, None)
+    params.filter_reg_end_date = req.args.get(reg_utils.END_TS_PARAM, None)
     # start_ts = req.args.get(reg_utils.START_TS_PARAM, None)
     # end_ts = req.args.get(reg_utils.END_TS_PARAM, None)
     # if start_ts and end_ts:
@@ -303,10 +304,12 @@ def get_account_registration_params(req: request, params: AccountRegistrationPar
         params.filter_username = params.filter_username.strip().upper()
         params.filter_username = remove_quotes(params.filter_username)
     if params.filter_client_reference_id:
-        params.filter_client_reference_id = params.filter_client_reference_id.strip()
+        params.filter_client_reference_id = params.filter_client_reference_id.strip().upper()
         params.filter_client_reference_id = remove_quotes(params.filter_client_reference_id)
-    if params.filter_registration_date:
-        params.filter_registration_date = remove_quotes(params.filter_registration_date)
+    if params.filter_reg_start_date:
+        params.filter_reg_start_date = remove_quotes(params.filter_reg_start_date)
+    if params.filter_reg_end_date:
+        params.filter_reg_end_date = remove_quotes(params.filter_reg_end_date)
     return params
 
 

--- a/mhr_api/src/mhr_api/resources/v1/permits.py
+++ b/mhr_api/src/mhr_api/resources/v1/permits.py
@@ -59,6 +59,10 @@ def post_permits(mhr_number: str):  # pylint: disable=too-many-return-statements
 
         # Validate request against the schema.
         current_app.logger.debug(f'Extra validation on transport permit json for {mhr_number}')
+        # Location may have no street - replace with blank to pass validation
+        if request_json.get('newLocation') and request_json['newLocation'].get('address') and \
+                not request_json['newLocation']['address'].get('street'):
+            request_json['newLocation']['address']['street'] = ' '
         valid_format, errors = schema_utils.validate(request_json, 'permit', 'mhr')
         # Additional validation not covered by the schema.
         extra_validation_msg = resource_utils.validate_permit(current_reg, request_json, is_staff(jwt), get_group(jwt))

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -93,6 +93,10 @@ def post_registrations():  # pylint: disable=too-many-return-statements
             return resource_utils.unauthorized_error_response(account_id)
         request_json = request.get_json(silent=True)
         # Validate request against the schema.
+        # Location may have no street - replace with blank to pass validation
+        if request_json.get('location') and request_json['location'].get('address') and \
+                not request_json['location']['address'].get('street'):
+            request_json['location']['address']['street'] = ' '
         valid_format, errors = schema_utils.validate(request_json, 'registration', 'mhr')
         # Additional validation not covered by the schema.
         extra_validation_msg = resource_utils.validate_registration(request_json, is_staff(jwt))

--- a/mhr_api/tests/unit/api/test_searches.py
+++ b/mhr_api/tests/unit/api/test_searches.py
@@ -57,7 +57,7 @@ OWNER_NAME_JSON = {
 SERIAL_NUMBER_JSON = {
     'type': 'SERIAL_NUMBER',
     'criteria': {
-        'value': '4551'
+        'value': '9493'
     },
     'clientReferenceId': 'T-SQ-MS-1'
 }

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -28,6 +28,24 @@ from mhr_api.models import Db2Document, Db2Manuhome, Db2Mhomnote, Db2Owngroup, M
 from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE
 
 
+COMMON_GROUP_1 = Db2Owngroup(interest='UNDIVIDED',
+                             interest_numerator=1,
+                             interest_denominator=4,
+                             group_id=1,
+                             tenancy_type='TC',
+                             status='3')
+COMMON_GROUP_2 = Db2Owngroup(interest='UNDIVIDED',
+                             interest_numerator=2,
+                             interest_denominator=8,
+                             group_id=2,
+                             tenancy_type='TC',
+                             status='3')
+COMMON_GROUP_3 = Db2Owngroup(interest='UNDIVIDED',
+                             interest_numerator=2,
+                             interest_denominator=4,
+                             group_id=3,
+                             tenancy_type='TC',
+                             status='3')
 # testdata pattern is ({exists}, {id}, {mhr_num}, {status}, {doc_id})
 TEST_DATA = [
     (True, 1, '022911', 'E', 'REG22911'),
@@ -67,6 +85,10 @@ TEST_DATA_GROUP_INTEREST = [
     ('UNDIVIDED', 1, 2, 'UNDIVIDED 1/2'),
     ('Undivided', 1, 2, 'UNDIVIDED 1/2'),
     ('Junk', 1, 2, '1/2')
+]
+# testdata pattern is ({group1}, {group2}, {group3}, {interest1}, {interest2}, {interest3})
+TEST_DATA_GROUP_INTEREST2 = [
+    (COMMON_GROUP_1, COMMON_GROUP_2, COMMON_GROUP_3, 'UNDIVIDED 2/8', 'UNDIVIDED 2/8', 'UNDIVIDED 4/8')
 ]
 
 
@@ -230,6 +252,25 @@ def test_adjust_group_interest_new(session, interest, numerator, denominator, ne
     groups.append(group)
     Db2Manuhome.adjust_group_interest(groups, True)
     assert groups[0].interest == new_interest
+
+
+@pytest.mark.parametrize('group1,group2,group3,interest1,interest2,interest3', TEST_DATA_GROUP_INTEREST2)
+def test_adjust_group_interest_2(session, group1, group2, group3, interest1, interest2, interest3):
+    groups = []
+    if group1:
+        groups.append(group1)
+    if group2:
+        groups.append(group2)
+    if group3:
+        groups.append(group3)
+    Db2Manuhome.adjust_group_interest(groups, True)
+    for group in groups:
+        if group.group_id == 1:
+            assert group.interest == interest1
+        elif group.group_id == 2:
+            assert group.interest == interest2
+        elif group.group_id == 3:
+            assert group.interest == interest3
 
 
 def test_notes_sort_order(session):

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -19,7 +19,7 @@ import pytest
 from flask import current_app
 
 from mhr_api.models import utils as model_utils
-
+from mhr_api.models.db2.search_utils import get_search_serial_number_key
 
 DB2_IND_NAME_MIDDLE = 'DANYLUK                  LEONARD        MICHAEL                       '
 DB2_IND_NAME = 'KING                     MARDI                                        '
@@ -55,17 +55,17 @@ TEST_DATA_OWNER_KEY = [
     ('MCCAUGHAN-MORRISON       MARGARET       MORRISON ', 'MCCAUGHANMORRISONMARGARETMORRI'),
     ('SCHWARTZENBERGER         RAYMOND        AMBROSE   ', 'SCHWARTZENBERGERRAYMONDAMBROSE')
 ]
-# testdata pattern is ({serial_num}, {hex_value})
+# testdata pattern is ({serial_num}, {key_value})
 TEST_DATA_SERIAL_KEY = [
-    ('WIN14569401627', '0620DB'),
-    ('A4492', '00118C'),
-    ('3E3947', '04A34B'),
-    ('6436252B10FK', '03DB8A'),
-    ('I1724B', '002DCC'),
-    ('2427', '00097B'),
-    ('123', '00007B'),
-    ('12345', '003039'),
-    ('999999', '0F423F')
+    ('313000Z009206AB', '920608'),
+    ('WIN24440204003A', '040030'),
+    ('KW2191U', '021910'),
+    ('6436252B10FK', '281000'),
+    ('D1644', '001644'),
+    ('2427', '002427'),
+    ('123', '000123'),
+    ('12345', '012345'),
+    ('BC123452', '123452')
 ]
 # testdata pattern is ({valid}, {registration_ts}, {tax_cert_ts})
 TEST_DATA_TAX_CERT_DATE = [
@@ -107,13 +107,13 @@ def test_search_key_owner(name, key_value):
     assert value == key_value
 
 
-@pytest.mark.parametrize('serial_num, hex_value', TEST_DATA_SERIAL_KEY)
-def test_search_key_serial(session, serial_num, hex_value):
+@pytest.mark.parametrize('serial_num, key_value', TEST_DATA_SERIAL_KEY)
+def test_search_key_serial(session, serial_num, key_value):
     """Assert that computing a serial number search key works as expected."""
-    value = model_utils.get_serial_number_key_hex(serial_num)
+    value = get_search_serial_number_key(serial_num)
     # current_app.logger.info(f'Key={value}')
     assert len(value) == 6
-    assert value == hex_value
+    assert value == key_value
 
 
 @pytest.mark.parametrize('valid,registration_ts,tax_cert_ts', TEST_DATA_TAX_CERT_DATE)


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14976
                  /bcgov/entity#14947

*Description of changes:*
- 14976 Fix for legacy db serial number key generation and comparison not always working.
- 14947 MHR account registrations filter updates. 
- Fix for legacy group fractional ownership common denominator adjustment bug (found by Cameron). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
