### PR TITLE
Fix for home owners table error bar bug

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -294,6 +294,7 @@ export default defineComponent({
               !hasMinimumGroups() ||
               hasEmptyGroup.value ||
               hasUnsavedChanges.value ||
+              (props.isMhrTransfer && !hasUnsavedChanges.value) ||
               !localState.isValidAllocation ||
               localState.hasGroupsWithNoOwners ||
               (!localState.isUngroupedTenancy && hasUndefinedGroupInterest(getTransferOrRegistrationHomeOwnerGroups()))

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -293,7 +293,7 @@ export default defineComponent({
             (
               !hasMinimumGroups() ||
               hasEmptyGroup.value ||
-              !hasUnsavedChanges.value ||
+              hasUnsavedChanges.value ||
               !localState.isValidAllocation ||
               localState.hasGroupsWithNoOwners ||
               (!localState.isUngroupedTenancy && hasUndefinedGroupInterest(getTransferOrRegistrationHomeOwnerGroups()))

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -293,7 +293,6 @@ export default defineComponent({
             (
               !hasMinimumGroups() ||
               hasEmptyGroup.value ||
-              hasUnsavedChanges.value ||
               (props.isMhrTransfer && !hasUnsavedChanges.value) ||
               !localState.isValidAllocation ||
               localState.hasGroupsWithNoOwners ||

--- a/ppr-ui/src/composables/fees/FeeSummary.vue
+++ b/ppr-ui/src/composables/fees/FeeSummary.vue
@@ -414,7 +414,7 @@ header {
 
   &-name {
     flex: 1 1 auto;
-    margin-right: 2rem;
+    margin-right: 1rem;
   }
 
   &-value {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15513

Tested for all ownership types

*Description of changes:*
- Fixed bug for red error bar displaying incorrectly in registration flow
- Minor visual update to fee summary, pointed out in 15295 by Sara


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
