### PR TITLE
Business Search for PPR Debtor & Secured Party

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -319,7 +319,7 @@ import {
 } from '@vue/composition-api'
 import { useInputRules } from '@/composables/useInputRules'
 import { useHomeOwners, useMhrValidations } from '@/composables/mhrRegistration'
-import { AutoComplete } from '@/components/search'
+import { AutoComplete, BusinessSearchAutocomplete } from '@/components/search'
 import { BaseAddress } from '@/composables/address'
 import { PartyAddressSchema } from '@/schemas'
 import { focusOnFirstError, fromDisplayPhone } from '@/utils'
@@ -336,7 +336,6 @@ import { SimpleHelpToggle } from '@/components/common'
 import HomeOwnerGroups from './HomeOwnerGroups.vue'
 import { useActions, useGetters } from 'vuex-composition-helpers'
 import { find } from 'lodash'
-import { BusinessSearchAutocomplete } from '@/components/mhrTransfers'
 
 interface FractionalOwnershipWithGroupIdIF extends MhrRegistrationFractionalOwnershipIF {
   groupId: number

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -319,7 +319,7 @@ import {
 } from '@vue/composition-api'
 import { useInputRules } from '@/composables/useInputRules'
 import { useHomeOwners, useMhrValidations } from '@/composables/mhrRegistration'
-import { AutoComplete, BusinessSearchAutocomplete } from '@/components/search'
+import { BusinessSearchAutocomplete } from '@/components/search'
 import { BaseAddress } from '@/composables/address'
 import { PartyAddressSchema } from '@/schemas'
 import { focusOnFirstError, fromDisplayPhone } from '@/utils'
@@ -347,7 +347,6 @@ export default defineComponent({
   name: 'AddEditHomeOwner',
   emits: ['remove', 'cancel'],
   components: {
-    AutoComplete,
     BaseAddress,
     SimpleHelpToggle,
     HomeOwnerGroups,

--- a/ppr-ui/src/components/mhrTransfers/index.ts
+++ b/ppr-ui/src/components/mhrTransfers/index.ts
@@ -1,4 +1,3 @@
 export { default as TransferDetails } from './TransferDetails.vue'
 export { default as TransferDetailsReview } from './TransferDetailsReview.vue'
 export { default as ConfirmCompletion } from './ConfirmCompletion.vue'
-export { default as BusinessSearchAutocomplete } from './BusinessSearchAutocomplete.vue'

--- a/ppr-ui/src/components/parties/debtor/EditDebtor.vue
+++ b/ppr-ui/src/components/parties/debtor/EditDebtor.vue
@@ -43,7 +43,11 @@
                   ref="debtorNameSearchField"
                   label="Find or enter the Full Legal Name of the Business"
                   v-model="searchValue"
-                  :rules="debtorNameRules"
+                  :error-messages="
+                    errors.businessName.message
+                      ? errors.businessName.message
+                      : ''
+                  "
                   persistent-hint
                   :clearable="showClear"
                   @click:clear="showClear = false"
@@ -266,7 +270,6 @@ import { useDebtor } from '@/components/parties/composables/useDebtor'
 import { useDebtorValidation } from '@/components/parties/composables/useDebtorValidation'
 import { formatAddress } from '@/composables/address/factories'
 import { useValidation } from '@/utils/validators/use-validation'
-import { useInputRules } from '@/composables/useInputRules'
 
 export default defineComponent({
   name: 'EditDebtor',
@@ -327,8 +330,6 @@ export default defineComponent({
       validateBusinessName
     } = useValidation()
 
-    const { required, customRules, maxLength } = useInputRules()
-
     const localState = reactive({
       autoCompleteIsActive: true,
       autoCompleteSearchValue: '',
@@ -342,11 +343,7 @@ export default defineComponent({
       }),
       showErrorBar: computed((): boolean => {
         return props.setShowErrorBar
-      }),
-      debtorNameRules: customRules(
-        required('Enter a business name'),
-        maxLength(70)
-      )
+      })
     })
 
     const onSubmitForm = async () => {

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -85,7 +85,11 @@
                       ref="partyNameSearchField"
                       label="Find or enter the Full Legal Name of the Business"
                       v-model="searchValue"
-                      :rules="partyNameRules"
+                      :error-messages="
+                        errors.businessName.message
+                          ? errors.businessName.message
+                          : ''
+                      "
                       persistent-hint
                       :clearable="showClear"
                       @click:clear="showClear = false"
@@ -264,7 +268,6 @@ import { formatAddress } from '@/composables/address/factories'
 import { SearchPartyIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { partyCodeSearch } from '@/utils'
 import { useValidation } from '@/utils/validators/use-validation'
-import { useInputRules } from '@/composables/useInputRules'
 import { isEqual } from 'lodash'
 
 export default defineComponent({
@@ -330,8 +333,6 @@ export default defineComponent({
       validateBusinessName
     } = useValidation()
 
-    const { required, customRules, maxLength } = useInputRules()
-
     const localState = reactive({
       autoCompleteIsActive: true,
       autoCompleteSearchValue: '',
@@ -350,11 +351,7 @@ export default defineComponent({
       }),
       showErrorBar: computed((): boolean => {
         return props.setShowErrorBar
-      }),
-      partyNameRules: customRules(
-        required('Enter a business name'),
-        maxLength(70)
-      )
+      })
     })
 
     const showDialog = () => {

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -82,24 +82,35 @@
                     <v-text-field
                       filled
                       id="txt-name-party"
-                      label="Business Legal Name"
-                      @keyup="validateNameField()"
+                      ref="partyNameSearchField"
+                      label="Find or enter the Full Legal Name of the Business"
                       v-model="searchValue"
-                      :error-messages="
-                        errors.businessName.message
-                          ? errors.businessName.message
-                          : ''
-                      "
+                      :rules="partyNameRules"
                       persistent-hint
-                    />
-                    <auto-complete
+                      :clearable="showClear"
+                      @click:clear="showClear = false"
+                    >
+                      <template v-slot:append>
+                        <v-progress-circular
+                          v-if="loadingSearchResults"
+                          indeterminate
+                          color="primary"
+                          class="mx-3"
+                          :size="25"
+                          :width="3"
+                        />
+                      </template>
+                    </v-text-field>
+
+                    <BusinessSearchAutocomplete
                       :searchValue="autoCompleteSearchValue"
                       :setAutoCompleteIsActive="autoCompleteIsActive"
                       v-click-outside="setCloseAutoComplete"
                       @search-value="setSearchValue"
-                      @hide-details="setHideDetails"
-                    >
-                    </auto-complete>
+                      @searching="loadingSearchResults = $event"
+                      :showDropdown="$refs.partyNameSearchField && $refs.partyNameSearchField.isFocused"
+                      isPPR
+                    />
                   </v-col>
                 </v-row>
                 <v-row v-else no-gutters>
@@ -243,7 +254,7 @@ import {
 } from '@vue/composition-api'
 // local components
 import { SecuredPartyDialog } from '@/components/dialogs'
-import { AutoComplete } from '@/components/search'
+import { BusinessSearchAutocomplete } from '@/components/search'
 import { BaseAddress } from '@/composables/address'
 import { SecuredPartyTypes } from '@/enums'
 // local helpers / types / etc.
@@ -253,13 +264,15 @@ import { formatAddress } from '@/composables/address/factories'
 import { SearchPartyIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { partyCodeSearch } from '@/utils'
 import { useValidation } from '@/utils/validators/use-validation'
+import { useInputRules } from '@/composables/useInputRules'
 import { isEqual } from 'lodash'
 
 export default defineComponent({
+  name: 'EditParty',
   components: {
     BaseAddress,
-    AutoComplete,
-    SecuredPartyDialog
+    SecuredPartyDialog,
+    BusinessSearchAutocomplete
   },
   props: {
     activeIndex: {
@@ -317,12 +330,15 @@ export default defineComponent({
       validateBusinessName
     } = useValidation()
 
+    const { required, customRules, maxLength } = useInputRules()
+
     const localState = reactive({
       autoCompleteIsActive: true,
       autoCompleteSearchValue: '',
       foundDuplicate: false,
       searchValue: '',
-      hideDetails: false,
+      loadingSearchResults: false,
+      showClear: false,
       toggleDialog: false,
       dialogResults: [],
       showAllAddressErrors: false,
@@ -334,7 +350,11 @@ export default defineComponent({
       }),
       showErrorBar: computed((): boolean => {
         return props.setShowErrorBar
-      })
+      }),
+      partyNameRules: customRules(
+        required('Enter a business name'),
+        maxLength(70)
+      )
     })
 
     const showDialog = () => {
@@ -357,7 +377,6 @@ export default defineComponent({
       if (validateSecuredPartyForm(partyType.value, currentSecuredParty, localState.isRegisteringParty)) {
         if (partyType.value === SecuredPartyTypes.INDIVIDUAL) {
           currentSecuredParty.value.businessName = ''
-          // localState.searchValue = ''
         } else {
           currentSecuredParty.value.personName.first = ''
           currentSecuredParty.value.personName.middle = ''
@@ -419,10 +438,6 @@ export default defineComponent({
       currentSecuredParty.value.businessName = searchValueTyped
     }
 
-    const setHideDetails = (hideDetails: boolean) => {
-      localState.hideDetails = hideDetails
-    }
-
     const setCloseAutoComplete = () => {
       localState.autoCompleteIsActive = false
     }
@@ -430,9 +445,14 @@ export default defineComponent({
     watch(
       () => localState.searchValue,
       (val: string) => {
-        localState.autoCompleteSearchValue = val
-        // show autocomplete results when there is a searchValue
-        localState.autoCompleteIsActive = val !== ''
+        if (val?.length >= 3) {
+          localState.autoCompleteSearchValue = val
+          // only open if debtor name changed
+          localState.autoCompleteIsActive = val !== ''
+        } else {
+          localState.autoCompleteSearchValue = val
+          localState.autoCompleteIsActive = false
+        }
         currentSecuredParty.value.businessName = val
       }
     )
@@ -456,7 +476,6 @@ export default defineComponent({
       updateValidity,
       validateNameField,
       setSearchValue,
-      setHideDetails,
       setCloseAutoComplete,
       errors,
       closeAndReset,

--- a/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
@@ -113,7 +113,7 @@ export default defineComponent({
 
     const updateAutoCompleteResults = async (searchValue: string) => {
       localState.searching = true
-      const response: SearchResponseI = await searchBusiness(searchValue)
+      const response: SearchResponseI = await searchBusiness(searchValue, props.isPPR)
       // check if results are still relevant before updating list
       if (searchValue === props.searchValue && response?.searchResults.results) {
         localState.autoCompleteResults = response?.searchResults.results

--- a/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
@@ -86,6 +86,10 @@ export default defineComponent({
     },
     showDropdown: {
       type: Boolean
+    },
+    isPPR: {
+      type: Boolean,
+      default: false
     }
   },
   setup (props, { emit }) {
@@ -118,7 +122,8 @@ export default defineComponent({
     }
 
     const isBusinessTypeSPGP = (businessType: BusinessTypes): boolean => {
-      return [BusinessTypes.GENERAL_PARTNERSHIP, BusinessTypes.SOLE_PROPRIETOR].includes(businessType)
+      // include all business types for PPR business searches
+      return [BusinessTypes.GENERAL_PARTNERSHIP, BusinessTypes.SOLE_PROPRIETOR].includes(businessType) && !props.isPPR
     }
 
     watch(

--- a/ppr-ui/src/components/search/index.ts
+++ b/ppr-ui/src/components/search/index.ts
@@ -1,3 +1,4 @@
 export { default as SearchBar } from './SearchBar.vue'
 export { default as SearchBarList } from './SearchBarList.vue'
 export { default as AutoComplete } from './AutoComplete.vue'
+export { default as BusinessSearchAutocomplete } from './BusinessSearchAutocomplete.vue'

--- a/ppr-ui/src/composables/useSearch.ts
+++ b/ppr-ui/src/composables/useSearch.ts
@@ -37,20 +37,30 @@ export const useSearch = () => {
 
     return { baseURL: url, headers: { 'Account-Id': currentAccountId, 'x-apikey': apiKey }, params: params }
   }
-  const searchBusiness = async (searchValue: string): Promise<SearchResponseI> => {
+  /**
+   * Search for a Business Name using Registry Search API
+   * @param searchValue search term, which is required
+   * @param isPPR search for active and historical statuses is search is for PPR
+   * @returns array of search results
+   */
+  const searchBusiness = async (searchValue: string, isPPR: boolean = false): Promise<SearchResponseI> => {
     if (!searchValue) return
     // basic params
     const params = { query: `value:${searchValue}`, categories: 'status:active', start: 0, rows: SEARCH_RESULT_SIZE }
+    // include all statuses for PPR business searches by removing categories filter
+    isPPR && delete params.categories
     // add search-api config stuff
     const config = getSearchConfig(params)
-    return axios.get<SearchResponseI>('businesses/search/facets', config)
+    return axios
+      .get<SearchResponseI>('businesses/search/facets', config)
       .then(response => {
         const data: SearchResponseI = response?.data
         if (!data) {
           throw new Error('Invalid API response')
         }
         return data
-      }).catch(error => {
+      })
+      .catch(error => {
         return {
           searchResults: null,
           error: {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15113

*Description of changes:*
- Use `BusinessSearchAutocomplete` component (aka business search api) in PPR instead of Org Lookup api
- Use it for Debtor and Secured Party
- Cleanup and small refactors

### Screenshot
<img width="1115" alt="Screen Shot 2023-02-22 at 8 01 49 PM" src="https://user-images.githubusercontent.com/2333290/220818701-040b016e-1509-44ea-a790-7ac37b20fc06.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
