### PR TITLE
Reset stepper validations on cancel

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/ButtonFooter.vue
+++ b/ppr-ui/src/components/common/ButtonFooter.vue
@@ -209,7 +209,10 @@ export default defineComponent({
     }
     const handleDialogResp = (val: boolean) => {
       localState.showCancelDialog = false
-      if (!val) goToDashboard()
+      if (!val) {
+        emit('cancelProceed')
+        goToDashboard()
+      }
     }
     /** Save the draft version from data stored in the state model. */
     const saveDraft = async (): Promise<Boolean> => {

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -51,6 +51,7 @@
           @registration-incomplete="registrationIncomplete()"
           @error="emitError()"
           @submit="submit()"
+          @cancelProceed="resetAllValidations()"
         />
       </v-col>
     </v-row>
@@ -251,6 +252,7 @@ export default defineComponent({
       isRouteName,
       registrationIncomplete,
       submit,
+      resetAllValidations,
       ...toRefs(localState)
     }
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14702

*Description of changes:*
- When user proceeds on cancel without saving, validations are reset
- Green checkmark is no longer showing when a registration is cancelled and a new one is initiated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
