### PR TITLE
Add search report messages.

### DIFF
--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -75,11 +75,6 @@
                             {% endif %}
                         </td>
                     </tr>
-                    {% if note.documentType == 'CAUC' and (note.expiryDate is not defined or note.expiryDate == '') %}
-                    <tr>
-                        <td class="section-sub-title pt-2" colspan="2">Continued until further order of the court.</td>
-                    </tr>
-                    {% endif %}
             </table>
             </div>
         {% endif %}    

--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -7,76 +7,74 @@
     </div>
 
     {% for note in detail.notes %}
-        {% if note.documentType not in ('103', '103E', 'STAT') %}
-            <div class="no-page-break">
-                <div class="section-title mt-4">{{note.documentDescription}}</div>      
-                <table class="no-page-break section-data details-table mt-4" role="presentation">
-                    <tr>
-                        <td class="section-sub-title">MHR Number:</td>
-                        <td>{{detail.mhrNumber}}</td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title">Document Number:</td>
-                        <td>{{note.documentId}}</td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title">Registration Date and Time:</td>
-                        <td>{{note.createDateTime}}</td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title">
-                            {% if note.documentType == 'EXNR' %}Destroyed Date:{% else %}Expired Date:{% endif %}
-                        </td>
-                        <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
-                                {{note.expiryDate}}
+        <div class="no-page-break">
+            <div class="section-title mt-4">{{note.documentDescription}}</div>      
+            <table class="no-page-break section-data details-table mt-4" role="presentation">
+                <tr>
+                    <td class="section-sub-title">MHR Number:</td>
+                    <td>{{detail.mhrNumber}}</td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title">Document Number:</td>
+                    <td>{{note.documentId}}</td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title">Registration Date and Time:</td>
+                    <td>{{note.createDateTime}}</td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title">
+                        {% if note.documentType == 'EXNR' %}Destroyed Date:{% else %}Expired Date:{% endif %}
+                    </td>
+                    <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
+                            {{note.expiryDate}}
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title">Remarks:</td>
+                    <td>{% if note.remarks is defined and note.remarks != '' %} 
+                            {{note.remarks}}
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title pt-2">Contact:</td>
+                    <td class="pt-2">
+                        <div>
+                            {% if note.contactName is defined and note.contactName != '' %}
+                                {{note.contactName}}
                             {% else %}
                                 N/A
                             {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title">Remarks:</td>
-                        <td>{% if note.remarks is defined and note.remarks != '' %} 
-                                {{note.remarks}}
-                            {% else %}
-                                N/A
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title pt-2">Contact:</td>
-                        <td class="pt-2">
+                        </div>
+                        {% if note.contactAddress is defined and note.contactAddress.street != '' %}
+                            <div>{{ note.contactAddress.street }}</div>
+                            <div>{{ note.contactAddress.streetAdditional }}</div>
+                            <div>{{ note.contactAddress.city }} {{ note.contactAddress.region }}</div>
                             <div>
-                                {% if note.contactName is defined and note.contactName != '' %}
-                                    {{note.contactName}}
-                                {% else %}
-                                    N/A
+                                {% if note.contactAddress.postalCode is defined and note.contactAddress.postalCode != '' %}
+                                    {{ note.contactAddress.postalCode }}&nbsp;&nbsp; 
                                 {% endif %}
+                                {{ note.contactAddress.country }}
                             </div>
-                            {% if note.contactAddress is defined and note.contactAddress.street != '' %}
-                                <div>{{ note.contactAddress.street }}</div>
-                                <div>{{ note.contactAddress.streetAdditional }}</div>
-                                <div>{{ note.contactAddress.city }} {{ note.contactAddress.region }}</div>
-                                <div>
-                                    {% if note.contactAddress.postalCode is defined and note.contactAddress.postalCode != '' %}
-                                        {{ note.contactAddress.postalCode }}&nbsp;&nbsp; 
-                                    {% endif %}
-                                    {{ note.contactAddress.country }}
-                                </div>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="section-sub-title">Phone:</td>
-                        <td>{% if note.contactPhoneNumber is defined and note.contactPhoneNumber != '' %} 
-                                {{note.contactPhoneNumber}}
-                            {% else %}
-                                N/A
-                            {% endif %}
-                        </td>
-                    </tr>
-            </table>
-            </div>
-        {% endif %}    
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="section-sub-title">Phone:</td>
+                    <td>{% if note.contactPhoneNumber is defined and note.contactPhoneNumber != '' %} 
+                            {{note.contactPhoneNumber}}
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </td>
+                </tr>
+        </table>
+        </div>
     {% endfor %}
 {% endif %}

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -85,6 +85,22 @@
     {% endif %}
   </div>
 
+  {% if detail.messages is defined %}
+    {% for message in detail.messages %}
+      <div class="no-page-break section-data pt-5">
+        {% if message.messageType == 'OUT_PROV' %}
+          Upon leaving British Columbia, this home is Exempted from the <span class="italic">Manufactured Home Act</span>. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
+        {% elif message.messageType == 'REGC' %}
+          Registration of this home was cancelled under Section 11(1) of the <span class="italic">Manufactured Home Act</span> by the Registrar of Manufactured Homes.
+        {% elif message.messageType == 'WIDTH' %}
+          SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
+        {% elif message.messageType in ('EXNR', 'EXRS') %}
+          Exempted pursuant to Section 21 of the <span class="italic">Manufactured Home Act</span> by an order of the Registrar dated {{message.messageDate}} on document registration number {{message.messageId}}.
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
+
 </div>
 
 {% if detail.pprRegistrations is defined %}

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -63,23 +63,6 @@
   [[search-result/location.html]]
   [[search-result/details.html]]
   [[search-result/sections.html]]
-  [[search-result/notes.html]]
-
-  {% if detail.messages is defined %}
-    {% for message in detail.messages %}
-      <div class="no-page-break section-data pt-5">
-        {% if message.messageType == 'OUT_PROV' %}
-          Upon leaving British Columbia, this home is Exempted from the <span class="italic">Manufactured Home Act</span>. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
-        {% elif message.messageType == 'REGC' %}
-          Registration of this home was cancelled under Section 11(1) of the <span class="italic">Manufactured Home Act</span> by the Registrar of Manufactured Homes.
-        {% elif message.messageType == 'WIDTH' %}
-          SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
-        {% elif message.messageType in ('EXNR', 'EXRS') %}
-          Exempted pursuant to Section 21 of the <span class="italic">Manufactured Home Act</span> by an order of the Registrar dated {{message.messageDate}} on document registration number {{message.messageId}}.
-        {% endif %}
-      </div>
-    {% endfor %}
-  {% endif %}
 
   <div class="no-page-break">
     <div class="separator mt-5"></div>
@@ -100,6 +83,24 @@
       <div class="section-data pt-3">N/A</div>
     {% endif %}
   </div>
+
+  [[search-result/notes.html]]
+
+  {% if detail.messages is defined %}
+    {% for message in detail.messages %}
+      <div class="no-page-break section-data pt-5">
+        {% if message.messageType == 'OUT_PROV' %}
+          Upon leaving British Columbia, this home is Exempted from the <span class="italic">Manufactured Home Act</span>. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
+        {% elif message.messageType == 'REGC' %}
+          Registration of this home was cancelled under Section 11(1) of the <span class="italic">Manufactured Home Act</span> by the Registrar of Manufactured Homes.
+        {% elif message.messageType == 'WIDTH' %}
+          SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
+        {% elif message.messageType in ('EXNR', 'EXRS') %}
+          Exempted pursuant to Section 21 of the <span class="italic">Manufactured Home Act</span> by an order of the Registrar dated {{message.messageDate}} on document registration number {{message.messageId}}.
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
 
 </div>
 

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -65,6 +65,22 @@
   [[search-result/sections.html]]
   [[search-result/notes.html]]
 
+  {% if detail.messages is defined %}
+    {% for message in detail.messages %}
+      <div class="no-page-break section-data pt-5">
+        {% if message.messageType == 'OUT_PROV' %}
+          Upon leaving British Columbia, this home is Exempted from the <span class="italic">Manufactured Home Act</span>. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
+        {% elif message.messageType == 'REGC' %}
+          Registration of this home was cancelled under Section 11(1) of the <span class="italic">Manufactured Home Act</span> by the Registrar of Manufactured Homes.
+        {% elif message.messageType == 'WIDTH' %}
+          SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
+        {% elif message.messageType in ('EXNR', 'EXRS') %}
+          Exempted pursuant to Section 21 of the <span class="italic">Manufactured Home Act</span> by an order of the Registrar dated {{message.messageDate}} on document registration number {{message.messageId}}.
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
+
   <div class="no-page-break">
     <div class="separator mt-5"></div>
     <div class="section-title mt-3">Rebuilt Status</div>
@@ -84,22 +100,6 @@
       <div class="section-data pt-3">N/A</div>
     {% endif %}
   </div>
-
-  {% if detail.messages is defined %}
-    {% for message in detail.messages %}
-      <div class="no-page-break section-data pt-5">
-        {% if message.messageType == 'OUT_PROV' %}
-          Upon leaving British Columbia, this home is Exempted from the <span class="italic">Manufactured Home Act</span>. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
-        {% elif message.messageType == 'REGC' %}
-          Registration of this home was cancelled under Section 11(1) of the <span class="italic">Manufactured Home Act</span> by the Registrar of Manufactured Homes.
-        {% elif message.messageType == 'WIDTH' %}
-          SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
-        {% elif message.messageType in ('EXNR', 'EXRS') %}
-          Exempted pursuant to Section 21 of the <span class="italic">Manufactured Home Act</span> by an order of the Registrar dated {{message.messageDate}} on document registration number {{message.messageId}}.
-        {% endif %}
-      </div>
-    {% endfor %}
-  {% endif %}
 
 </div>
 

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -199,6 +199,10 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                     current_app.logger.debug('updating doc type=' + doc_type)
                     if not self.staff and doc_type == 'FZE':  # Only staff can see remarks.
                         note['remarks'] = ''
+                    elif not self.staff and doc_type == 'REGC' and note.get('remarks') and \
+                            note['remarks'] != 'MANUFACTURED HOME REGISTRATION CANCELLED':
+                        # Only staff can see remarks if not default.
+                        note['remarks'] = 'MANUFACTURED HOME REGISTRATION CANCELLED'
                     elif doc_type == 'TAXN' and note.get('status') != 'A':  # Conditionally display remarks.
                         note['remarks'] = ''
                     # No remarks if expiry elapsed.

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -192,11 +192,16 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         if self.manuhome:
             reg_json = self.manuhome.registration_json
             # Inject note document type descriptions here. Apply all unit note business rules here.
+            # Exclude STAT, 103, 103E, and CAU, CAUC, CAUE if expiry date has elapsed.
             if reg_json and reg_json.get('notes'):
+                updated_notes = []
                 for note in reg_json.get('notes'):
+                    include: bool = True
                     doc_desc = ''
                     doc_type = note.get('documentType', '')
                     current_app.logger.debug('updating doc type=' + doc_type)
+                    if doc_type in ('103', '103E', 'STAT'):  # Always exclude
+                        include = False
                     if not self.staff and doc_type == 'FZE':  # Only staff can see remarks.
                         note['remarks'] = ''
                     elif not self.staff and doc_type == 'REGC' and note.get('remarks') and \
@@ -205,10 +210,10 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                         note['remarks'] = 'MANUFACTURED HOME REGISTRATION CANCELLED'
                     elif doc_type == 'TAXN' and note.get('status') != 'A':  # Conditionally display remarks.
                         note['remarks'] = ''
-                    # No remarks if expiry elapsed.
+                    # Exlude if expiry elapsed.
                     elif doc_type in ('CAU', 'CAUC', 'CAUE') and note.get('expiryDate') and \
                             model_utils.date_elapsed(note.get('expiryDate')):
-                        note['remarks'] = ''
+                        include = False
                     if doc_type == 'FZE':  # Do not display contact info.
                         if note.get('contactName'):
                             del note['contactName']
@@ -216,12 +221,15 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                             del note['contactAddress']
                         if note.get('contactPhoneNumber'):
                             del note['contactPhoneNumber']
-                    if FROM_LEGACY_DOC_TYPE.get(doc_type):
-                        doc_type = FROM_LEGACY_DOC_TYPE.get(doc_type)
-                    doc_type_info: MhrDocumentType = MhrDocumentType.find_by_doc_type(doc_type)
-                    if doc_type_info:
-                        doc_desc = doc_type_info.document_type_desc
-                    note['documentDescription'] = doc_desc
+                    if include:
+                        if FROM_LEGACY_DOC_TYPE.get(doc_type):
+                            doc_type = FROM_LEGACY_DOC_TYPE.get(doc_type)
+                        doc_type_info: MhrDocumentType = MhrDocumentType.find_by_doc_type(doc_type)
+                        if doc_type_info:
+                            doc_desc = doc_type_info.document_type_desc
+                        note['documentDescription'] = doc_desc
+                        updated_notes.append(note)
+                reg_json['notes'] = updated_notes
             return reg_json
         return self.json
 

--- a/mhr_api/src/mhr_api/models/search_result.py
+++ b/mhr_api/src/mhr_api/models/search_result.py
@@ -95,8 +95,10 @@ class SearchResult(db.Model):  # pylint: disable=too-many-instance-attributes
         detail_response = {
             'searchDateTime': model_utils.format_ts(self.search.search_ts),
             'searchQuery': self.search.search_criteria,
-            'certified': certified
+            'certified': False
         }
+        if certified:
+            detail_response['certified'] = True
         client_ref: str = '' if not self.search.client_reference_id else self.search.client_reference_id
         detail_response['searchQuery']['clientReferenceId'] = client_ref
         if self.search.pay_invoice_id and self.search.pay_path:

--- a/mhr_api/tests/unit/reports/data/search-detail-notes-example.json
+++ b/mhr_api/tests/unit/reports/data/search-detail-notes-example.json
@@ -106,23 +106,6 @@
             "street": "5612 YALTA PLACE"
           }, 
           "contactName": "CHRISTOPHER DEAN GUDERYAN", 
-          "contactPhoneNumber": "2505407761", 
-          "createDateTime": "2021-10-29T16:26:00-07:53", 
-          "documentDescription": "CONTINUE CAUTION", 
-          "documentId": "63056537", 
-          "documentType": "CAUC", 
-          "expiryDate": "2021-11-15T09:00:00-07:53", 
-          "remarks": "", 
-          "status": "E"
-        }, {
-          "contactAddress": {
-            "city": "VANCOUVER", 
-            "country": "CA", 
-            "postalCode": "V6T 2C2", 
-            "region": "BC", 
-            "street": "5612 YALTA PLACE"
-          }, 
-          "contactName": "CHRISTOPHER DEAN GUDERYAN", 
           "createDateTime": "2021-10-22T15:34:00-07:53", 
           "documentDescription": "EXTEND CAUTION", 
           "documentId": "63056323", 
@@ -130,56 +113,6 @@
           "expiryDate": "2023-06-30T09:00:00-07:53", 
           "remarks": "CAUTION EXTENSION FOR 7 DAYS UNTIL COURT ORDER IS SIGNED AND SUBMITTEDDOCUMENT REGISTRATION # 451621 UNTIL OCTOBER 31 2021 WITH LIBERTY TO  APPLY FOR A FURTHER CONTINUATION.                                     SUPREME COURT OF BC VANCOUVER REGISTRY NO# S210218                    COURT FILE # VLC-S-S-210218", 
           "status": "E"
-        }, {
-          "contactAddress": {
-            "city": "PRINCE GEORGE", 
-            "country": "CA", 
-            "postalCode": "V2L 3L4", 
-            "region": "BC", 
-            "street": "1396 5TH AVENUE, SUITE 201"
-          }, 
-          "contactName": "ANDREW KEMP C/O LLOYD PERCIVAL MURRAY", 
-          "contactPhoneNumber": "2505645544", 
-          "createDateTime": "2021-04-01T17:00:00-07:53", 
-          "documentDescription": "EXTEND CAUTION", 
-          "documentId": "62875618", 
-          "documentType": "CAUE", 
-          "expiryDate": "2021-04-16T09:00:00-07:53", 
-          "remarks": "", 
-          "status": "C"
-        }, {
-          "contactAddress": {
-            "city": "PRINCE GEORGE", 
-            "country": "CA", 
-            "postalCode": "V2L 3L4", 
-            "region": "BC", 
-            "street": "1396 5TH AVENUE, SUITE 201"
-          }, 
-          "contactName": "ANDREW KEMP C/O LLOYD PERCIVAL MURRAY", 
-          "contactPhoneNumber": "2505645544", 
-          "createDateTime": "2020-12-03T09:20:00-07:53", 
-          "documentDescription": "CAUTION", 
-          "documentId": "62859743", 
-          "documentType": "CAU", 
-          "expiryDate": "2021-03-03T09:00:00-07:53", 
-          "remarks": "", 
-          "status": "C"
-        }, {
-          "contactAddress": {
-            "city": "PENTICTON",
-            "country": "CA",
-            "postalCode": "V2A 5X5",
-            "region": "BC",
-            "street": "1175 RAILWAY STREET"
-          },
-          "contactName": "CHAMPION CANADA INTERNATIONAL ULC",
-          "contactPhoneNumber": "2504930122",
-          "createDateTime": "2014-04-03T15:44:26-07:53",
-          "documentDescription": "TRANSPORT PERMIT",
-          "documentId": "80031322",
-          "documentType": "103",
-          "expiryDate": "2014-05-03T09:00:00-07:53",
-          "remarks": ""
         }, {
           "contactAddress": {
             "city": "SURREY", 
@@ -241,20 +174,19 @@
           "status": "C"
         }, {
           "contactAddress": {
-            "city": "KELOWNA", 
+            "city": "VICTORIA", 
             "country": "CA", 
-            "postalCode": "V4V 1S5", 
+            "postalCode": "V8W 3E6", 
             "region": "BC", 
-            "street": "9500 JIM BAILEY ROAD"
+            "street": "940 BLANSHARD STREET"
           }, 
-          "contactName": "SRI HOMES INC (WINFIELD)", 
+          "contactName": "REGISTRAR OF MANUFACTURED HOMES.", 
           "contactPhoneNumber": "604", 
-          "createDateTime": "1996-02-02T15:44:50-07:53", 
-          "documentDescription": "EXTEND TRAN PERMIT", 
-          "documentId": "42477667", 
-          "documentType": "103E", 
-          "expiryDate": "1996-02-19T09:00:00-07:53", 
-          "remarks": "", 
+          "createDateTime": "1997-04-03T13:21:58-07:53", 
+          "documentDescription": "REGISTRARS CORRECTION", 
+          "documentId": "42413815", 
+          "documentType": "REGC", 
+          "remarks": "MANUFACTURED HOME REGISTRATION CANCELLED                              THIS HOME WAS REGISTERED TWICE UNDER NUMBERS 78831 AND 78855. PLEASE  REFER TO FILE 78855 FOR FURTHER DETAILS ON THIS HOME.", 
           "status": "A"
         }, {
           "contactAddress": {


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#14924

*Description of changes:*
- Add search report messages based on the mh registration state and history.
- Further changes to message position and text case are waiting on a BA decision.
- 14095 new REGC unit note requirement. CAUC do not display duplicate text. CAU, CAUE, CAUC do not include if expiry date elapsed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
