### PR TITLE
Search results return activeCount, exemptCount, historicalCount for o…

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -202,7 +202,9 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                     current_app.logger.debug('updating doc type=' + doc_type)
                     if doc_type in ('103', '103E', 'STAT'):  # Always exclude
                         include = False
-                    if not self.staff and doc_type in ('FZE', '102', 'NCON'):  # Only staff can see remarks.
+                    elif not self.staff and doc_type in ('102', 'NCON'):  # Always exclude for non-staff
+                        include = False
+                    elif not self.staff and doc_type == 'FZE':  # Only staff can see remarks.
                         note['remarks'] = ''
                     elif not self.staff and doc_type == 'REGC' and note.get('remarks') and \
                             note['remarks'] != 'MANUFACTURED HOME REGISTRATION CANCELLED':

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -202,7 +202,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                     current_app.logger.debug('updating doc type=' + doc_type)
                     if doc_type in ('103', '103E', 'STAT'):  # Always exclude
                         include = False
-                    if not self.staff and doc_type == 'FZE':  # Only staff can see remarks.
+                    if not self.staff and doc_type in ('FZE', '102', 'NCON'):  # Only staff can see remarks.
                         note['remarks'] = ''
                     elif not self.staff and doc_type == 'REGC' and note.get('remarks') and \
                             note['remarks'] != 'MANUFACTURED HOME REGISTRATION CANCELLED':

--- a/mhr_api/src/mhr_api/models/search_result.py
+++ b/mhr_api/src/mhr_api/models/search_result.py
@@ -200,28 +200,6 @@ class SearchResult(db.Model):  # pylint: disable=too-many-instance-attributes
         else:
             self.search_select = final_selection
 
-    def set_search_selection_last(self, update_select):
-        """Sort the selection for the report TOC."""
-        original_results = self.search.search_response
-        final_selection = []
-        for result in original_results:
-            for match in update_select:
-                if result['mhrNumber'] == match['mhrNumber']:
-                    if match.get('includeLienInfo', False):
-                        result['includeLienInfo'] = match.get('includeLienInfo')
-                    final_selection.append(result)
-                    break
-
-        # Now sort by search type.
-        if self.search.search_type == SearchRequest.SearchTypes.OWNER_NAME:
-            self.search_select = SearchResult.__sort_owner_ind(final_selection)
-        if self.search.search_type == SearchRequest.SearchTypes.ORGANIZATION_NAME:
-            self.search_select = SearchResult.__sort_owner_org(final_selection)
-        if self.search.search_type == SearchRequest.SearchTypes.SERIAL_NUM:
-            self.search_select = SearchResult.__sort_serial_num(final_selection)
-        else:
-            self.search_select = final_selection
-
     @classmethod
     def __sort_serial_num(cls, update_select):
         """Sort selected serial numbers."""

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.2.2'  # pylint: disable=invalid-name
+__version__ = '1.2.3'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_db2_search_request.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_search_request.py
@@ -200,6 +200,9 @@ def test_search_valid(session, search_type, json_data):
     for match in result['results']:
         assert match['mhrNumber']
         assert match['status']
+        assert match.get('activeCount') >= 0
+        assert match.get('exemptCount') >= 0
+        assert match.get('historicalCount') >= 0
         assert match['createDateTime']
         assert match['homeLocation']
         assert match['serialNumber']

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -137,6 +137,112 @@ MS_NONE_JSON = {
     },
     'clientReferenceId': 'T-SQ-MS-4'
 }
+UPDATE_RESULTS_ORG_BASE = [
+    {
+        'mhrNumber': '003456',
+        'organizationName': 'TEST LTD.',
+        'activeCount': 1,
+        'exemptCount': 0,
+        'historicalCount': 0
+    }
+]
+UPDATE_ORG_RESULT_1 = {
+    'mhrNumber': '003456',
+    'organizationName': 'TEST LTD.',
+    'activeCount': 0,
+    'exemptCount': 1,
+    'historicalCount': 0
+}
+UPDATE_ORG_RESULT_2 = {
+    'mhrNumber': '003456',
+    'organizationName': 'TEST LTD.',
+    'activeCount': 0,
+    'exemptCount': 0,
+    'historicalCount': 1
+}
+UPDATE_ORG_RESULT_3 = {
+    'mhrNumber': '003457',
+    'organizationName': 'TEST LTD.',
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+UPDATE_ORG_RESULT_4 = {
+    'mhrNumber': '003458',
+    'organizationName': 'TEST LTD.',
+    'activeCount': 0,
+    'exemptCount': 1,
+    'historicalCount': 0
+}
+ORG_NAME_JSON_COLLAPSE = {
+    'type': 'ORGANIZATION_NAME',
+    'criteria': {
+        'value': 'RANCOURT HOLDINGS LTD.'
+    },
+    'clientReferenceId': 'T-SQ-MO-2'
+}
+OWNER_NAME_JSON_COLLAPSE = {
+    'type': 'OWNER_NAME',
+    'criteria': {
+        'ownerName': {
+            'first': 'GAYLEEN',
+            'last': 'ALEXANDER'
+        }
+    },
+    'clientReferenceId': 'T-SQ-MI-3'
+}
+UPDATE_RESULTS_OWNER_BASE = [
+    {
+        'mhrNumber': '003456',
+        'ownerName': {
+            'first': 'JOHN',
+            'last': 'SMITH'
+        },
+        'activeCount': 1,
+        'exemptCount': 0,
+        'historicalCount': 0
+    }
+]
+UPDATE_OWNER_RESULT_1 = {
+    'mhrNumber': '003456',
+    'ownerName': {
+        'first': 'JOHN',
+        'last': 'SMITH'
+    },
+    'activeCount': 0,
+    'exemptCount': 1,
+    'historicalCount': 0
+}
+UPDATE_OWNER_RESULT_2 = {
+    'mhrNumber': '003456',
+    'ownerName': {
+        'first': 'JOHN',
+        'last': 'SMITH'
+    },
+    'activeCount': 0,
+    'exemptCount': 0,
+    'historicalCount': 1
+}
+UPDATE_OWNER_RESULT_3 = {
+    'mhrNumber': '003457',
+    'ownerName': {
+        'first': 'JOHN',
+        'last': 'SMITH'
+    },
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+UPDATE_OWNER_RESULT_4 = {
+    'mhrNumber': '003458',
+    'ownerName': {
+        'first': 'JOHN',
+        'last': 'SMITH'
+    },
+    'activeCount': 0,
+    'exemptCount': 1,
+    'historicalCount': 0
+}
 
 # testdata pattern is ({search type}, {JSON data})
 TEST_VALID_DATA = [
@@ -179,7 +285,28 @@ TEST_SERIAL_NUMBER_DATA = [
 # testdata pattern is ({last_name}, {first_name}, count)
 TEST_OWNER_IND_DATA = [
     ('Hamm', 'David', 2),
-    ('Hamm', '', 250)
+    ('Hamm', '', 245)
+]
+# testdata pattern is ({result1}, {result2}, {result_count}, {active_count}, {exempt_count}, {historical_count})
+TEST_UPDATE_DATA_ORG = [
+    (UPDATE_ORG_RESULT_1, None, 1, 1, 1, 0),
+    (UPDATE_ORG_RESULT_2, None, 1, 1, 0, 1),
+    (UPDATE_ORG_RESULT_1, UPDATE_ORG_RESULT_2, 1, 1, 1, 1),
+    (UPDATE_ORG_RESULT_1, UPDATE_ORG_RESULT_3, 2, 1, 1, 0),
+    (UPDATE_ORG_RESULT_3, UPDATE_ORG_RESULT_4, 3, 1, 0, 0)
+]
+# testdata pattern is ({result1}, {result2}, {result_count}, {active_count}, {exempt_count}, {historical_count})
+TEST_UPDATE_DATA_OWNER = [
+    (UPDATE_OWNER_RESULT_1, None, 1, 1, 1, 0),
+    (UPDATE_OWNER_RESULT_2, None, 1, 1, 0, 1),
+    (UPDATE_OWNER_RESULT_1, UPDATE_OWNER_RESULT_2, 1, 1, 1, 1),
+    (UPDATE_OWNER_RESULT_1, UPDATE_OWNER_RESULT_3, 2, 1, 1, 0),
+    (UPDATE_OWNER_RESULT_3, UPDATE_OWNER_RESULT_4, 3, 1, 0, 0)
+]
+# testdata pattern is ({mhr_num}, {search_data}, {active_count}, {exempt_count}, {historical_count})
+TEST_COLLAPSE_DATA = [
+    ('091688', ORG_NAME_JSON_COLLAPSE, 1, 0, 2),
+    ('005520', OWNER_NAME_JSON_COLLAPSE, 1, 0, 5)
 ]
 
 
@@ -220,6 +347,9 @@ def test_search_valid(session, search_type, json_data):
         assert match['mhrNumber']
         if match['mhrNumber'] != '089036':  # bogus incomplete data
             assert match['status']
+            assert match.get('activeCount') >= 0
+            assert match.get('exemptCount') >= 0
+            assert match.get('historicalCount') >= 0
             assert match['createDateTime']
             assert match['homeLocation']
             assert match['serialNumber']
@@ -334,3 +464,54 @@ def test_search_owner_ind(session, last_name, first_name, count):
     assert len(result.get('results')) >= count
     for match in result.get('results'):
         assert str(match['ownerName'].get('last')).startswith(last)
+
+
+@pytest.mark.parametrize('result1,result2,result_count,active_count,exempt_count,historical_count',
+                         TEST_UPDATE_DATA_ORG)
+def test_update_result_org(session, result1, result2, result_count, active_count, exempt_count, historical_count):
+    """Assert that a search consolidating/collapsing results works as expected."""
+    results = copy.deepcopy(UPDATE_RESULTS_ORG_BASE)
+    if result1:
+        SearchRequest.update_result_matches(results, result1, SearchRequest.SearchTypes.ORGANIZATION_NAME)
+    if result2:
+        SearchRequest.update_result_matches(results, result2, SearchRequest.SearchTypes.ORGANIZATION_NAME)
+    assert len(results) == result_count
+    match = results[0]
+    assert match.get('activeCount') == active_count
+    assert match.get('exemptCount') == exempt_count
+    assert match.get('historicalCount') == historical_count
+
+
+@pytest.mark.parametrize('result1,result2,result_count,active_count,exempt_count,historical_count',
+                         TEST_UPDATE_DATA_OWNER)
+def test_update_result_owner(session, result1, result2, result_count, active_count, exempt_count, historical_count):
+    """Assert that a search consolidating/collapsing results works as expected."""
+    results = copy.deepcopy(UPDATE_RESULTS_OWNER_BASE)
+    if result1:
+        SearchRequest.update_result_matches(results, result1, SearchRequest.SearchTypes.OWNER_NAME)
+    if result2:
+        SearchRequest.update_result_matches(results, result2, SearchRequest.SearchTypes.OWNER_NAME)
+    assert len(results) == result_count
+    match = results[0]
+    assert match.get('activeCount') == active_count
+    assert match.get('exemptCount') == exempt_count
+    assert match.get('historicalCount') == historical_count
+
+
+@pytest.mark.parametrize('mhr_num,json_data,active_count,exempt_count,historical_count', TEST_COLLAPSE_DATA)
+def test_search_collapse(session, mhr_num, json_data, active_count, exempt_count, historical_count):
+    """Assert that a search returns the expected result with multiple matches within an MH registration."""
+    test_data = copy.deepcopy(json_data)
+    test_data['type'] = model_utils.TO_DB_SEARCH_TYPE[json_data['type']]
+    # current_app.logger.info('type=' + str(json_data['type']))
+    query: SearchRequest = SearchRequest.create_from_json(json_data, 'PS12345', 'UNIT_TEST')
+    query.search()
+    assert not query.updated_selection
+    result = query.json
+    # current_app.logger.debug('Results size:' + str(result['totalResultsSize']))
+    assert len(result['results']) >= 1
+    for match in result['results']:
+        if match['mhrNumber'] == mhr_num:
+            assert match.get('activeCount') == active_count
+            assert match.get('exemptCount') == exempt_count
+            assert match.get('historicalCount') == historical_count

--- a/mhr_api/tests/unit/models/test_search_result.py
+++ b/mhr_api/tests/unit/models/test_search_result.py
@@ -319,13 +319,18 @@ def test_search_sort_serial(session, client, jwt, mhr1, mhr2, mhr3, mhr4):
     sorted_data = search_result.search_select
 
     # check
-    assert len(sorted_data) == 4
+    assert len(sorted_data) == 3
     assert sorted_data[0]['mhrNumber'] == '022911'
     assert sorted_data[1]['mhrNumber'] == '002200'
-    assert sorted_data[1]['serialNumber'] == '2427'
-    assert sorted_data[2]['mhrNumber'] == '002200'
-    assert sorted_data[2]['serialNumber'] == '9427'
-    assert sorted_data[3]['mhrNumber'] == '001999'
+    assert sorted_data[1]['serialNumber'] == '9427'
+    assert sorted_data[2]['mhrNumber'] == '001999'
+    assert sorted_data[1].get('extraMatches')
+    assert not sorted_data[0].get('extraMatches')
+    assert not sorted_data[2].get('extraMatches')
+    extra = sorted_data[1].get('extraMatches')
+    assert len(extra) == 1
+    assert extra[0].get('mhrNumber') == '002200'
+    assert extra[0].get('serialNumber') == '2427'
 
 
 @pytest.mark.parametrize('mhr1,mhr2,mhr3,mhr4', TEST_SELECT_SORT_DATA_ORG)
@@ -348,13 +353,18 @@ def test_search_sort_org(session, client, jwt, mhr1, mhr2, mhr3, mhr4):
     sorted_data = search_result.search_select
 
     # check
-    assert len(sorted_data) == 4
+    assert len(sorted_data) == 3
     assert sorted_data[0]['mhrNumber'] == '022911'
     assert sorted_data[1]['mhrNumber'] == '002200'
     assert sorted_data[1]['organizationName'] == 'CRYSTAL POND DESIGN LIMITED'
-    assert sorted_data[2]['mhrNumber'] == '002200'
-    assert sorted_data[2]['organizationName'] == 'CRYSTAL RIVER COURT LTD.'
-    assert sorted_data[3]['mhrNumber'] == '001999'
+    assert sorted_data[2]['mhrNumber'] == '001999'
+    assert sorted_data[1].get('extraMatches')
+    assert not sorted_data[0].get('extraMatches')
+    assert not sorted_data[2].get('extraMatches')
+    extra = sorted_data[1].get('extraMatches')
+    assert len(extra) == 1
+    assert extra[0].get('mhrNumber') == '002200'
+    assert extra[0].get('organizationName') == 'CRYSTAL RIVER COURT LTD.'
 
 
 @pytest.mark.parametrize('mhr1,mhr2,mhr3,mhr4', TEST_SELECT_SORT_DATA_IND)
@@ -377,10 +387,15 @@ def test_search_sort_ind(session, client, jwt, mhr1, mhr2, mhr3, mhr4):
     sorted_data = search_result.search_select
 
     # check
-    assert len(sorted_data) == 4
+    assert len(sorted_data) == 3
     assert sorted_data[0]['mhrNumber'] == '022911'
     assert sorted_data[1]['mhrNumber'] == '002200'
     assert sorted_data[1]['ownerName']['first'] == 'JANE'
-    assert sorted_data[2]['mhrNumber'] == '002200'
-    assert sorted_data[2]['ownerName']['first'] == 'JOHN'
-    assert sorted_data[3]['mhrNumber'] == '001999'
+    assert sorted_data[2]['mhrNumber'] == '001999'
+    assert sorted_data[1].get('extraMatches')
+    assert not sorted_data[0].get('extraMatches')
+    assert not sorted_data[2].get('extraMatches')
+    extra = sorted_data[1].get('extraMatches')
+    assert len(extra) == 1
+    assert extra[0].get('mhrNumber') == '002200'
+    assert extra[0].get('ownerName')['first'] == 'JOHN'


### PR DESCRIPTION
…wner status.

Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#15061

*Description of changes:*
- Collapse search results with identical names within a MH registration. 
- Also refactor search results to facilitate transition from DB2 to Postgres
- Also align search report regeneration with registration report regeneration. 
- 14095 only display NCON, 102 document type remarks for staff.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
