### PR TITLE
Add new owner group tenancy type NA

### DIFF
--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -4,7 +4,9 @@
 <div class="no-page-break mt-3">
     <span class="section-sub-title">Home Tenancy Type:</span>
     <span class="section-data">
-        {% if addOwnerGroups is defined and addOwnerGroups[0].type == 'SOLE' %}
+        {% if hasNA is defined and hasNA %}
+            N/A
+        {% elif addOwnerGroups is defined and addOwnerGroups[0].type == 'SOLE' %}
             Sole Owner
         {% elif addOwnerGroups is defined and addOwnerGroups[0].type == 'JOINT' and
                 (addOwnerGroups[0].interestDenominator is not defined or addOwnerGroups[0].interestDenominator == '') %}

--- a/mhr_api/report-templates/template-parts/search-result/owners.html
+++ b/mhr_api/report-templates/template-parts/search-result/owners.html
@@ -4,7 +4,9 @@
     <div class="no-page-break mt-3">
         <span class="section-sub-title">Home Tenancy Type:</span>
         <span class="section-data">
-            {% if detail.ownerGroups[0].type == 'SOLE' %}
+            {% if hasNA is defined and hasNA %}
+                N/A
+            {% elif detail.ownerGroups[0].type == 'SOLE' %}
                 Sole Owner
             {% elif detail.ownerGroups|length == 1 %}
                 Joint Tenants

--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.5.3
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.8
-git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.7.0#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.6.9#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.7.0#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/owngroup.py
+++ b/mhr_api/src/mhr_api/models/db2/owngroup.py
@@ -16,6 +16,7 @@ from flask import current_app
 
 from mhr_api.exceptions import DatabaseException
 from mhr_api.models import db, utils as model_utils
+from mhr_api.models.type_tables import MhrTenancyTypes
 from mhr_api.models.db2.owner import Db2Owner
 from mhr_api.utils.base import BaseEnum
 
@@ -34,6 +35,7 @@ NEW_TENANCY_LEGACY = {
     'JOINT': 'JT',
     'COMMON': 'TC',
     'SOLE': 'SO',
+    'NA': 'TC',
     'JT': 'JT',
     'TC': 'TC',
     'SO': 'SO'
@@ -281,6 +283,8 @@ class Db2Owngroup(db.Model):
         # current_app.logger.info(new_info)
         tenancy: str = new_info.get('type', Db2Owngroup.TenancyTypes.SOLE)
         tenancy_type: str = NEW_TENANCY_LEGACY.get(tenancy)
+        if tenancy == MhrTenancyTypes.NA and len(new_info.get('owners')) > 1:
+            tenancy_type = Db2Owngroup.TenancyTypes.JOINT
         interest: str = new_info.get('interest', '')
         if tenancy_type == Db2Owngroup.TenancyTypes.COMMON or \
                 (tenancy_type == Db2Owngroup.TenancyTypes.JOINT and new_info.get('interestDenominator') and

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -25,8 +25,7 @@ from mhr_api.models import utils as model_utils, Db2Manuhome
 from mhr_api.models.mhr_extra_registration import MhrExtraRegistration
 from mhr_api.models.db2 import utils as legacy_utils
 from mhr_api.models.registration_utils import AccountRegistrationParams, get_owner_group_count
-from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE, \
-                                   GENERAL_USER_GROUP, BCOL_HELP
+from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GENERAL_USER_GROUP, BCOL_HELP
 
 from .db import db
 from .mhr_description import MhrDescription
@@ -597,10 +596,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             registration.add_new_groups(json_data, get_owner_group_count(base_reg))
         # Other parties
         registration.parties = MhrParty.create_from_registration_json(json_data, registration.id)
-        if registration.doc_id and not json_data.get('documentId'):
-            json_data['documentId'] = registration.doc_id
-        elif not registration.doc_id and json_data.get('documentId'):
-            registration.doc_id = json_data.get('documentId')
+        json_data['documentId'] = registration.doc_id
         registration.documents = [MhrDocument.create_from_json(registration,
                                                                json_data,
                                                                REG_TO_DOC_TYPE[registration.registration_type])]
@@ -645,10 +641,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         if 'clientReferenceId' in json_data:
             registration.client_reference_id = json_data['clientReferenceId']
         registration.parties = MhrParty.create_from_registration_json(json_data, registration.id)
-        if registration.doc_id and not json_data.get('documentId'):
-            json_data['documentId'] = registration.doc_id
-        elif not registration.doc_id and json_data.get('documentId'):
-            registration.doc_id = json_data.get('documentId')
+        json_data['documentId'] = registration.doc_id
         doc: MhrDocument = MhrDocument.create_from_json(registration,
                                                         json_data,
                                                         REG_TO_DOC_TYPE[registration.registration_type])
@@ -699,10 +692,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             registration.client_reference_id = json_data['clientReferenceId']
         # Other parties
         registration.parties = MhrParty.create_from_registration_json(json_data, registration.id)
-        if registration.doc_id and not json_data.get('documentId'):
-            json_data['documentId'] = registration.doc_id
-        elif not registration.doc_id and json_data.get('documentId'):
-            registration.doc_id = json_data.get('documentId')
+        json_data['documentId'] = registration.doc_id
         doc: MhrDocument = MhrDocument.create_from_json(registration,
                                                         json_data,
                                                         REG_TO_DOC_TYPE[registration.registration_type])
@@ -877,7 +867,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             query += DOC_ID_QUALIFIED_CLAUSE
         elif user_group and user_group == MANUFACTURER_GROUP:
             query += DOC_ID_MANUFACTURER_CLAUSE
-        elif user_group and user_group == GOV_ACCOUNT_ROLE:
+        # elif user_group and user_group == GOV_ACCOUNT_ROLE:
+        else:
             query += DOC_ID_GOV_AGENT_CLAUSE
         result = db.session.execute(query)
         row = result.first()
@@ -887,12 +878,12 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         if not draft:
             registration.draft_number = str(row[3])
             registration.draft_id = int(row[4])
-        if user_group and user_group in (QUALIFIED_USER_GROUP, MANUFACTURER_GROUP, GOV_ACCOUNT_ROLE,
-                                         GENERAL_USER_GROUP, BCOL_HELP):
-            if draft:
-                registration.doc_id = str(row[3])
-            else:
-                registration.doc_id = str(row[5])
+        # if user_group and user_group in (QUALIFIED_USER_GROUP, MANUFACTURER_GROUP, GOV_ACCOUNT_ROLE,
+        #                                 GENERAL_USER_GROUP, BCOL_HELP):
+        if draft:
+            registration.doc_id = str(row[3])
+        else:
+            registration.doc_id = str(row[5])
         return registration
 
     @staticmethod

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -285,6 +285,7 @@ class MhrTenancyTypes(BaseEnum):
 
     COMMON = 'COMMON'
     JOINT = 'JOINT'
+    NA = 'NA'
     SOLE = 'SOLE'
 
 

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -20,6 +20,7 @@ from flask import current_app, jsonify
 
 from mhr_api.exceptions import ResourceErrorCodes
 from mhr_api.models import utils as model_utils
+from mhr_api.models.type_tables import MhrTenancyTypes
 from mhr_api.reports import ppr_report_utils
 from mhr_api.reports.v2 import report_utils
 from mhr_api.reports.v2.report_utils import ReportTypes
@@ -362,19 +363,31 @@ class Report:  # pylint: disable=too-few-public-methods
         group_id: int = 1
         if self._report_key == ReportTypes.MHR_TRANSFER:
             if self._report_data.get('addOwnerGroups'):
+                has_na: bool = False
                 for group in self._report_data.get('addOwnerGroups'):
+                    if group.get('type', '') == MhrTenancyTypes.NA:
+                        has_na = True
                     group['groupId'] = group_id
                     group_id += 1
+                self._report_data['hasNA'] = has_na
         elif self._report_key == ReportTypes.MHR_REGISTRATION:
+            has_na: bool = False
             for group in self._report_data.get('ownerGroups'):
                 group['groupId'] = group_id
                 group_id += 1
+                if group.get('type', '') == MhrTenancyTypes.NA:
+                    has_na = True
+            self._report_data['hasNA'] = has_na
         elif self._report_key in (ReportTypes.SEARCH_DETAIL_REPORT, ReportTypes.SEARCH_BODY_REPORT):
             for detail in self._report_data['details']:
                 group_id = 1
+                has_na: bool = False
                 for group in detail.get('ownerGroups'):
                     group['groupId'] = group_id
                     group_id += 1
+                    if group.get('type', '') == MhrTenancyTypes.NA:
+                        has_na = True
+                self._report_data['hasNA'] = has_na
 
     def _set_location(self):
         """Set up report location information."""

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -54,7 +54,7 @@ PPR_LIEN_EXISTS = 'This registration is not allowed to complete as an outstandin
 BAND_NAME_REQUIRED = 'The location Indian Reserve band name is required for this registration. '
 RESERVE_NUMBER_REQUIRED = 'The location Indian Reserve number is required for this registration. '
 OWNERS_JOINT_INVALID = 'The owner group must contain at least 2 owners. '
-OWNERS_COMMON_INVALID = 'Each owner group must contain at least 1 owner. '
+OWNERS_COMMON_INVALID = 'Each COMMON owner group must contain exactly 1 owner. '
 LOCATION_DEALER_REQUIRED = 'The location dealer name is required for this registration. '
 STATUS_CONFIRMATION_REQUIRED = 'The land status confirmation is required for this registration. '
 LOCATION_PARK_NAME_REQUIRED = 'The location park name is required for this registration. '
@@ -95,8 +95,7 @@ def validate_transfer(registration: MhrRegistration, json_data, staff: bool = Fa
     """Perform all transfer data validation checks not covered by schema validation."""
     error_msg = ''
     try:
-        if staff:
-            error_msg += validate_doc_id(json_data)
+        current_app.logger.info(f'Validating transfer staff={staff}')
         if registration:
             error_msg += validate_ppr_lien(registration.mhr_number)
         active_group_count: int = get_active_group_count(json_data, registration)
@@ -127,8 +126,7 @@ def validate_exemption(registration: MhrRegistration, json_data, staff: bool = F
     """Perform all exemption data validation checks not covered by schema validation."""
     error_msg = ''
     try:
-        if staff:
-            error_msg += validate_doc_id(json_data)
+        current_app.logger.info(f'Validating exemption staff={staff}')
         if registration:
             error_msg += validate_ppr_lien(registration.mhr_number)
         error_msg += validate_submitting_party(json_data)
@@ -147,10 +145,9 @@ def validate_permit(registration: MhrRegistration, json_data, staff: bool = Fals
     """Perform all transport permit data validation checks not covered by schema validation."""
     error_msg = ''
     try:
+        current_app.logger.info(f'Validating permit staff={staff}')
         current_location = get_existing_location(registration)
-        if staff:
-            error_msg += validate_doc_id(json_data)
-        elif registration and group_name and group_name == MANUFACTURER_GROUP:
+        if registration and group_name and group_name == MANUFACTURER_GROUP:
             error_msg += validate_manufacturer_permit(registration.mhr_number, json_data.get('submittingParty'),
                                                       current_location)
         if registration:
@@ -303,14 +300,19 @@ def validate_owner_group(group, int_required: bool = False):
     error_msg = ''
     if not group:
         return error_msg
-    tenancy_type: str = NEW_TENANCY_LEGACY.get(group.get('type', ''), '')
+    orig_type: str = group.get('type', '')
+    tenancy_type: str = NEW_TENANCY_LEGACY.get(orig_type, '')
     if tenancy_type == Db2Owngroup.TenancyTypes.COMMON or int_required:
         if not group.get('interestNumerator') or group.get('interestNumerator', 0) < 1:
             error_msg += GROUP_NUMERATOR_MISSING
         if not group.get('interestDenominator') or group.get('interestDenominator', 0) < 1:
             error_msg += GROUP_DENOMINATOR_MISSING
+
     if tenancy_type == Db2Owngroup.TenancyTypes.JOINT and (not group.get('owners') or len(group.get('owners')) < 2):
         error_msg += OWNERS_JOINT_INVALID
+    elif orig_type != 'NA' and tenancy_type == Db2Owngroup.TenancyTypes.COMMON and \
+            (not group.get('owners') or len(group.get('owners')) > 1):
+        error_msg += OWNERS_COMMON_INVALID
     return error_msg
 
 
@@ -324,7 +326,10 @@ def delete_group(group_id: int, delete_groups):
     return False
 
 
-def validate_group_interest(groups, denominator: int, registration: MhrRegistration = None, delete_groups=None):
+def validate_group_interest(groups,  # pylint: disable=too-many-branches
+                            denominator: int,
+                            registration: MhrRegistration = None,
+                            delete_groups=None):
     """Verify owner group interest values are valid."""
     error_msg = ''
     numerator_sum: int = 0
@@ -341,6 +346,8 @@ def validate_group_interest(groups, denominator: int, registration: MhrRegistrat
                         numerator_sum += existing.interest_numerator
                     elif den < denominator:
                         numerator_sum += (denominator/den * existing.interest_numerator)
+                    else:
+                        numerator_sum += int((denominator * existing.interest_numerator)/den)
         # current_app.logger.debug(f'existing numerator_sum={numerator_sum}, denominator={denominator}')
     if group_count < 2:  # Could have transfer of joint tenants with no interest.
         return error_msg
@@ -403,11 +410,6 @@ def validate_owner_groups(groups, new: bool, registration: MhrRegistration = Non
             error_msg += validate_owner(owner)
     if so_count > 1 or (so_count == 1 and len(groups) > 1):
         error_msg += ADD_SOLE_OWNER_INVALID
-    # Adjust COMMON type when multiple owners: remove after UI change made.
-    for group in groups:
-        if group.get('type') and group.get('type') == MhrTenancyTypes.COMMON and group.get('owners') and \
-                len(group.get('owners')) > 1:
-            group['type'] = MhrTenancyTypes.JOINT
     return error_msg
 
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.2.4'  # pylint: disable=invalid-name
+__version__ = '1.2.5'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/api/test_exemptions.py
+++ b/mhr_api/tests/unit/api/test_exemptions.py
@@ -30,7 +30,6 @@ from mhr_api.services.authz import MHR_ROLE, STAFF_ROLE, COLIN_ROLE, \
 from tests.unit.services.utils import create_header, create_header_account
 
 
-DOC_ID_VALID = '63166035'
 MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
 
@@ -81,8 +80,6 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
         headers = create_header_account(jwt, roles, 'UT-TEST', account)
     else:
         headers = create_header(jwt, roles)
-    if status == HTTPStatus.CREATED and STAFF_ROLE in roles:
-        json_data['documentId'] = DOC_ID_VALID
     # test
     response = client.post('/api/v1/exemptions/' + mhr_num,
                            json=json_data,

--- a/mhr_api/tests/unit/api/test_permits.py
+++ b/mhr_api/tests/unit/api/test_permits.py
@@ -92,7 +92,6 @@ PERMIT = {
   },
   'landStatusConfirmation': True
 }
-DOC_ID_VALID = '63166035'
 MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
 
@@ -129,8 +128,6 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
         headers = create_header_account(jwt, roles, 'UT-TEST', account)
     else:
         headers = create_header(jwt, roles)
-    if status == HTTPStatus.CREATED and STAFF_ROLE in roles:
-        json_data['documentId'] = DOC_ID_VALID
     # test
     response = client.post('/api/v1/permits/' + mhr_num,
                            json=json_data,

--- a/mhr_api/tests/unit/api/test_transfers.py
+++ b/mhr_api/tests/unit/api/test_transfers.py
@@ -30,7 +30,6 @@ from mhr_api.services.authz import MHR_ROLE, STAFF_ROLE, COLIN_ROLE, \
 from tests.unit.services.utils import create_header, create_header_account
 
 
-DOC_ID_VALID = '63166035'
 MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
 
@@ -88,8 +87,6 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
         headers = create_header_account(jwt, roles, 'UT-TEST', account)
     else:
         headers = create_header(jwt, roles)
-    if status == HTTPStatus.CREATED and STAFF_ROLE in roles:
-        json_data['documentId'] = DOC_ID_VALID
     # test
     response = client.post('/api/v1/transfers/' + mhr_num,
                            json=json_data,

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -30,7 +30,7 @@ from mhr_api.models.registration_utils import AccountRegistrationParams
 from mhr_api.models.type_tables import MhrLocationTypes, MhrPartyTypes, MhrOwnerStatusTypes, MhrStatusTypes
 from mhr_api.models.type_tables import MhrRegistrationTypes, MhrRegistrationStatusTypes, MhrDocumentTypes
 from mhr_api.models.type_tables import MhrTenancyTypes
-from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE
+from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE, STAFF_ROLE
 
 
 REG_DESCRIPTION = 'REGISTER NEW UNIT'
@@ -181,6 +181,7 @@ TEST_DOC_ID_DATA = [
 ]
 # testdata pattern is ({mhr_num}, {group_id}, {doc_id_prefix}, {account_id})
 TEST_DATA_TRANSFER = [
+    ('150062', STAFF_ROLE, '9', '2523'),
     ('150062', GOV_ACCOUNT_ROLE, '9', '2523'),
     ('150062', MANUFACTURER_GROUP, '8', '2523'),
     ('150062', QUALIFIED_USER_GROUP, '1', '2523')
@@ -199,6 +200,7 @@ TEST_DATA_TRANSFER_SAVE = [
 ]
 # testdata pattern is ({mhr_num}, {group_id}, {doc_id_prefix}, {account_id})
 TEST_DATA_EXEMPTION = [
+    ('150062', STAFF_ROLE, '9', '2523'),
     ('150062', GOV_ACCOUNT_ROLE, '9', '2523'),
     ('150062', MANUFACTURER_GROUP, '8', '2523'),
     ('150062', QUALIFIED_USER_GROUP, '1', '2523')
@@ -209,6 +211,7 @@ TEST_DATA_EXEMPTION_SAVE = [
 ]
 # testdata pattern is ({mhr_num}, {group_id}, {doc_id_prefix}, {account_id})
 TEST_DATA_PERMIT = [
+    ('150062', STAFF_ROLE, '9', '2523'),
     ('150062', GOV_ACCOUNT_ROLE, '9', '2523'),
     ('150062', MANUFACTURER_GROUP, '8', '2523'),
     ('150062', QUALIFIED_USER_GROUP, '1', '2523')

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -40,7 +40,7 @@ SOLE_OWNER_GROUP = [
         'groupId': 1,
         'owners': [
             {
-            'businessName': 'TEST BUS.',
+            'organizationName': 'TEST BUS.',
             'address': {
                 'street': '3122B LYNNLARK PLACE',
                 'city': 'VICTORIA',
@@ -185,12 +185,13 @@ TEST_DATA_TRANSFER = [
     ('150062', MANUFACTURER_GROUP, '8', '2523'),
     ('150062', QUALIFIED_USER_GROUP, '1', '2523')
 ]
-# testdata pattern is ({mhr_num}, {group_id}, {account_id}, {party_type})
+# testdata pattern is ({mhr_num}, {group_id}, {account_id}, {party_type}, {tenancy_type})
 TEST_DATA_TRANSFER_DEATH = [
-    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.EXECUTOR),
-    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.ADMINISTRATOR),
-    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.TRUSTEE),
-    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.TRUST)
+    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.EXECUTOR, None),
+    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.ADMINISTRATOR, None),
+    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.TRUSTEE, None),
+    ('150062', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.TRUST, None),
+    ('004764', QUALIFIED_USER_GROUP, '2523', MhrPartyTypes.EXECUTOR, MhrTenancyTypes.NA)
 ]
 # testdata pattern is ({mhr_num}, {group_id}, {account_id})
 TEST_DATA_TRANSFER_SAVE = [
@@ -226,6 +227,15 @@ TEST_DATA_NEW_GROUP = [
     ('SOLE', 1, 1, None, SOLE_OWNER_GROUP),
     ('JOINT', 1, 2, None, JOINT_OWNER_GROUP),
     ('COMMON', 2, 2, 10, COMMON_OWNER_GROUP)
+]
+# testdata pattern is ({tenancy_type}, {group_id}, {mhr_num}, {party_type}, {account_id})
+TEST_DATA_GROUP_TYPE = [
+    (MhrTenancyTypes.SOLE, 3, '017270', MhrPartyTypes.OWNER_IND, '2523'),
+    (MhrTenancyTypes.JOINT, 3, '016148', MhrPartyTypes.OWNER_BUS, '2523'),
+    (MhrTenancyTypes.COMMON, 2, '080282', MhrPartyTypes.OWNER_BUS, '2523'),
+    (MhrTenancyTypes.NA, 8, '004764', MhrPartyTypes.EXECUTOR, '2523'),
+    (MhrTenancyTypes.NA, 6, '051414', MhrPartyTypes.ADMINISTRATOR, '2523'),
+    (MhrTenancyTypes.NA, 4, '098504', MhrPartyTypes.TRUSTEE, '2523')
 ]
 
 
@@ -548,8 +558,8 @@ def test_create_transfer_from_json(session, mhr_num, user_group, doc_id_prefix, 
         assert registration.manuhome
 
 
-@pytest.mark.parametrize('mhr_num,user_group,account_id,party_type', TEST_DATA_TRANSFER_DEATH)
-def test_create_transfer_death_from_json(session, mhr_num, user_group, account_id, party_type):
+@pytest.mark.parametrize('mhr_num,user_group,account_id,party_type,tenancy_type', TEST_DATA_TRANSFER_DEATH)
+def test_create_transfer_death_from_json(session, mhr_num, user_group, account_id, party_type, tenancy_type):
     """Assert that an MHR tranfer due to death is created from MHR transfer json correctly."""
     json_data = copy.deepcopy(TRANSFER)
     del json_data['documentId']
@@ -559,6 +569,8 @@ def test_create_transfer_death_from_json(session, mhr_num, user_group, account_i
     json_data['deathOfOwner'] = True
     json_data['mhrNumber'] = mhr_num
     for group in json_data.get('addOwnerGroups'):
+        if tenancy_type:
+            group['type'] = tenancy_type
         for owner in group.get('owners'):
             owner['partyType'] = party_type
     base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
@@ -589,8 +601,10 @@ def test_create_transfer_death_from_json(session, mhr_num, user_group, account_i
     assert registration.parties
     for group in registration.owner_groups:
         if group.modified:
+            if tenancy_type:
+                assert group.tenancy_type == tenancy_type
             for owner in group.owners:
-                assert party.party_type == party_type
+                assert owner.party_type == party_type
     if model_utils.is_legacy():
         assert registration.manuhome
 
@@ -806,3 +820,17 @@ def test_create_new_groups(session, type, group_count, owner_count, denominator,
             assert not group.interest_numerator
             assert not group.interest_denominator
     assert own_count == owner_count
+
+
+@pytest.mark.parametrize('tenancy_type,group_id,mhr_num,party_type,account_id', TEST_DATA_GROUP_TYPE)
+def test_group_type(session, tenancy_type, group_id, mhr_num, party_type, account_id):
+    """Assert that find manufauctured home by mhr_number contains all expected elements."""
+    registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+    assert registration
+    json_data = registration.registration_json
+    for group in json_data.get('ownerGroups'):
+        if group.get('groupId') == group_id:
+            assert group['type'] == tenancy_type
+            if party_type and group.get('owners'):
+                for owner in group.get('owners'):
+                    assert owner.get('partyType') == party_type

--- a/mhr_api/tests/unit/models/test_types.py
+++ b/mhr_api/tests/unit/models/test_types.py
@@ -47,11 +47,12 @@ def test_mhr_tenancy_type(session):
     """Assert that MhrTenancyType.find_all() contains all expected elements."""
     results = type_tables.MhrTenancyType.find_all()
     assert results
-    assert len(results) == 3
+    assert len(results) == 4
     for result in results:
         assert result.tenancy_type in type_tables.MhrTenancyTypes
         assert result.tenancy_type_desc
-        assert result.legacy_tenancy_type
+        if result.tenancy_type != type_tables.MhrTenancyTypes.NA:
+            assert result.legacy_tenancy_type
 
 
 def test_mhr_registration_type(session):

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -283,10 +283,8 @@ TEST_LOCATION_DATA = [
     ('Invalid band name', None, None, None, None, INVALID_TEXT_CHARSET, INVALID_CHARSET_MESSAGE)
 ]
 TEST_PERMIT_DATA = [
-    (DESC_VALID, True, True, DOC_ID_VALID, None, MhrRegistrationStatusTypes.ACTIVE, STAFF_ROLE),
+    (DESC_VALID, True, True, None, None, MhrRegistrationStatusTypes.ACTIVE, STAFF_ROLE),
     ('Valid no doc id not staff', True, False, None, None, None, REQUEST_TRANSPORT_PERMIT),
-    (DESC_MISSING_DOC_ID, False, True, None, validator.DOC_ID_REQUIRED, None, STAFF_ROLE),
-    (DESC_DOC_ID_EXISTS, False, True, DOC_ID_EXISTS, validator.DOC_ID_EXISTS, None, STAFF_ROLE),
     ('Invalid EXEMPT', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT,
      REQUEST_TRANSPORT_PERMIT),
     ('Invalid HISTORICAL', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL,

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -483,10 +483,8 @@ TEST_LOCATION_DATA = [
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content}, {status})
 TEST_TRANSFER_DATA = [
-    (DESC_VALID, True, True, DOC_ID_VALID, None, MhrRegistrationStatusTypes.ACTIVE),
+    (DESC_VALID, True, True, None, None, MhrRegistrationStatusTypes.ACTIVE),
     ('Valid no doc id not staff', True, False, None, None, None),
-    (DESC_MISSING_DOC_ID, False, True, None, validator.DOC_ID_REQUIRED, None),
-    (DESC_DOC_ID_EXISTS, False, True, DOC_ID_EXISTS, validator.DOC_ID_EXISTS, None),
     ('Invalid EXEMPT', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT),
     ('Invalid HISTORICAL', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL),
     (DESC_INVALID_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_INVALID, MhrRegistrationStatusTypes.ACTIVE),
@@ -497,10 +495,8 @@ TEST_TRANSFER_DATA = [
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content}, {status})
 TEST_EXEMPTION_DATA = [
-    (DESC_VALID, True, True, DOC_ID_VALID, None, MhrRegistrationStatusTypes.ACTIVE),
+    (DESC_VALID, True, True, None, None, MhrRegistrationStatusTypes.ACTIVE),
     ('Valid no doc id not staff', True, False, None, None, None),
-    (DESC_MISSING_DOC_ID, False, True, None, validator.DOC_ID_REQUIRED, None),
-    (DESC_DOC_ID_EXISTS, False, True, DOC_ID_EXISTS, validator.DOC_ID_EXISTS, None),
     ('Invalid EXEMPT', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT),
     ('Invalid HISTORICAL', False, False, None, validator.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL),
     ('Invalid note doc type', False, False, None, validator.NOTE_DOC_TYPE_INVALID, MhrRegistrationStatusTypes.ACTIVE)
@@ -524,7 +520,8 @@ TEST_TRANSFER_DATA_GROUP = [
     ('Invalid TC denominator missing', False, 1, None, TC_GROUPS_VALID, validator.GROUP_DENOMINATOR_MISSING),
     ('Invalid TC denominator < 1', False, 1, 0, TC_GROUPS_VALID, validator.GROUP_DENOMINATOR_MISSING),
     ('Invalid add SO 2 groups', False, None, None, SO_GROUP_MULTIPLE, validator.ADD_SOLE_OWNER_INVALID),
-    ('Invalid add SO 2 owners', False, None, None, SO_OWNER_MULTIPLE, validator.ADD_SOLE_OWNER_INVALID)
+    ('Invalid add SO 2 owners', False, None, None, SO_OWNER_MULTIPLE, validator.ADD_SOLE_OWNER_INVALID),
+    ('Invalid add TC > 1 owner', False, None, None, TC_GROUP_TRANSFER_ADD, validator.OWNERS_COMMON_INVALID)
 ]
 # testdata pattern is ({description}, {valid}, {party_type1}, {party_type2}, {text}, {add_group}, {message content})
 TEST_TRANSFER_DEATH_DATA = [
@@ -734,6 +731,8 @@ def test_validate_transfer_group(session, desc, valid, numerator, denominator, a
         json_data['addOwnerGroups'] = copy.deepcopy(add_group)
         if desc == 'Invalid add TC no owner':
             json_data['addOwnerGroups'][0]['owners'] = []
+        elif desc == 'Invalid add TC > 1 owner':
+            json_data['addOwnerGroups'][0]['type'] = 'COMMON'
         else:
             for group in json_data.get('addOwnerGroups'):
                 if not numerator:


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#13271
                 /bcgov/entity#15182

*Description of changes:*
- To support transfer due to death registrations add a new tenancy type "NA".
- 15182 registries staff auto-generate document id's for transfers, exemptions and permits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
