### PR TITLE
Remove tenancy checkbox section in add/edit owner

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -446,8 +446,7 @@ export default defineComponent({
         type: group?.type || '',
         interest: group?.interest || 'Undivided',
         interestNumerator: group?.interestNumerator || null,
-        interestDenominator: group?.interestDenominator || null,
-        tenancySpecified: group?.tenancySpecified || false
+        interestDenominator: group?.interestDenominator || null
       }
     }) as FractionalOwnershipWithGroupIdIF[]
 
@@ -466,8 +465,7 @@ export default defineComponent({
         type: 'N/A',
         interest: 'Undivided',
         interestNumerator: null,
-        interestDenominator: defaultLcm,
-        tenancySpecified: false
+        interestDenominator: defaultLcm
       } as FractionalOwnershipWithGroupIdIF)
     }
 
@@ -555,7 +553,6 @@ export default defineComponent({
           delete localState.group.interest
           delete localState.group.interestNumerator
           delete localState.group.interestDenominator
-          delete localState.group.tenancySpecified
         }
 
         if (props.isMhrTransfer) setUnsavedChanges(props.editHomeOwner !== localState.owner)

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -267,7 +267,7 @@
             :isMhrTransfer="isMhrTransfer"
           />
         </v-form>
-        <v-row>
+        <v-row class="py-6">
           <v-col>
             <div class="form__row form__btns">
               <v-btn

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
@@ -76,8 +76,7 @@ export default defineComponent({
         type: '',
         interest: 'Undivided',
         interestNumerator: null,
-        interestDenominator: null,
-        tenancySpecified: null
+        interestDenominator: null
       },
       required: true
     },

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/FractionalOwnership.vue
@@ -52,14 +52,6 @@
           @blur="$refs.interestNumerator.validate()"
         />
       </div>
-      <label class="generic-label" for="tenancy-type">Tenancy</label>
-      <v-checkbox :id="`tenancy-type-group-${groupId}`" v-model="fractionalData.tenancySpecified">
-        <template v-slot:label>
-          <p class="ma-0">
-            Tenancy not specified
-          </p>
-        </template>
-      </v-checkbox>
     </div>
   </div>
 </template>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -145,7 +145,7 @@
     </div>
 
     <!-- Group Edit -->
-    <div v-else>
+    <div v-else class="py-8">
       <v-row>
         <v-col cols="3">
           <label class="generic-label"> Edit Group </label>
@@ -153,7 +153,7 @@
         <v-col cols="9">
           <label class="generic-label"> Group {{ groupId }} Details: </label>
 
-          <v-form class="my-5" ref="homeFractionalOwnershipForm" v-model="isHomeFractionalOwnershipValid">
+          <v-form class="mt-5" ref="homeFractionalOwnershipForm" v-model="isHomeFractionalOwnershipValid">
             <FractionalOwnership
               :groupId="groupId"
               :fractionalData="fractionalData"

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -242,8 +242,7 @@ export default defineComponent({
         type: localState.group?.type || '',
         interest: localState.group?.interest || 'Undivided',
         interestNumerator: localState.group?.interestNumerator || null,
-        interestDenominator: localState.group?.interestDenominator || null,
-        tenancySpecified: localState.group?.tenancySpecified || false
+        interestDenominator: localState.group?.interestDenominator || null
       } as MhrRegistrationFractionalOwnershipIF
 
       localState.isEditGroupMode = true


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15478

*Description of changes:*
- Removed tenancy checkbox section from add/edit owner form in transfer and registration flows
- Verified that submission of transfers and registrations still functions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
