### PR TITLE
MHR,PPR staff payment set account id.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -482,7 +482,7 @@ class Db2Manuhome(db.Model):
     @classmethod
     def __update_group_type(cls, groups, existing_count: int = 0):
         """Set type if multiple active owner groups and a trustee, admin, executor exists."""
-        if not groups or (len(groups) + existing_count) == 1:
+        if not groups or (len(groups) + existing_count) == 1 and groups[0].get('type') == MhrTenancyTypes.SOLE:
             return groups
         for group in groups:
             for owner in group.get('owners'):

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -482,7 +482,7 @@ class Db2Manuhome(db.Model):
     @classmethod
     def __update_group_type(cls, groups, existing_count: int = 0):
         """Set type if multiple active owner groups and a trustee, admin, executor exists."""
-        if not groups or (len(groups) + existing_count) == 1 and groups[0].get('type') == MhrTenancyTypes.SOLE:
+        if not groups or ((len(groups) + existing_count) == 1 and groups[0].get('type') == MhrTenancyTypes.SOLE):
             return groups
         for group in groups:
             for owner in group.get('owners'):

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -644,7 +644,7 @@ def __update_summary_info(result, results, reg_summary_list, doc_types, staff, a
                 break
     else:
         result['registrationDescription'] = summary_result.get('reg_description')
-        result['username'] = summary_result.get('username')
+        # result['username'] = summary_result.get('username')  # Sorting by username does not work with this.
         if staff or account_id == summary_result.get('account_id'):
             if summary_result.get('report_url') or model_utils.report_retry_elapsed(summary_result.get('report_ts')):
                 if summary_result.get('registration_type') == MhrRegistrationTypes.MHREG:

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -365,7 +365,8 @@ class Report:  # pylint: disable=too-few-public-methods
             if self._report_data.get('addOwnerGroups'):
                 has_na: bool = False
                 for group in self._report_data.get('addOwnerGroups'):
-                    if group.get('type', '') == MhrTenancyTypes.NA:
+                    if group.get('type', '') == MhrTenancyTypes.NA and not group.get('interestNumerator') and \
+                            not group.get('interestDenominator'):
                         has_na = True
                     group['groupId'] = group_id
                     group_id += 1
@@ -375,7 +376,8 @@ class Report:  # pylint: disable=too-few-public-methods
             for group in self._report_data.get('ownerGroups'):
                 group['groupId'] = group_id
                 group_id += 1
-                if group.get('type', '') == MhrTenancyTypes.NA:
+                if group.get('type', '') == MhrTenancyTypes.NA and not group.get('interestNumerator') and \
+                        not group.get('interestDenominator'):
                     has_na = True
             self._report_data['hasNA'] = has_na
         elif self._report_key in (ReportTypes.SEARCH_DETAIL_REPORT, ReportTypes.SEARCH_BODY_REPORT):
@@ -385,7 +387,8 @@ class Report:  # pylint: disable=too-few-public-methods
                 for group in detail.get('ownerGroups'):
                     group['groupId'] = group_id
                     group_id += 1
-                    if group.get('type', '') == MhrTenancyTypes.NA:
+                    if group.get('type', '') == MhrTenancyTypes.NA and not group.get('interestNumerator') and \
+                            not group.get('interestDenominator'):
                         has_na = True
                 self._report_data['hasNA'] = has_na
 

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -261,7 +261,8 @@ def build_staff_payment(req: request, trans_type: str, quantity: int = 1, transa
     payment_info = {
         'transactionType': trans_type,
         'quantity': quantity,
-        'waiveFees': True
+        'waiveFees': True,
+        'accountId': resource_utils.get_staff_account_id(req)
     }
     if transaction_id:
         payment_info['transactionId'] = transaction_id

--- a/mhr_api/src/mhr_api/resources/utils.py
+++ b/mhr_api/src/mhr_api/resources/utils.py
@@ -85,6 +85,11 @@ def get_account_id(req):
     return req.headers.get('Account-Id')
 
 
+def get_staff_account_id(req):
+    """Get reg staff account ID from request headers."""
+    return req.headers.get('Staff-Account-Id')
+
+
 def is_pdf(req):
     """Check if request headers Accept is application/pdf."""
     accept = req.headers.get('Accept')

--- a/mhr_api/src/mhr_api/resources/v1/search_results.py
+++ b/mhr_api/src/mhr_api/resources/v1/search_results.py
@@ -301,7 +301,8 @@ def get_payment_details(search_detail: SearchResult, request_json):
 def build_staff_payment(req: request, account_id: str):
     """Extract staff payment information from request parameters."""
     payment_info = {
-        'waiveFees': True
+        'waiveFees': True,
+        'accountId': resource_utils.get_staff_account_id(req)
     }
     if is_bcol_help(account_id):
         return payment_info

--- a/mhr_api/src/mhr_api/services/payment/client/__init__.py
+++ b/mhr_api/src/mhr_api/services/payment/client/__init__.py
@@ -186,7 +186,7 @@ class BaseClient:
                 headers['Account-Id'] = self.account_id
             if self.api_key:
                 headers['x-apikey'] = self.api_key
-
+            current_app.logger.debug(f'Submitting pay-api request for Account-Id={self.account_id}')
             # current_app.logger.debug(json.dumps(headers))
             url = self.api_url + relative_path
             # current_app.logger.debug(method.value + ' url=' + url)
@@ -459,7 +459,7 @@ class SBCPaymentClient(BaseClient):
             del data['details']
         current_app.logger.debug('staff search create payment payload for account: ' + self.account_id)
         current_app.logger.debug(json.dumps(data))
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=False)
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
         return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def create_payment_staff(self, transaction_info, client_reference_id=None):
@@ -473,7 +473,7 @@ class SBCPaymentClient(BaseClient):
             del data['details']
         current_app.logger.debug('staff registration create payment payload: ')
         current_app.logger.debug(json.dumps(data))
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=False)
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
         return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def cancel_payment(self, invoice_id):

--- a/mhr_api/src/mhr_api/services/payment/payment.py
+++ b/mhr_api/src/mhr_api/services/payment/payment.py
@@ -123,7 +123,7 @@ class Payment:
         """
         try:
             api_instance = SBCPaymentClient(self.jwt,
-                                            self.account_id,
+                                            transaction_info.get('accountId'),
                                             self.api_key,
                                             self.details)
             if self.api_url:
@@ -147,7 +147,7 @@ class Payment:
         """
         try:
             api_instance = SBCPaymentClient(self.jwt,
-                                            self.account_id,
+                                            transaction_info.get('accountId'),
                                             self.api_key,
                                             self.details)
             if self.api_url:

--- a/mhr_api/tests/unit/api/test_search_results.py
+++ b/mhr_api/tests/unit/api/test_search_results.py
@@ -215,6 +215,7 @@ def test_staff_search(session, client, jwt, role, routing_slip, bcol_number, dat
     if role == GOV_ACCOUNT_ROLE:
         account_id = '1234'
     headers=create_header_account(jwt, roles, 'test-user', account_id)
+    headers['Staff-Account-Id'] = '3040'
     rv = client.post('/api/v1/searches',
                     json=MHR_NUMBER_JSON,
                     headers=headers,

--- a/mhr_api/tests/unit/services/test_payment.py
+++ b/mhr_api/tests/unit/services/test_payment.py
@@ -262,6 +262,7 @@ def test_payment_staff_search_mock(session, client, jwt, selection, routing_slip
     payment = Payment(jwt=token, account_id='PS12345', details=PAY_DETAILS_SEARCH)
     payment.api_url = MOCK_URL_NO_KEY
     transaction_info = {
+        'accountId': '3040'
     }
     if routing_slip:
         transaction_info['routingSlipNumber'] = routing_slip
@@ -396,7 +397,8 @@ def test_create_payment_data_staff(client, jwt, type, trans_id, client_id, routi
     """Assert that the staff payment payment-request body is as expected for a pay transaction type."""
     transaction_info = {
         'transactionType': type,
-        'quantity': 1
+        'quantity': 1,
+        'accountId': '3040'
     }
     if routing_slip:
         transaction_info['routingSlipNumber'] = routing_slip
@@ -456,7 +458,8 @@ def test_client_registration_staff_mock(session, client, jwt, type, trans_id, cl
     pay_client.api_url = MOCK_URL_NO_KEY
     transaction_info = {
         'transactionType': type,
-        'quantity': 1
+        'quantity': 1,
+        'accountId': '3040'
     }
     if routing_slip:
         transaction_info['routingSlipNumber'] = routing_slip
@@ -492,7 +495,8 @@ def test_pay_registration_staff_mock(session, client, jwt, type, trans_id, clien
     payment.api_url = MOCK_URL_NO_KEY
     transaction_info = {
         'transactionType': type,
-        'quantity': 1
+        'quantity': 1,
+        'accountId': '3040'
     }
     if routing_slip:
         transaction_info['routingSlipNumber'] = routing_slip

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -397,6 +397,66 @@ TC_GROUP_TRANSFER_ADD = [
         'interestDenominator': 2
     }
 ]
+TC_GROUP_TRANSFER_ADD2 = [
+    {
+        'groupId': 5,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }, {
+            'individualName': {
+                'first': 'Jane',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'JOINT',
+        'interest': 'UNDIVIDED',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }, {
+        'groupId': 6,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }
+]
 TC_GROUP_TRANSFER_DELETE_2 = [
     {
         'groupId': 3,
@@ -513,7 +573,7 @@ TEST_TRANSFER_DATA_EXTRA = [
 # testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {add_group}, {message content})
 TEST_TRANSFER_DATA_GROUP = [
     ('Valid', True, 1, 2, None, None),
-    ('Invalid add TC no owner', False, None, None, TC_GROUP_TRANSFER_ADD, validator.OWNERS_COMMON_INVALID),
+    ('Invalid add TC no owner', False, None, None, TC_GROUP_TRANSFER_ADD2, validator.OWNERS_COMMON_INVALID),
     ('Invalid add JT 1 owner', False, None, None, JT_OWNER_SINGLE, validator.OWNERS_JOINT_INVALID),
     ('Invalid TC numerator missing', False, None, 2, TC_GROUPS_VALID, validator.GROUP_NUMERATOR_MISSING),
     ('Invalid TC numerator < 1', False, 0, 2, TC_GROUPS_VALID, validator.GROUP_NUMERATOR_MISSING),
@@ -620,7 +680,7 @@ def test_validate_registration_group(session, desc, valid, numerator, denominato
     """Assert that new MH registration owner group validation works as expected."""
     # setup
     json_data = copy.deepcopy(REGISTRATION)
-    json_data['ownerGroups'] = groups
+    json_data['ownerGroups'] = copy.deepcopy(groups)
     if json_data.get('documentId'):
         del json_data['documentId']
     if desc == 'Invalid TC only 1 group':

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -539,8 +539,9 @@ TEST_TRANSFER_DEATH_DATA = [
 ]
 # testdata pattern is ({description}, {valid}, {mhr_num}, {tenancy_type}, {add_group}, {message content})
 TEST_TRANSFER_DEATH_NA_DATA = [
-    ('Invalid single active', False, '045349', MhrTenancyTypes.NA, TC_GROUP_TRANSFER_ADD,
-     validator.TENANCY_TYPE_NA_INVALID),
+    ('Valid JOINT active', True, '045349', MhrTenancyTypes.NA, TC_GROUP_TRANSFER_ADD, None),
+    ('Invalid JOINT tenancy-party type', False, '045349', MhrTenancyTypes.JOINT, TC_GROUP_TRANSFER_ADD,
+     validator.TENANCY_PARTY_TYPE_INVALID),
     ('Invalid tenancy type - party type', False, '080282', MhrTenancyTypes.JOINT, TC_GROUP_TRANSFER_ADD,
      validator.TENANCY_PARTY_TYPE_INVALID),
     ('Valid', True, '080282', MhrTenancyTypes.NA, TC_GROUP_TRANSFER_ADD, None)
@@ -769,6 +770,7 @@ def test_validate_transfer_death(session, desc, valid, party_type1, party_type2,
     if desc != 'No death invalid party type':
         json_data['deathOfOwner'] = True
     json_data['addOwnerGroups'] = copy.deepcopy(add_group)
+    json_data['addOwnerGroups'][0]['type'] = 'NA'
     owners = json_data['addOwnerGroups'][0]['owners']
     if text:
         owners[0]['description'] = text

--- a/ppr-api/src/ppr_api/resources/searches.py
+++ b/ppr-api/src/ppr_api/resources/searches.py
@@ -238,7 +238,8 @@ def staff_search(req: request, request_json, account_id: str):
 def build_staff_payment(req: request, account_id: str):
     """Extract payment information from request parameters."""
     payment_info = {
-        'transactionType': TransactionTypes.SEARCH_STAFF_NO_FEE.value
+        'transactionType': TransactionTypes.SEARCH_STAFF_NO_FEE.value,
+        'accountId': resource_utils.get_staff_account_id(req)
     }
     if is_bcol_help(account_id):
         return payment_info

--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -100,6 +100,11 @@ def get_account_id(req):
     return req.headers.get('Account-Id')
 
 
+def get_staff_account_id(req):
+    """Get reg staff account ID from request headers."""
+    return req.headers.get('Staff-Account-Id')
+
+
 def is_pdf(req):
     """Check if request headers Accept is application/pdf."""
     accept = req.headers.get('Accept')
@@ -381,7 +386,8 @@ def build_staff_registration_payment(req: request, pay_trans_type: str, fee_quan
     payment_info = {
         'transactionType': pay_trans_type,
         'feeQuantity': fee_quantity,
-        'waiveFees': False
+        'waiveFees': False,
+        'accountId': get_staff_account_id(req)
     }
 
     routing_slip = req.args.get(ROUTING_SLIP_PARAM)

--- a/ppr-api/src/ppr_api/services/payment/client/__init__.py
+++ b/ppr-api/src/ppr_api/services/payment/client/__init__.py
@@ -233,7 +233,7 @@ class BaseClient:
                 headers['Account-Id'] = self.account_id
             if self.api_key:
                 headers['x-apikey'] = self.api_key
-
+            current_app.logger.debug(f'Submitting pay-api request for Account-Id={self.account_id}')
             # current_app.logger.debug(json.dumps(headers))
             url = self.api_url + relative_path
             # current_app.logger.debug(method.value + ' url=' + url)
@@ -428,7 +428,7 @@ class SBCPaymentClient(BaseClient):
             del data['details']
         current_app.logger.debug('staff search create payment payload for account: ' + self.account_id)
         current_app.logger.debug(json.dumps(data))
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=False)
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
         return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def create_payment_staff_registration(self, transaction_info, client_reference_id=None, processing_fee=None):
@@ -442,7 +442,7 @@ class SBCPaymentClient(BaseClient):
             del data['details']
         current_app.logger.debug('staff registration create payment payload: ')
         current_app.logger.debug(json.dumps(data))
-        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=False)
+        invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
         return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def cancel_payment(self, invoice_id):

--- a/ppr-api/src/ppr_api/services/payment/payment.py
+++ b/ppr-api/src/ppr_api/services/payment/payment.py
@@ -92,7 +92,7 @@ class Payment:
         """
         try:
             api_instance = SBCPaymentClient(self.jwt,
-                                            self.account_id,
+                                            transaction_info.get('accountId'),
                                             self.api_key,
                                             self.details)
             if self.api_url:
@@ -113,7 +113,7 @@ class Payment:
         """
         try:
             api_instance = SBCPaymentClient(self.jwt,
-                                            None,
+                                            transaction_info.get('accountId'),
                                             self.api_key,
                                             self.details)
             if self.api_url:

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.0.9'  # pylint: disable=invalid-name
+__version__ = '1.1.0'  # pylint: disable=invalid-name

--- a/ppr-api/tests/unit/api/test_search_results.py
+++ b/ppr-api/tests/unit/api/test_search_results.py
@@ -75,11 +75,13 @@ def test_search_detail_valid_200(session, client, jwt):
         },
         'clientReferenceId': 'T-API-SQ-DB-2'
     }
+    headers = create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE)
+    headers['Staff-Account-Id'] = '3040'
 
     # test
     rv1 = client.post('/api/v1/searches',
                       json=json_data,
-                      headers=create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE),
+                      headers=headers,
                       content_type='application/json')
     search_id = rv1.json['searchId']
     json_data = []
@@ -151,11 +153,13 @@ def test_search_detail_staff_missing_account_400(session, client, jwt):
         },
         'clientReferenceId': 'T-API-SD-RN-1'
     }
+    headers = create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE)
+    headers['Staff-Account-Id'] = '3040'
 
     # test
     rv1 = client.post('/api/v1/searches',
                       json=json_data,
-                      headers=create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE),
+                      headers=headers,
                       content_type='application/json')
     assert rv1.status_code == HTTPStatus.CREATED
 
@@ -200,11 +204,13 @@ def test_search_detail_no_duplicates_200(session, client, jwt):
         },
         'clientReferenceId': 'T-API-SQ-DB-3'
     }
+    headers = create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE)
+    headers['Staff-Account-Id'] = '3040'
 
     # test
     rv1 = client.post('/api/v1/searches',
                       json=json_data,
-                      headers=create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE),
+                      headers=headers,
                       content_type='application/json')
     search_id = rv1.json['searchId']
     json_data = []

--- a/ppr-api/tests/unit/api/test_searches.py
+++ b/ppr-api/tests/unit/api/test_searches.py
@@ -126,9 +126,11 @@ def test_search_valid(session, client, jwt, search_type, json_data):
 def test_staff_search_certified(session, client, jwt, search_type, json_data):
     """Assert that valid staff certified search criteria returns a 201 status."""
     current_app.config.update(PAYMENT_SVC_URL=MOCK_PAY_URL)
+    headers = create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE)
+    headers['Staff-Account-Id'] = '3040'
     rv = client.post('/api/v1/searches?certified=true',
                      json=json_data,
-                     headers=create_header_account(jwt, [PPR_ROLE], 'test-user', STAFF_ROLE),
+                     headers=headers,
                      content_type='application/json')
     # check
     assert rv.status_code == HTTPStatus.CREATED
@@ -163,8 +165,10 @@ def test_staff_search(session, client, jwt, role, routing_slip, bcol_number, dat
     roles = [PPR_ROLE, role]
     if role == BCOL_HELP:
         headers = create_header_account(jwt, roles, 'test-user', BCOL_HELP)
+        headers['Staff-Account-Id'] = '3040'
     elif role == STAFF_ROLE:
         headers = create_header_account(jwt, roles, 'test-user', STAFF_ROLE)
+        headers['Staff-Account-Id'] = '3040'
     elif role == GOV_ACCOUNT_ROLE:
         headers = create_header_account(jwt, roles, 'test-user', '1234')
     else:

--- a/ppr-api/tests/unit/services/test_payment.py
+++ b/ppr-api/tests/unit/services/test_payment.py
@@ -84,7 +84,8 @@ TEST_PAY_STAFF_REGISTRATION = [
 def test_payment_data_staff_search(client, jwt, pay_trans_type, routing_slip, bcol_number, dat_number, waive_fees):
     """Assert that the staff payment payment-request body is as expected for a pay transaction type."""
     transaction_info = {
-        'transactionType': pay_trans_type
+        'transactionType': pay_trans_type,
+        'accountId': '3040'
     }
     if pay_trans_type in (TransactionTypes.SEARCH_STAFF_CERTIFIED_NO_FEE.value,
                           TransactionTypes.SEARCH_STAFF_NO_FEE.value):
@@ -130,7 +131,8 @@ def test_payment_staff_search_mock(client, jwt, pay_trans_type, routing_slip, bc
     payment = Payment(jwt=token, account_id='PS12345', details=PAY_DETAILS_SEARCH)
     payment.api_url = MOCK_URL_NO_KEY
     transaction_info = {
-        'transactionType': pay_trans_type
+        'transactionType': pay_trans_type,
+        'accountId': '3040'
     }
     if pay_trans_type in (TransactionTypes.SEARCH_STAFF_CERTIFIED_NO_FEE.value,
                           TransactionTypes.SEARCH_STAFF_NO_FEE.value):
@@ -157,7 +159,8 @@ def test_payment_data_staff_registration(client, jwt, pay_trans_type, routing_sl
     """Assert that the staff payment payment-request body is as expected for a pay transaction type."""
     transaction_info = {
         'transactionType': pay_trans_type,
-        'feeQuantity': 1
+        'feeQuantity': 1,
+        'accountId': '3040'
     }
     if waive_fees:
         transaction_info['waiveFees'] = True
@@ -199,7 +202,8 @@ def test_payment_staff_registration_mock(client, jwt, pay_trans_type, routing_sl
     payment.api_url = MOCK_URL_NO_KEY
     transaction_info = {
         'transactionType': pay_trans_type,
-        'feeQuantity': 1
+        'feeQuantity': 1,
+        'accountId': '3040'
     }
     if waive_fees:
         transaction_info['waiveFees'] = True


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#15153

*Description of changes:*
- MHR API set the original staff account id in the pay api request.
- PPR API set the original staff account id in the pay api request.
- 15271 JOINT tenancy type owner group with executor... is now NA tenancy type. 
- 15271 COMMON tenancy type all active owners are executor... is COMMON report home tenancy type. 
- Minor tweak to improve registration username sorting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
