### PR TITLE
15022 Similar Owner Names

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -175,7 +175,9 @@
             {{ getOwnerStatusText(item) }}
           </template>
           <template v-if="isReviewMode" v-slot:[`item.yearMakeModel`]="{ item }">
-            <span>{{ item.baseInformation.year }} {{ item.baseInformation.make }} {{ item.baseInformation.model }}</span>
+            <span>
+              {{ item.baseInformation.year }} {{ item.baseInformation.make }} {{ item.baseInformation.model }}
+            </span>
           </template>
           <template v-else v-slot:[`item.year`]="{ item }">
             {{ item.baseInformation.year || '-' }}
@@ -486,7 +488,9 @@ export default defineComponent({
       })
       // sort search results by mhrNumber for grouping purposes, only when table is in review and has collapsed results
       if (props.isReviewMode && localState.hasCollapsedResults) {
-        const sortedResults = orderBy(localState.results, ['ownerName.lastName', 'ownerName.middleName', 'ownerName.firsName', 'mhrNumber'], ['asc', 'asc', 'asc', 'asc'])
+        const sortedResults = orderBy(localState.results,
+          ['ownerName.lastName', 'ownerName.middleName', 'ownerName.firstName', 'mhrNumber'],
+          ['asc', 'asc', 'asc', 'asc'])
         localState.results = sortedResults
       }
 

--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -408,10 +408,13 @@ export default defineComponent({
       if (count > 1) return `(${count})`
     }
     const getItemClass = (item: ManufacturedHomeSearchResultIF): string => {
-      const rowClass =
+      var rowClass = ''
+      if (props.isReviewMode && localState.uniqueResults < localState.results) {
+        rowClass =
         localState.uniqueResults?.indexOf(item.ownerName) === -1
           ? 'duplicate-reg-num'
           : 'unique-reg-num'
+      }
       return item.selected && !props.isReviewMode ? 'selected' : rowClass
     }
 
@@ -649,7 +652,7 @@ th {
     .selected {
       background-color: $blueSelected !important;
     }
-    tr:hover:not(.selected, .unique-reg-num) {
+    tr:hover:not(.selected, .unique-reg-num, .duplicate-reg-num) {
       // $gray1 at 75%
       background-color: #f1f3f5BF !important;
     }

--- a/ppr-ui/src/components/tables/mhr/SearchedResults.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResults.vue
@@ -215,7 +215,7 @@
                   <v-checkbox
                     :label="`${!isReviewMode ? 'Include lien' : 'Lien'} information`"
                     v-model="item.includeLienInfo"
-                    :disabled="!item.selected"
+                    :disabled="noSelectedOwner(item)"
                   />
                 </span>
               </template>
@@ -460,6 +460,13 @@ export default defineComponent({
              (item.exemptCount > 0 && item.historicalCount > 0)
     }
 
+    const noSelectedOwner = (item: ManufacturedHomeSearchResultIF): boolean => {
+      var filteredResults = localState.results?.filter(result => result.mhrNumber === item.mhrNumber)
+      filteredResults = filteredResults.filter(result => result.selected === true)
+      console.log(filteredResults)
+      return filteredResults.length < 1
+    }
+
     const updateFolioOrReference = (folioOrReference: string): void => {
       setFolioOrReferenceNumber(folioOrReference)
     }
@@ -530,6 +537,7 @@ export default defineComponent({
       reviewAndConfirm,
       getOwnerName,
       getOwnerStatus,
+      noSelectedOwner,
       getOwnerCount,
       hasSimilarOwners,
       getOwnerStatusText,

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
@@ -4,7 +4,6 @@ import { IndividualNameIF } from '@/interfaces'
 export interface ManufacturedHomeSearchResultIF {
   id: number
   ownerName: IndividualNameIF
-  similarOwners?: Array<IndividualNameIF>
   organizationName?: string
   status: string // ACTIVE or EXEMPT or HISTORIC
   mhrNumber: string

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
@@ -4,6 +4,7 @@ import { IndividualNameIF } from '@/interfaces'
 export interface ManufacturedHomeSearchResultIF {
   id: number
   ownerName: IndividualNameIF
+  similarOwners?: Array<IndividualNameIF>
   organizationName?: string
   status: string // ACTIVE or EXEMPT or HISTORIC
   mhrNumber: string
@@ -17,4 +18,8 @@ export interface ManufacturedHomeSearchResultIF {
   selected?: boolean // Optional
   includeLienInfo?: boolean // Optional
   ownerStatus?: string
+  activeCount?: number
+  exemptCount?: number
+  historicalCount?: number
+  firstRow?: boolean
 }

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/manufactured-home-search-result-interface.ts
@@ -21,5 +21,4 @@ export interface ManufacturedHomeSearchResultIF {
   activeCount?: number
   exemptCount?: number
   historicalCount?: number
-  firstRow?: boolean
 }

--- a/ppr-ui/src/resources/tableHeaders.ts
+++ b/ppr-ui/src/resources/tableHeaders.ts
@@ -540,7 +540,7 @@ export const mhSearchNameHeaders: Array<BaseHeaderIF> = [
   {
     class: 'column-mds',
     sortable: false,
-    text: 'Registration Status',
+    text: 'Current Registration Status',
     value: 'status'
   },
   {

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -109,7 +109,7 @@ import {
 import { BaseDialog } from '@/components/dialogs'
 import { StaffPayment as StaffPaymentComponent } from '@bcrs-shared-components/staff-payment'
 // local helpers/enums/interfaces/resources
-import { RouteNames } from '@/enums'
+import { RouteNames, UIMHRSearchTypeValues } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import {
@@ -124,6 +124,7 @@ import { getFeatureFlag, submitSelectedMhr } from '@/utils'
 import { SearchedResultMhr } from '@/components/tables'
 import { AdditionalSearchFeeIF } from '@/composables/fees/interfaces'
 import { StaffPaymentIF } from '@bcrs-shared-components/interfaces'
+import { uniqBy } from 'lodash'
 /* eslint-enable no-unused-vars */
 
 @Component({
@@ -196,11 +197,10 @@ export default class ConfirmMHRSearch extends Vue {
 
   private get feeQuantity (): number {
     // Return selected quantity that is not a combination search
-    const uniqueRegNums = []
-    this.getSelectedManufacturedHomes.forEach(result => {
-      if (!uniqueRegNums.includes(result.mhrNumber)) uniqueRegNums.push(result.mhrNumber)
-    })
-    return uniqueRegNums.length
+    const filteredResults =
+      this.getSelectedManufacturedHomes.filter(result => result.selected && !result.includeLienInfo)
+    const uniqueRegNumRegistrations = uniqBy(filteredResults, UIMHRSearchTypeValues.MHRMHR_NUMBER)
+    return uniqueRegNumRegistrations.length
   }
 
   private get staffPaymentData (): any {

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -20,8 +20,9 @@
           <h1>Review Selection(s)</h1>
           <div class="mt-6">
             <p class="ma-0">
-              Review the details of the manufactured home before paying. Your search result will be available in your
-              Searches list.
+              Review the details of the manufactured home registration(s) before paying. Your search result will be
+              available in your Searches list for up to 14 days. <b>Note:</b> Search fees are charged per unique
+              manufactured home registration number.
             </p>
           </div>
 

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -195,7 +195,11 @@ export default class ConfirmMHRSearch extends Vue {
 
   private get feeQuantity (): number {
     // Return selected quantity that is not a combination search
-    return this.getSelectedManufacturedHomes.filter(result => result.selected && !result.includeLienInfo).length
+    const uniqueRegNums = []
+    this.getSelectedManufacturedHomes.forEach(result => {
+      if (!uniqueRegNums.includes(result.mhrNumber)) uniqueRegNums.push(result.mhrNumber)
+    })
+    return uniqueRegNums.length
   }
 
   private get staffPaymentData (): any {

--- a/ppr-ui/src/views/mhrSearch/MHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/MHRSearch.vue
@@ -4,7 +4,7 @@
       <v-progress-circular color="primary" size="50" indeterminate />
     </v-overlay>
     <v-container class="container">
-      <v-icon class="mr-2" size="30" style="vertical-align: baseline; color: #212529;">mdi-home</v-icon>
+      <v-icon :class="[$style['home'], 'mr-2']" size="30">mdi-home</v-icon>
       <b :class="$style['search-title']">Selection List</b>
       <p v-if="!getManufacturedHomeSearchResults" :class="[$style['search-info'], 'ma-0']" style="padding-top: 26px;">
         Your search results will display below.
@@ -177,6 +177,10 @@ export default class MHRSearch extends Vue {
   color: $gray7;
   font-size: 1rem;
   line-height: 1.5rem;
+}
+.home {
+  vertical-align: baseline !important;
+  color: #212529 !important;
 }
 
 </style>

--- a/ppr-ui/src/views/mhrSearch/MHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/MHRSearch.vue
@@ -4,6 +4,7 @@
       <v-progress-circular color="primary" size="50" indeterminate />
     </v-overlay>
     <v-container class="container">
+      <v-icon class="mr-2" size="30" style="vertical-align: baseline; color: #212529;">mdi-home</v-icon>
       <b :class="$style['search-title']">Selection List</b>
       <p v-if="!getManufacturedHomeSearchResults" :class="[$style['search-info'], 'ma-0']" style="padding-top: 26px;">
         Your search results will display below.
@@ -12,9 +13,10 @@
         <v-row no-gutters class="mt-6">
           <v-col class="pr-6" :class="$style['search-info']">
             <span v-if="totalResultsLength !== 0" id="results-info">
-              Select the manufactured home to download the full details of the home. Selecting the home will debit your
-              search fee. The downloaded report will contain the full record of the registration for the home and will
-              be automatically saved to your dashboard for up to 14 days.
+              Select manufactured home registrations to download a search result report containing the full details of
+              the registration(s). Lien information contained in the Personal Property Registry can be included for an
+              additional fee per manufactured home registration. You will be able to review your selection prior to
+              payment.
             </span>
             <span v-else id="no-results-info">
               No Registrations were found.

--- a/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
+++ b/ppr-ui/tests/unit/SearchedResultsMHR.spec.ts
@@ -108,9 +108,8 @@ describe('Serial number results', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(true)
-    expect(wrapper.find('#home-results-count').text()).toBe('5 homes found')
-    expect(wrapper.find('#active-results-count').text()).toBe('2 active homes')
-    expect(wrapper.find('#selected-results-count').text()).toBe('0 homes selected + 0 lien search')
+    expect(wrapper.find('#home-results-count').text()).toBe('Matches Found: 5')
+    expect(wrapper.find('#selected-results-count').text()).toBe('Matches Selected: 0')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(true)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(true)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(true)
@@ -155,7 +154,7 @@ describe('Serial number results in Review Mode', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(false)
-    expect(wrapper.find('#review-results-count').text()).toBe('2 Manufactured Homes')
+    expect(wrapper.find('#review-results-count').text()).toBe('Matches Selected: 2')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(false)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(false)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(false)
@@ -194,9 +193,8 @@ describe('Owner name debtor results', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(true)
-    expect(wrapper.find('#home-results-count').text()).toBe('5 homes found')
-    expect(wrapper.find('#active-results-count').text()).toBe('2 active homes')
-    expect(wrapper.find('#selected-results-count').text()).toBe('0 homes selected + 0 lien search')
+    expect(wrapper.find('#home-results-count').text()).toBe('Matches Found: 5')
+    expect(wrapper.find('#selected-results-count').text()).toBe('Matches Selected: 0')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(true)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(true)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(true)
@@ -241,7 +239,7 @@ describe('Owner name name in Review Mode', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(false)
-    expect(wrapper.find('#review-results-count').text()).toBe('1 Manufactured Homes')
+    expect(wrapper.find('#review-results-count').text()).toBe('Matches Selected: 1')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(false)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(false)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(false)
@@ -280,9 +278,8 @@ describe('Business organization results', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(true)
-    expect(wrapper.find('#home-results-count').text()).toBe('5 homes found')
-    expect(wrapper.find('#active-results-count').text()).toBe('2 active homes')
-    expect(wrapper.find('#selected-results-count').text()).toBe('0 homes selected + 0 lien search')
+    expect(wrapper.find('#home-results-count').text()).toBe('Matches Found: 5')
+    expect(wrapper.find('#selected-results-count').text()).toBe('Matches Selected: 0')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(true)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(true)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(true)
@@ -323,7 +320,7 @@ describe('Business organization results in Review Mode', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(false)
-    expect(wrapper.find('#review-results-count').text()).toBe('2 Manufactured Homes')
+    expect(wrapper.find('#review-results-count').text()).toBe('Matches Selected: 2')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(false)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(false)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(false)
@@ -360,9 +357,8 @@ describe('Manufactured home results', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(true)
-    expect(wrapper.find('#home-results-count').text()).toBe('5 homes found')
-    expect(wrapper.find('#active-results-count').text()).toBe('2 active homes')
-    expect(wrapper.find('#selected-results-count').text()).toBe('0 homes selected + 0 lien search')
+    expect(wrapper.find('#home-results-count').text()).toBe('Matches Found: 5')
+    expect(wrapper.find('#selected-results-count').text()).toBe('Matches Selected: 0')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(true)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(true)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(true)
@@ -407,7 +403,7 @@ describe('Manufactured home results in Review Mode', () => {
 
     // Verify base mode features
     expect(wrapper.find('#search-summary-info').exists()).toBe(false)
-    expect(wrapper.find('#review-results-count').text()).toBe('3 Manufactured Homes')
+    expect(wrapper.find('#review-results-count').text()).toBe('Matches Selected: 3')
     expect(wrapper.find('#review-confirm-btn').exists()).toBe(false)
     expect(wrapper.find('#select-all-checkbox').exists()).toBe(false)
     expect(wrapper.find('#select-all-lien-checkbox').exists()).toBe(false)

--- a/ppr-ui/tests/unit/test-data/mock-search-results.ts
+++ b/ppr-ui/tests/unit/test-data/mock-search-results.ts
@@ -421,7 +421,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -438,7 +441,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -455,7 +461,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 4,
@@ -472,7 +481,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 5,
@@ -489,7 +501,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHROWNER_NAME]: [
@@ -508,7 +523,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -525,7 +543,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -542,7 +563,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 4,
@@ -559,7 +583,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHRORGANIZATION_NAME]: [
@@ -578,7 +605,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -595,7 +625,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -612,7 +645,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 4,
@@ -629,7 +665,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHRSERIAL_NUMBER]: [
@@ -648,7 +687,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -665,7 +707,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -682,7 +727,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 4,
@@ -699,7 +747,10 @@ export const mockedMHRSearchResults: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ]
 }
@@ -721,7 +772,10 @@ export const mockedMHRSearchResultsSorted: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -738,7 +792,10 @@ export const mockedMHRSearchResultsSorted: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -755,7 +812,10 @@ export const mockedMHRSearchResultsSorted: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 5,
@@ -772,7 +832,10 @@ export const mockedMHRSearchResultsSorted: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 4,
@@ -789,7 +852,10 @@ export const mockedMHRSearchResultsSorted: mockMHRSearchResults = {
         model: 'Trailer'
       },
       homeLocation: 'Victoria',
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ]
 }
@@ -812,7 +878,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: true
+      includeLienInfo: true,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -830,7 +899,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 3,
@@ -848,7 +920,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHROWNER_NAME]: [
@@ -868,7 +943,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHRORGANIZATION_NAME]: [
@@ -888,7 +966,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -906,7 +987,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: true
+      includeLienInfo: true,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ],
   [UIMHRSearchTypes.MHRSERIAL_NUMBER]: [
@@ -926,7 +1010,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: false
+      includeLienInfo: false,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     },
     {
       id: 2,
@@ -944,7 +1031,10 @@ export const mockedMHRSearchSelections: mockMHRSearchResults = {
       },
       homeLocation: 'Victoria',
       selected: true,
-      includeLienInfo: true
+      includeLienInfo: true,
+      activeCount: 0,
+      exemptCount: 0,
+      historicalCount: 0
     }
   ]
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15022

*Description of Changes*
- Search results with multiple copies are collapsed and the number and type of registrations are displayed
![image](https://user-images.githubusercontent.com/112968185/215617211-f57cb258-256e-4485-bb9b-921f32d4216b.png)

- Selected search results with matching registration numbers are collapsed on review screen as follows. The numbers beside the owner names represent the sum of active, exempt, and historical results under that name.
![image](https://user-images.githubusercontent.com/112968185/216189082-db2e54e7-ac57-4425-93da-44709254e560.png)

- Fixed fee summary to display fee according to unique registrations
![image](https://user-images.githubusercontent.com/112968185/216192596-eaf75a65-4c4e-4ffd-8202-7bf224644118.png)


- Other minor UI changes: Checkbox alignment, title text, Icon on selection screen, other text updates, tooltip on registration numbers with multiple owner names displayed.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
