### PR TITLE
Add new TRANS_WILL data validation rules.

### DIFF
--- a/mhr_api/src/mhr_api/resources/v1/search_results.py
+++ b/mhr_api/src/mhr_api/resources/v1/search_results.py
@@ -151,7 +151,7 @@ def post_search_results(search_id: str):  # pylint: disable=too-many-branches, t
         if request.args.get(CLIENT_REF_PARAM):
             client_ref: str = request.args.get(CLIENT_REF_PARAM)
             client_ref = client_ref.strip()
-            if client_ref and len(client_ref) < 51:
+            if client_ref is not None and len(client_ref) < 51:  # Allow empty strings as clearing the value.
                 query.client_reference_id = client_ref
                 # Also update the original search criteria json as this is used in the account search history.
                 criteria = copy.deepcopy(query.search_criteria)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15594

*Description of changes:*
- Only executors can be added.
- Exactly one deleted owner must be due to probate (no death certificate information). All other deleted owners must have death certificate information.
- 15544 search step 2 allow an empty string clientReferenceId to clear the folio number.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
