### PR TITLE
ReadOnly Interest Text

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
@@ -15,11 +15,11 @@
       </p>
       <v-text-field
         :id="`interest-type-group-${groupId}`"
-        label="Interest Type (Optional)"
+        label="Interest Type"
         filled
         class="background-white"
-        v-model="fractionalData.interest"
-        :rules="isLettersOnly('Do not include the fraction in the Interest Type field.')"
+        v-model="interestText"
+        disabled
         :data-test-id="`interest-type-field-group-${groupId}`"
       />
       <div class="owner-fractions">
@@ -66,6 +66,7 @@ import { MhrRegistrationHomeOwnerIF } from '@/interfaces'
 
 import { computed, defineComponent, reactive, toRefs } from '@vue/composition-api'
 import { useInputRules } from '@/composables/useInputRules'
+import { toTitleCase } from '@/utils'
 
 let DEFAULT_OWNER_ID = 1
 
@@ -99,6 +100,9 @@ export default defineComponent({
 
     const localState = reactive({
       id: props.editHomeOwner?.ownerId || (DEFAULT_OWNER_ID++).toString(),
+      interestText: computed(() =>
+        toTitleCase(props.fractionalData.interest)
+      ),
       fractionalInterest: computed(
         () =>
           // eslint-disable-next-line max-len
@@ -163,6 +167,10 @@ export default defineComponent({
       top: 3px;
       position: relative;
     }
+  }
+
+  .theme--light.v-text-field--filled.v-input--is-disabled > .v-input__control > .v-input__slot {
+    border-bottom: 1px dotted;
   }
 }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -176,6 +176,7 @@ import { find } from 'lodash'
 /* eslint-disable no-unused-vars */
 import { MhrRegistrationFractionalOwnershipIF, MhrHomeOwnerGroupIF } from '@/interfaces/mhr-registration-interfaces'
 import { ActionTypes } from '@/enums'
+import { toTitleCase } from '@/utils'
 /* eslint-enable no-unused-vars */
 
 export default defineComponent({
@@ -239,7 +240,7 @@ export default defineComponent({
       const { interest, interestNumerator, interestDenominator } = localState.group
       if (!interestNumerator || !interestDenominator) return 'N/A'
 
-      return `${interest} ${interestNumerator}/${interestDenominator}`
+      return `${toTitleCase(interest)} ${interestNumerator}/${interestDenominator}`
     }
 
     const isRemovedHomeOwnerGroup = (group: MhrHomeOwnerGroupIF): boolean => {

--- a/ppr-ui/src/utils/format-helper.ts
+++ b/ppr-ui/src/utils/format-helper.ts
@@ -39,3 +39,12 @@ export function fromDisplayPhone (phoneNumber: string): string {
     return match[1] + match[2] + match[3]
   } else return phoneNumber
 }
+
+/**
+ * Formats a string word to title case for display.
+ * @param value the string word to format
+ * @returns a title case string word
+ */
+export function toTitleCase (value: string): string {
+  return value[0].toUpperCase() + value.slice(1).toLowerCase()
+}

--- a/ppr-ui/src/utils/format-helper.ts
+++ b/ppr-ui/src/utils/format-helper.ts
@@ -46,5 +46,5 @@ export function fromDisplayPhone (phoneNumber: string): string {
  * @returns a title case string word
  */
 export function toTitleCase (value: string): string {
-  return value[0].toUpperCase() + value.slice(1).toLowerCase()
+  return (value[0]?.toUpperCase() + value.slice(1)?.toLowerCase()) || ''
 }

--- a/ppr-ui/tests/unit/test-data/mock-mhr-transfer.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-transfer.ts
@@ -7,6 +7,7 @@ import {
 
 export const mockMhrTransferCurrentHomeOwner = {
   groupId: 1,
+  interest: 'Undivided',
   interestNumerator: 1,
   interestDenominator: 1,
   owners: [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15138

*Description of changes:*
* Updated Interest Text field to be read only for Transfers and Registrations.
* TitleCase mapping method for display.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
