### PR TITLE
Hotfix for PPR Debtor DOB

### DIFF
--- a/ppr-ui/src/composables/useParty.ts
+++ b/ppr-ui/src/composables/useParty.ts
@@ -21,7 +21,11 @@ export const useParty = () => {
 
   const getFormattedBirthdate = (party: PartyIF): string => {
     if (party.birthDate) {
-      const date = new Date(party.birthDate)
+      let date = new Date(party.birthDate)
+      // prod hotfix to check if browser does not support locales
+      if (!(date instanceof Date && !isNaN(date.valueOf()))) {
+        date = new Date(party.birthDate.substring(0, party.birthDate.indexOf('T')))
+      }
       return (
         date.toLocaleString('default', { month: 'long' }) +
         ' ' +


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15375

*Description of changes:*

- Quick fix to a PPR Debtor DOB if the browser cannot parse the date properly
- Would need to implement a proper solution

*Solution*

1. Check if the browser cannot create a Date instance from date string
2. Shorten `1/1/2000T00:00:00-08:00` to this -> `1/1/2000`
3. Then it can properly create a Date instance


*References*

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString


**Before / After (Firefox)**

<img width="916" alt="Screen Shot 2023-02-14 at 12 43 23 PM" src="https://user-images.githubusercontent.com/2333290/218859822-4fcdf303-04d6-44a1-bfa8-cc9cbe6e490d.png">

<img width="935" alt="Screen Shot 2023-02-14 at 12 43 03 PM" src="https://user-images.githubusercontent.com/2333290/218859841-dc0ccaa9-c5a0-4dfe-9bbe-35b58c9a1d7b.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
