### PR TITLE
Minor change to display service fee in UI

### DIFF
--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -136,6 +136,7 @@
           v-else-if="hasProcessingFee && feeSummary.processingFee > 0"
           id="processing-fee-summary"
           :class="[$style['fee-container'], $style['fee-list__item'], 'pb-4', 'pr-4', 'py-4']"
+          key="MHRProcessingFeeKey"
         >
           <div :class="$style['fee-list__item-name']">
             Staff Processing Fee
@@ -147,6 +148,7 @@
         <li
           v-else-if="feeSummary && feeSummary.serviceFee > 0"
           :class="[$style['fee-container'], $style['fee-list__item'], 'pb-4', 'pr-4', 'py-4']"
+          key="MHRServiceFeeKey"
         >
           <div :class="$style['fee-list__item-name']">
             Service Fee


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13280

Found a bug in review where on a client account, the fee summary would total the correct amount, but the service fee of $1.50 was not being displayed in the summary

*Description of changes:*
- Added keys to list items to display on specific user types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
