### PR TITLE
Added certified search option for staff payment

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -198,15 +198,9 @@ export default defineComponent({
     const localState = reactive({
       feeType: props.setFeeType,
       registrationType: props.setRegistrationType,
-      hasPriorityFee: computed((): Boolean => {
-        return getStaffPayment.value?.isPriority
-      }),
-      hasCertifyFee: computed((): Boolean => {
-        return isSearchCertified.value
-      }),
-      registrationLength: computed((): RegistrationLengthI => {
-        return props.setRegistrationLength
-      }),
+      hasPriorityFee: computed((): Boolean => getStaffPayment.value?.isPriority),
+      hasCertifyFee: computed((): Boolean => isSearchCertified.value),
+      registrationLength: computed((): RegistrationLengthI => props.setRegistrationLength),
       isValid: computed((): boolean => {
         return getLengthTrust.value.valid ||
           [FeeSummaryTypes.MHSEARCH, FeeSummaryTypes.NEW_MHR, FeeSummaryTypes.MHR_TRANSFER].includes(localState.feeType)

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -83,6 +83,19 @@
           </div>
         </li>
         <li
+          v-if="hasCertifyFee"
+          id="certify-fee"
+          :class="[$style['fee-container'], $style['fee-list__item'], 'pb-4', 'pr-4', 'py-4']"
+          key="CertifyFee"
+        >
+          <div :class="$style['fee-list__item-name']">
+            Certified search
+          </div>
+          <div :class="$style['fee-list__item-value']">
+            $ 25.00
+          </div>
+        </li>
+        <li
           v-if="hasProcessingFee"
           id="processing-fee-summary"
           :class="[$style['fee-container'], $style['fee-list__item'], 'pb-4', 'pr-4', 'py-4']"
@@ -178,15 +191,18 @@ export default defineComponent({
   },
   setup (props) {
     const {
-      getLengthTrust, isRoleStaff, getStaffPayment
+      getLengthTrust, isRoleStaff, getStaffPayment, isSearchCertified
     } = useGetters<any>([
-      'getLengthTrust', 'isRoleStaff', 'getStaffPayment'
+      'getLengthTrust', 'isRoleStaff', 'getStaffPayment', 'isSearchCertified'
     ])
     const localState = reactive({
       feeType: props.setFeeType,
       registrationType: props.setRegistrationType,
       hasPriorityFee: computed((): Boolean => {
         return getStaffPayment.value?.isPriority
+      }),
+      hasCertifyFee: computed((): Boolean => {
+        return isSearchCertified.value
       }),
       registrationLength: computed((): RegistrationLengthI => {
         return props.setRegistrationLength
@@ -266,6 +282,9 @@ export default defineComponent({
           }
           if (getStaffPayment.value?.isPriority) {
             extraFee = extraFee + 100
+          }
+          if (localState.hasCertifyFee) {
+            extraFee += 25
           }
           return (
             (localState.feeSummary.feeAmount *

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -608,6 +608,7 @@ function addSortParams (url: string, sortOptions: RegistrationSortIF): string {
     if (sortOptions[sortKeys[i]] === 'registeringParty') sortOptions[sortKeys[i]] = 'submittingName'
     if (sortOptions[sortKeys[i]] === 'ownerNames') sortOptions[sortKeys[i]] = 'ownerName'
     if (sortOptions[sortKeys[i]] === 'registrationDescription') sortOptions[sortKeys[i]] = 'registrationType'
+    if (sortOptions[sortKeys[i]] === 'registeringName') sortOptions[sortKeys[i]] = 'username'
     // add timestamp onto datetime param values
     if (sortOptions[sortKeys[i]] && ['startDateTime', 'endDateTime'].includes(UIFilterToApiFilter[sortKeys[i]])) {
       sortOptions[sortKeys[i]] =

--- a/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
+++ b/ppr-ui/src/views/mhrSearch/ConfirmMHRSearch.vue
@@ -64,6 +64,17 @@
                 @update:staffPaymentData="onStaffPaymentDataUpdate($event)"
                 @valid="staffPaymentValid = $event"
               />
+              <v-row no-gutters>
+                <v-spacer></v-spacer>
+                <v-col cols="12" :sm="9">
+                  <v-checkbox
+                    class="mt-2"
+                    id="certify-checkbox"
+                    label="Make this a Certified Search ($25.00)"
+                    @change="setSearchCertified($event)"
+                  />
+                </v-col>
+              </v-row>
             </v-card>
           </section>
 
@@ -150,6 +161,7 @@ export default class ConfirmMHRSearch extends Vue {
 
   @Action setUnsavedChanges: ActionBindingIF
   @Action setStaffPayment!: ActionBindingIF
+  @Action setSearchCertified!: ActionBindingIF
 
   /** Whether App is ready. */
   @Prop({ default: false })

--- a/ppr-ui/tests/unit/FeeSummary.spec.ts
+++ b/ppr-ui/tests/unit/FeeSummary.spec.ts
@@ -714,4 +714,66 @@ describe('FeeSummary component tests', () => {
     expect(wrapper.find('#priority-fee').text()).toContain('Priority Fee')
     expect(wrapper.find('#priority-fee').text()).toContain('$ 100.00')
   })
+
+  it('renders certify search fee for a MHR Search as Staff on behalf of a client', async () => {
+    const state = wrapper.vm.$store.state.stateModel as StateModelIF
+    state.authorization.authRoles = ['staff']
+    state.search.searchCertified = true
+    expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
+    await wrapper.setProps({
+      setFeeType: FeeSummaryTypes.MHSEARCH,
+      setFeeQuantity: 1,
+      setRegistrationLength: null,
+      setRegistrationType: null,
+      setStaffReg: true,
+      setStaffClientPayment: true
+    })
+    await store.dispatch('setStaffPayment')
+    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.MHSEARCH)
+    expect(wrapper.vm.$data.registrationType).toBe(null)
+    expect(wrapper.vm.$data.feeLabel).toBe('Manufactured Home search')
+    expect(wrapper.vm.$data.feeSummary.feeAmount).toBe(10)
+    expect(wrapper.vm.$data.feeSummary.quantity).toBe(1)
+    expect(wrapper.find('#processing-fee-summary').text()).toContain('No Fee')
+    expect(wrapper.vm.$data.totalFees).toBe(10)
+    expect(wrapper.vm.$data.totalAmount).toBe(35)
+    expect(wrapper.vm.$data.isComplete).toBe(true)
+    expect(wrapper.vm.$data.hintFee).toBe('')
+    expect(wrapper.find('#priority-fee').exists()).toBe(false)
+    expect(wrapper.find('#certify-fee').exists()).toBe(true)
+    expect(wrapper.find('#certify-fee').text()).toContain('Certified search')
+    expect(wrapper.find('#certify-fee').text()).toContain('$ 25.00')
+  })
+
+  it('renders certify search and priority fee for a MHR Search as Staff on behalf of a client', async () => {
+    const state = wrapper.vm.$store.state.stateModel as StateModelIF
+    state.authorization.authRoles = ['staff']
+    state.search.searchCertified = true
+    expect(wrapper.findComponent(FeeSummary).exists()).toBe(true)
+    await wrapper.setProps({
+      setFeeType: FeeSummaryTypes.MHSEARCH,
+      setFeeQuantity: 1,
+      setRegistrationLength: null,
+      setRegistrationType: null,
+      setStaffReg: true,
+      setStaffClientPayment: true
+    })
+    await store.dispatch('setStaffPayment', { isPriority: true })
+    expect(wrapper.vm.$data.feeType).toBe(FeeSummaryTypes.MHSEARCH)
+    expect(wrapper.vm.$data.registrationType).toBe(null)
+    expect(wrapper.vm.$data.feeLabel).toBe('Manufactured Home search')
+    expect(wrapper.vm.$data.feeSummary.feeAmount).toBe(10)
+    expect(wrapper.vm.$data.feeSummary.quantity).toBe(1)
+    expect(wrapper.find('#processing-fee-summary').text()).toContain('No Fee')
+    expect(wrapper.vm.$data.totalFees).toBe(10)
+    expect(wrapper.vm.$data.totalAmount).toBe(135)
+    expect(wrapper.vm.$data.isComplete).toBe(true)
+    expect(wrapper.vm.$data.hintFee).toBe('')
+    expect(wrapper.find('#priority-fee').exists()).toBe(true)
+    expect(wrapper.find('#priority-fee').text()).toContain('Priority Fee')
+    expect(wrapper.find('#priority-fee').text()).toContain('$ 100.00')
+    expect(wrapper.find('#certify-fee').exists()).toBe(true)
+    expect(wrapper.find('#certify-fee').text()).toContain('Certified search')
+    expect(wrapper.find('#certify-fee').text()).toContain('$ 25.00')
+  })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15030

*Description of changes:*
- Added checkbox option for certified search on staff payment searches
- Update fee summary and API report call
- Updated tests
- Fix for username sort in ticket 14335

![image](https://user-images.githubusercontent.com/112968185/217665811-571beac7-342c-4759-a4de-ab6ef8777229.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
