### PR TITLE
Search results return activeCount for serial searches.

### DIFF
--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -33,7 +33,7 @@
         <div class="mt-3">
             <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
             {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|lower }}
+                <span class="section-data">Interest {{ group.interest|capitalize }}
                     {% if group.interestNumerator is defined and group.interestDenominator is defined %}
                         {{ group.interestNumerator }}/{{ group.interestDenominator }}
                     {% endif %}
@@ -88,11 +88,12 @@
     {% endfor %}
 {% elif addOwnerGroups is defined %}
     {% for group in addOwnerGroups %}
-        {% if group.type == 'COMMON' or (group.interestNumerator is defined and group.interestDenominator is defined) %}
+        {% if group.type == 'COMMON' or (group.interestNumerator is defined and group.interestDenominator is defined and
+              group.interestNumerator > 0 and group.interestDenominator > 0) %}
         <div class="mt-3">
             <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
             {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|lower }}
+                <span class="section-data">Interest {{ group.interest|capitalize }}
                     {% if group.interestNumerator is defined and group.interestDenominator is defined %}
                         {{ group.interestNumerator }}/{{ group.interestDenominator }}
                     {% endif %}

--- a/mhr_api/report-templates/template-parts/search-result/owners.html
+++ b/mhr_api/report-templates/template-parts/search-result/owners.html
@@ -21,7 +21,7 @@
         <div class="mt-3">
             <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
             {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|lower }}
+                <span class="section-data">Interest {{ group.interest|capitalize }}
                     {% if group.interestNumerator is defined and group.interestDenominator is defined %}
                         {{ group.interestNumerator }}/{{ group.interestDenominator }}
                     {% endif %}

--- a/mhr_api/src/mhr_api/models/db2/search_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/search_utils.py
@@ -64,7 +64,7 @@ SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate, l.towncity, de.sernumb
 #          FROM owner o2
 #        WHERE o2.manhomid = mh.manhomid) as owner_names, 
 SERIAL_NUM_QUERY = """
-SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
+SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
        (SELECT o.ownrtype || og.status || o.ownrname
           FROM owner o, owngroup og
          WHERE mh.manhomid = o.manhomid
@@ -72,8 +72,8 @@ SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
            AND o.owngrpid = og.owngrpid
            AND og.status IN ('3', '4')
            FETCH FIRST 1 ROWS ONLY) AS owner_info,
-       l.towncity, de.sernumb1, de.yearmade,
-       de.makemodl, mh.manhomid, TRIM(de.sernumb2), TRIM(de.sernumb3), TRIM(de.sernumb4)
+       l.towncity, TRIM(de.sernumb1) AS serial_num, de.yearmade,
+       de.makemodl, mh.manhomid
   FROM manuhome mh, document d, location l, descript de
  WHERE mh.mhregnum = d.mhregnum
    AND mh.regdocid = d.documtid
@@ -81,15 +81,70 @@ SELECT DISTINCT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
    AND l.status = 'A'
    AND mh.manhomid = de.manhomid
    AND de.status = 'A'
-   AND (RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb1), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
-              6) = :query_value OR
-        RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb2), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
-              6) = :query_value OR
-        RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb3), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
-              6) = :query_value OR
-        RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb4), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
-              6) = :query_value)
-ORDER BY de.sernumb1 ASC, mh.mhstatus ASC, mh.mhregnum DESC
+   AND RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb1), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
+             6) = :query_value
+ UNION ALL (
+SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
+       (SELECT o.ownrtype || og.status || o.ownrname
+          FROM owner o, owngroup og
+         WHERE mh.manhomid = o.manhomid
+           AND mh.manhomid = og.manhomid
+           AND o.owngrpid = og.owngrpid
+           AND og.status IN ('3', '4')
+           FETCH FIRST 1 ROWS ONLY) AS owner_info,
+       l.towncity, TRIM(de.sernumb2) AS serial_num, de.yearmade,
+       de.makemodl, mh.manhomid
+  FROM manuhome mh, document d, location l, descript de
+ WHERE mh.mhregnum = d.mhregnum
+   AND mh.regdocid = d.documtid
+   AND mh.manhomid = l.manhomid
+   AND l.status = 'A'
+   AND mh.manhomid = de.manhomid
+   AND de.status = 'A'
+   AND RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb2), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
+             6) = :query_value
+) UNION ALL (
+SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
+       (SELECT o.ownrtype || og.status || o.ownrname
+          FROM owner o, owngroup og
+         WHERE mh.manhomid = o.manhomid
+           AND mh.manhomid = og.manhomid
+           AND o.owngrpid = og.owngrpid
+           AND og.status IN ('3', '4')
+           FETCH FIRST 1 ROWS ONLY) AS owner_info,
+       l.towncity, TRIM(de.sernumb3) AS serial_num, de.yearmade,
+       de.makemodl, mh.manhomid
+  FROM manuhome mh, document d, location l, descript de
+ WHERE mh.mhregnum = d.mhregnum
+   AND mh.regdocid = d.documtid
+   AND mh.manhomid = l.manhomid
+   AND l.status = 'A'
+   AND mh.manhomid = de.manhomid
+   AND de.status = 'A'
+   AND RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb3), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
+              6) = :query_value
+) UNION ALL (
+SELECT mh.mhregnum, mh.mhstatus, mh.exemptfl, d.regidate,
+       (SELECT o.ownrtype || og.status || o.ownrname
+          FROM owner o, owngroup og
+         WHERE mh.manhomid = o.manhomid
+           AND mh.manhomid = og.manhomid
+           AND o.owngrpid = og.owngrpid
+           AND og.status IN ('3', '4')
+           FETCH FIRST 1 ROWS ONLY) AS owner_info,
+       l.towncity, TRIM(de.sernumb4) AS serial_num, de.yearmade,
+       de.makemodl, mh.manhomid
+  FROM manuhome mh, document d, location l, descript de
+ WHERE mh.mhregnum = d.mhregnum
+   AND mh.regdocid = d.documtid
+   AND mh.manhomid = l.manhomid
+   AND l.status = 'A'
+   AND mh.manhomid = de.manhomid
+   AND de.status = 'A'
+   AND RIGHT(('000000' || TRANSLATE(TRIM(de.sernumb4), '08600064100100000050000042', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
+             6) = :query_value
+)
+ORDER BY serial_num ASC, mhstatus ASC, mhregnum DESC
 """
 
 OWNER_NAME_QUERY = """
@@ -304,7 +359,7 @@ def build_search_result_mhr(row):
     # current_app.logger.info(result_json)
     return result_json
 
-def build_search_result_serial(row, search_key: str):
+def build_search_result_serial(row):
     """Build a single search summary json from a DB row for a serial number search."""
     mh_status = str(row[1])
     status = LEGACY_TO_REGISTRATION_STATUS[mh_status]
@@ -313,7 +368,6 @@ def build_search_result_serial(row, search_key: str):
     # current_app.logger.info('Timestamp mapped')
     value: str = str(row[7])
     year = int(value) if value.isnumeric() else 0
-    serial_num: str = str(row[6]).strip()
     result_json = {
         'mhrNumber': str(row[0]),
         'status': status,
@@ -324,6 +378,7 @@ def build_search_result_serial(row, search_key: str):
             'make': str(row[8]).strip(),
             'model': ''
         },
+        'serialNumber': str(row[6]).strip(),
         'activeCount': 1,
         'exemptCount': 0,
         'historicalCount': 0,
@@ -339,18 +394,4 @@ def build_search_result_serial(row, search_key: str):
     else:
         result_json['ownerName'] = model_utils.get_ind_name_from_db2(owner_name)
     result_json['ownerStatus'] = LEGACY_TO_OWNER_STATUS[owner_status]
-    key: str = get_search_serial_number_key(serial_num)
-    if key != search_key:  # Match is on one of the other serial numbers.
-        serial_num = str(row[10])
-        if serial_num:
-            key = get_search_serial_number_key(serial_num.strip())
-    if key != search_key:
-        serial_num = str(row[11])
-        if serial_num:
-            key = get_search_serial_number_key(serial_num.strip())
-    if key != search_key:
-        serial_num = str(row[12])
-        if serial_num:
-            key = get_search_serial_number_key(serial_num.strip())
-    result_json['serialNumber'] = serial_num
     return result_json

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -191,6 +191,13 @@ OWNER_NAME_JSON_COLLAPSE = {
     },
     'clientReferenceId': 'T-SQ-MI-3'
 }
+SERIAL_NUMBER_JSON_COLLAPSE = {
+    'type': 'SERIAL_NUMBER',
+    'criteria': {
+        'value': '000060'
+    },
+    'clientReferenceId': 'T-SQ-MS-3'
+}
 UPDATE_RESULTS_OWNER_BASE = [
     {
         'mhrNumber': '003456',
@@ -243,6 +250,44 @@ UPDATE_OWNER_RESULT_4 = {
     'exemptCount': 1,
     'historicalCount': 0
 }
+UPDATE_RESULTS_SERIAL_BASE = [
+    {
+        'mhrNumber': '003456',
+        'serialNumber': '313000A008326ABC',
+        'activeCount': 1,
+        'exemptCount': 0,
+        'historicalCount': 0
+    }
+]
+UPDATE_SERIAL_RESULT_1 = {
+    'mhrNumber': '003456',
+    'serialNumber': '313000A008326ABC',
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+UPDATE_SERIAL_RESULT_2 = {
+    'mhrNumber': '003456',
+    'serialNumber': '313000A008326ABC',
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+UPDATE_SERIAL_RESULT_3 = {
+    'mhrNumber': '003457',
+    'serialNumber': '313000A008326ABC',
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+UPDATE_SERIAL_RESULT_4 = {
+    'mhrNumber': '003458',
+    'serialNumber': '313000A008326ABC',
+    'activeCount': 1,
+    'exemptCount': 0,
+    'historicalCount': 0
+}
+
 
 # testdata pattern is ({search type}, {JSON data})
 TEST_VALID_DATA = [
@@ -303,10 +348,19 @@ TEST_UPDATE_DATA_OWNER = [
     (UPDATE_OWNER_RESULT_1, UPDATE_OWNER_RESULT_3, 2, 1, 1, 0),
     (UPDATE_OWNER_RESULT_3, UPDATE_OWNER_RESULT_4, 3, 1, 0, 0)
 ]
+# testdata pattern is ({result1}, {result2}, {result_count}, {active_count}, {exempt_count}, {historical_count})
+TEST_UPDATE_DATA_SERIAL = [
+    (None, None, 1, 1, 0, 0),
+    (UPDATE_SERIAL_RESULT_1, None, 1, 2, 0, 0),
+    (UPDATE_SERIAL_RESULT_1, UPDATE_SERIAL_RESULT_2, 1, 3, 0, 0),
+    (UPDATE_SERIAL_RESULT_1, UPDATE_SERIAL_RESULT_3, 2, 2, 0, 0),
+    (UPDATE_SERIAL_RESULT_3, UPDATE_SERIAL_RESULT_4, 3, 1, 0, 0)
+]
 # testdata pattern is ({mhr_num}, {search_data}, {active_count}, {exempt_count}, {historical_count})
 TEST_COLLAPSE_DATA = [
     ('091688', ORG_NAME_JSON_COLLAPSE, 1, 0, 2),
-    ('005520', OWNER_NAME_JSON_COLLAPSE, 1, 0, 5)
+    ('005520', OWNER_NAME_JSON_COLLAPSE, 1, 0, 5),
+    ('099327', SERIAL_NUMBER_JSON_COLLAPSE, 3, 0, 0)
 ]
 
 
@@ -491,6 +545,22 @@ def test_update_result_owner(session, result1, result2, result_count, active_cou
         SearchRequest.update_result_matches(results, result1, SearchRequest.SearchTypes.OWNER_NAME)
     if result2:
         SearchRequest.update_result_matches(results, result2, SearchRequest.SearchTypes.OWNER_NAME)
+    assert len(results) == result_count
+    match = results[0]
+    assert match.get('activeCount') == active_count
+    assert match.get('exemptCount') == exempt_count
+    assert match.get('historicalCount') == historical_count
+
+
+@pytest.mark.parametrize('result1,result2,result_count,active_count,exempt_count,historical_count',
+                         TEST_UPDATE_DATA_SERIAL)
+def test_update_result_serial(session, result1, result2, result_count, active_count, exempt_count, historical_count):
+    """Assert that a search consolidating/collapsing results works as expected."""
+    results = copy.deepcopy(UPDATE_RESULTS_SERIAL_BASE)
+    if result1:
+        SearchRequest.update_result_matches(results, result1, SearchRequest.SearchTypes.SERIAL_NUM)
+    if result2:
+        SearchRequest.update_result_matches(results, result2, SearchRequest.SearchTypes.SERIAL_NUM)
     assert len(results) == result_count
     match = results[0]
     assert match.get('activeCount') == active_count


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#15062
                 /bcgov/entity#13940

*Description of changes:*
- Collapse search results with identical serial numbers within a MH registration. 
- 13940 report group interest update from lower case to capitalized/title case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
