### PR TITLE
App Session Timing Bug

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -271,9 +271,11 @@ export default class App extends Mixins(AuthMixin) {
         }
       }
 
-      // if we are already authenticated then go right to init
+      // When we are authenticated, allow time for session storage propagation from auth, then initialize application
       // (since we won't get the event from Signin component)
-      if (this.isAuthenticated) this.onProfileReady(true)
+      if (this.isAuthenticated) {
+        setTimeout(() => { this.onProfileReady(true) }, this.isJestRunning ? 0 : 1000)
+      }
     }
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15220

*Description of changes:*
* Fixes minor bug that would impact SBC Staff accounts, attempting to request for Authentications before the Session storage would be propagated from the Common components sign in to the app session storage.
* Implemented 1s delay to allow for this propagation since the component which populates the session is a common/shared external component.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
