### PR TITLE
MHR API initial transfer due to death changes.

### DIFF
--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.5.3
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.6.8#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.6.8#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -213,17 +213,16 @@ REG_FILTER_CLIENT_REF_COLLAPSE = """
       (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
                                               FROM document d2
                                              WHERE d2.mhregnum = mh.mhregnum
-                                               AND TRIM(d2.olbcfoli) LIKE '?%')))
+                                               AND TRIM(d2.olbcfoli) LIKE '%?%')))
 """
-REG_FILTER_USERNAME = " AND TRIM(d.affirmby) LIKE '?%'"
+REG_FILTER_USERNAME = " AND TRIM(d.affirmby) LIKE '%?%'"
 REG_FILTER_USERNAME_COLLAPSE = """
- AND (TRIM(d.affirmby) LIKE '?%' OR
+ AND (TRIM(d.affirmby) LIKE '%?%' OR
       (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
                                               FROM document d2
                                              WHERE d2.mhregnum = mh.mhregnum
-                                               AND TRIM(d2.affirmby) LIKE '?%')))
+                                               AND TRIM(d2.affirmby) LIKE '%?%')))
 """
-# REG_FILTER_DATE = " AND TO_CHAR(d.regidate, 'YYYY-MM-DD') = '?'"
 REG_FILTER_DATE = ' AND d.regidate BETWEEN :query_start AND :query_end'
 REG_FILTER_DATE_COLLAPSE = """
  AND (d.regidate BETWEEN :query_start AND :query_end OR

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -413,10 +413,10 @@ def find_all_by_account_id(params: AccountRegistrationParams):
                 mhr_numbers += f"'{mhr_number}'"
             query = text(build_account_query(params, mhr_numbers, doc_types))
             if params.has_filter() and params.filter_reg_start_date and params.filter_reg_end_date:
-                start_date = model_utils.date_from_iso_format(params.filter_reg_start_date)
-                end_date = model_utils.date_from_iso_format(params.filter_reg_end_date)
+                start_ts = model_utils.search_ts_local(params.filter_reg_start_date, True)
+                end_ts = model_utils.search_ts_local(params.filter_reg_end_date, False)
                 result = db.get_engine(current_app, 'db2').execute(query,
-                                                                   {'query_start': start_date, 'query_end': end_date})
+                                                                   {'query_start': start_ts, 'query_end': end_ts})
             else:
                 result = db.get_engine(current_app, 'db2').execute(query)
             rows = result.fetchall()

--- a/mhr_api/src/mhr_api/models/mhr_party.py
+++ b/mhr_api/src/mhr_api/models/mhr_party.py
@@ -41,6 +41,8 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
     email_id = db.Column('email_address', db.String(250), nullable=True)
     phone_number = db.Column('phone_number', db.String(20), nullable=True)
     phone_extension = db.Column('phone_extension', db.String(10), nullable=True)
+    suffix = db.Column('suffix', db.String(100), nullable=True)
+    description = db.Column('description', db.String(150), nullable=True)
 
     # parent keys
     address_id = db.Column('address_id', db.Integer, db.ForeignKey('addresses.id'), nullable=True, index=True)
@@ -97,6 +99,10 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
             party['phoneNumber'] = self.phone_number
         if self.phone_extension:
             party['phoneExtension'] = self.phone_extension
+        if self.description:
+            party['description'] = self.description
+        if self.suffix:
+            party['suffix'] = self.suffix
         return party
 
     @classmethod

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -750,9 +750,11 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             group.group_id = sequence
             # Add owners
             for owner_json in group_json.get('owners'):
-                party_type = MhrPartyTypes.OWNER_BUS
-                if owner_json.get('individualName'):
+                party_type = owner_json.get('partyType', None)
+                if not party_type and owner_json.get('individualName'):
                     party_type = MhrPartyTypes.OWNER_IND
+                elif not party_type:
+                    party_type = MhrPartyTypes.OWNER_BUS
                 group.owners.append(MhrParty.create_from_json(owner_json, party_type, self.id))
             self.owner_groups.append(group)
         # Update interest common denominator
@@ -771,9 +773,11 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 group_id += 1
                 # Add owners
                 for owner_json in group_json.get('owners'):
-                    party_type = MhrPartyTypes.OWNER_BUS
-                    if owner_json.get('individualName'):
+                    party_type = owner_json.get('partyType', None)
+                    if not party_type and owner_json.get('individualName'):
                         party_type = MhrPartyTypes.OWNER_IND
+                    elif not party_type:
+                        party_type = MhrPartyTypes.OWNER_BUS
                     new_group.owners.append(MhrParty.create_from_json(owner_json, party_type, self.id))
                 current_app.logger.info(f'Creating owner group id={group_id} reg id={new_group.registration_id}')
                 self.owner_groups.append(new_group)

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -247,6 +247,7 @@ class MhrPartyTypes(BaseEnum):
     EXECUTOR = 'EXECUTOR'
     ADMINISTRATOR = 'ADMINISTRATOR'
     TRUSTEE = 'TRUSTEE'
+    TRUST = 'TRUST'
 
 
 class MhrRegistrationStatusTypes(BaseEnum):

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -767,3 +767,13 @@ def date_elapsed(date_iso: str):
     today_date = date(now.year, now.month, now.day)
     # current_app.logger.info('Comparing now ' + today_date.isoformat() + ' with expiry ' + test_date.isoformat())
     return today_date > test_date
+
+
+def search_ts_local(date_iso: str, start: bool = True):
+    """Get a search timestamp in local time zone as start or end of day."""
+    date_part = date.fromisoformat(date_iso[0:10])
+    if start:
+        day_time = time(0, 0, 0, tzinfo=LOCAL_TZ)
+        return _datetime.combine(date_part, day_time)
+    day_time = time(23, 59, 59, tzinfo=LOCAL_TZ)
+    return _datetime.combine(date_part, day_time)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.2.1'  # pylint: disable=invalid-name
+__version__ = '1.2.2'  # pylint: disable=invalid-name

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -1408,6 +1408,63 @@
 						"description": "Retrieve the recent history of search requests for the account."
 					},
 					"response": []
+				},
+				{
+					"name": "Create Transfer Due to Death",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"description": "Prism only local mock server header.",
+								"key": "Prefer",
+								"type": "text",
+								"value": "example=/api/v1/searches/1294376/put"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clientReferenceId\": \"EX-TRAND-001\",\n  \"submittingParty\": {\n    \"personName\": {\n      \"first\": \"JOHN\",\n      \"middle\": \"B\",\n      \"last\": \"SMITH\"\n    },\n    \"address\": {\n      \"street\": \"222 SUMMER STREET\",\n      \"city\": \"VICTORIA\",\n      \"region\": \"BC\",\n      \"country\": \"CA\",\n      \"postalCode\": \"V8W 2V8\"\n    },\n    \"emailAddress\": \"jbsmith@gmail.com\",\n    \"phoneNumber\": \"2504930122\",\n    \"phoneExtension\": \"\"\n  },\n  \"deleteOwnerGroups\": [\n    {\n      \"groupId\": 1,\n      \"owners\": [\n        {\n          \"individualName\": {\n            \"first\": \"MARY-ANNE\",\n            \"last\": \"BICKNELL\"\n          },\n          \"address\": {\n            \"street\": \"6665 238TH STREET\",\n            \"city\": \"LANGLEY\",\n            \"region\": \"BC\",\n            \"country\": \"CA\",\n            \"postalCode\": \"V3A 6H4\"\n          },\n          \"phoneNumber\": \"6044620279\",\n          \"ownerId\": 1\n        }\n      ],\n      \"type\": \"SOLE\",\n      \"status\": \"ACTIVE\"\n    }\n  ],\n  \"addOwnerGroups\": [\n    {\n      \"groupId\": 2,\n      \"owners\": [\n        {\n          \"individualName\": {\n            \"first\": \"JOHN\",\n            \"middle\": \"STEVEN\",\n            \"last\": \"CONNOLLY\"\n          },\n          \"partyType\": \"EXECUTOR\",\n          \"description\": \"EXECUTOR OF THE ESTATE OF MARY-ANNE BICKNELL\",\n          \"address\": {\n            \"street\": \"6665 238TH STREET\",\n            \"city\": \"LANGLEY\",\n            \"region\": \"BC\",\n            \"country\": \"CA\",\n            \"postalCode\": \"V3A 6H4\"\n          },\n          \"phoneNumber\": \"6044620279\",\n          \"ownerId\": 2\n        }\n      ],\n      \"type\": \"SOLE\"\n    }\n  ],\n  \"declaredValue\": 78766,\n  \"consideration\": \"$78766.00\",\n  \"transferDate\": \"2022-10-04T20:29:36+00:00\",\n  \"ownLand\": false,\n  \"deathOfOwner\": true\n}\n"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/transfers/125235",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"transfers",
+								"125235"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
 				}
 			]
 		},

--- a/mhr_api/tests/unit/models/test_mhr_party.py
+++ b/mhr_api/tests/unit/models/test_mhr_party.py
@@ -42,6 +42,19 @@ OWNER_IND = {
     'phoneNumber': '6041234567',
     'phoneExtension': '546'
 }
+OWNER_ORG = {
+    'organizationName': 'ORG NAME HERE.',
+    'address': {
+    'street': '3122B LYNNLARK PLACE',
+    'city': 'VICTORIA',
+    'region': 'BC',
+    'postalCode': ' ',
+    'country': 'CA'
+    },
+    'emailAddress': 'bsmith@abc-search.com',
+    'phoneNumber': '6041234567',
+    'phoneExtension': '546'
+}
 SUBMITTING_IND = {
     'personName': {
         'first': 'JANE',
@@ -68,6 +81,19 @@ TEST_IND_DATA = [
 TEST_ID_DATA = [
     (200000000, True),
     (300000000, False)
+]
+# testdata pattern is ({data}, {party_type}, {expected})
+TEST_PARTY_TYPE_DATA = [
+    (OWNER_IND, None, MhrPartyTypes.OWNER_IND),
+    (OWNER_ORG, None, MhrPartyTypes.OWNER_BUS),
+    (OWNER_IND, MhrPartyTypes.ADMINISTRATOR, MhrPartyTypes.ADMINISTRATOR),
+    (OWNER_ORG, MhrPartyTypes.ADMINISTRATOR, MhrPartyTypes.ADMINISTRATOR),
+    (OWNER_IND, MhrPartyTypes.EXECUTOR, MhrPartyTypes.EXECUTOR),
+    (OWNER_ORG, MhrPartyTypes.EXECUTOR, MhrPartyTypes.EXECUTOR),
+    (OWNER_IND, MhrPartyTypes.TRUSTEE, MhrPartyTypes.TRUSTEE),
+    (OWNER_ORG, MhrPartyTypes.TRUSTEE, MhrPartyTypes.TRUSTEE),
+    (OWNER_IND, MhrPartyTypes.TRUST, MhrPartyTypes.TRUST),
+    (OWNER_ORG, MhrPartyTypes.TRUST, MhrPartyTypes.TRUST)
 ]
 
 
@@ -213,3 +239,19 @@ def test_create_ind_from_json(session, middle, email, phone, phone_extension, da
         assert party.phone_extension
     else:
         assert not party.phone_extension
+
+
+@pytest.mark.parametrize('data, party_type, expected', TEST_PARTY_TYPE_DATA)
+def test_party_type_from_json(session, data, party_type, expected):
+    json_data = copy.deepcopy(data)
+    if party_type:
+        json_data['partyType'] = party_type
+        p_type = party_type
+    elif json_data.get('individualName'):
+        p_type = MhrPartyTypes.OWNER_IND
+    else:
+        p_type = MhrPartyTypes.OWNER_BUS
+    party: MhrParty = MhrParty.create_from_json(json_data, p_type, 1000)
+    assert party
+    assert party.party_type == expected
+

--- a/mhr_api/tests/unit/models/test_types.py
+++ b/mhr_api/tests/unit/models/test_types.py
@@ -69,7 +69,7 @@ def test_mhr_party_type(session):
     """Assert that MhrPartyType.find_all() contains all expected elements."""
     results = type_tables.MhrPartyType.find_all()
     assert results
-    assert len(results) == 6
+    assert len(results) == 7
     for result in results:
         assert result.party_type in type_tables.MhrPartyTypes
         assert result.party_type_desc

--- a/ppr-api/requirements.txt
+++ b/ppr-api/requirements.txt
@@ -58,4 +58,4 @@ strict-rfc3339==0.7
 typing-inspect==0.7.1
 typing_extensions==4.0.1
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.5.7#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas

--- a/ppr-api/requirements/bcregistry-libraries.txt
+++ b/ppr-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.5.7#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.7'  # pylint: disable=invalid-name
+__version__ = '1.0.8'  # pylint: disable=invalid-name


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14864

*Description of changes:*
- MHR api update schema version to 1.6.9
- add new transfer death party types ADMINISTRATOR, EXECUTOR, TRUSTEE, TRUST and party description.
- add transfer death validation rules
- 15087 PPR api update schema version to 1.6.9
- Allow mhr account registrations filter partial match on username anywhere in the name.
- Update  mhr account filter date range to use timestamps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
