### PR TITLE
14825 remove optional first name in search

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/search/SearchBar.vue
+++ b/ppr-ui/src/components/search/SearchBar.vue
@@ -87,7 +87,7 @@
                   filled
                   :hint="searchHintFirst"
                   persistent-hint
-                  :label="optionFirst"
+                  label="First Name"
                   v-model="searchValueFirst"
                   @keypress.enter="searchCheck()"
                 />
@@ -374,9 +374,6 @@ export default defineComponent({
       }),
       searchMessage: computed((): string => {
         return localState.validations?.searchValue?.message || ''
-      }),
-      optionFirst: computed((): string => {
-        return isRoleStaffReg.value ? 'First Name (Optional)' : 'First Name'
       }),
       typeOfSearch: computed((): string => {
         // only show the type of search if authorized to both types

--- a/ppr-ui/src/components/search/SearchBar.vue
+++ b/ppr-ui/src/components/search/SearchBar.vue
@@ -87,7 +87,7 @@
                   filled
                   :hint="searchHintFirst"
                   persistent-hint
-                  label="First Name"
+                  :label="optionFirst"
                   v-model="searchValueFirst"
                   @keypress.enter="searchCheck()"
                 />
@@ -374,6 +374,10 @@ export default defineComponent({
       }),
       searchMessage: computed((): string => {
         return localState.validations?.searchValue?.message || ''
+      }),
+      optionFirst: computed((): string => {
+        return isRoleStaffReg.value && isMHRSearchType(localState.selectedSearchType?.searchTypeAPI)
+          ? 'First Name (Optional)' : 'First Name'
       }),
       typeOfSearch: computed((): string => {
         // only show the type of search if authorized to both types

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -79,7 +79,9 @@
         transition="fade-transition"
       >
         <template v-slot:activator="{ on, attrs }">
-          <v-icon color="primary" small v-bind="attrs" v-on="on">mdi-information-outline</v-icon>
+          <v-icon style="vertical-align: baseline" color="primary" small v-bind="attrs" v-on="on">
+            mdi-information-outline
+          </v-icon>
         </template>
         <div class="pt-2 pb-2">
           The records for this registration were converted from paper to digital format on November 14, 1995, and may


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14825

*Description of changes:*
-Removed "(Optional)" text for Debtor Name search First name text field for staff accounts
-Fixed icon alignment for ticket #15029
![image](https://user-images.githubusercontent.com/112968185/214414312-3fdd2b4d-c7aa-42f1-bc23-9b690e638e07.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
