### PR TITLE
Deceased Owner Changes Dialog

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.32",
+      "version": "0.4.33",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -136,6 +136,7 @@
           class="pr-0"
           :ripple="false"
           @click="undoGroupRemoval(groupId, true)"
+          :disabled="isGlobalEditingMode"
           data-test-id="group-header-undo-btn"
         >
           <v-icon small>mdi-undo</v-icon>

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -70,3 +70,11 @@ export const mhrTableRemoveDialog: DialogOptionsIF = {
     'table? If you remove this registration from your table, you can add it back later ' +
     'by retrieving the registration using the MHR Number.'
 }
+
+export const mhrDeceasedOwnerChanges: DialogOptionsIF = {
+  acceptText: 'Undo Changes and Delete Owner',
+  cancelText: 'Cancel',
+  title: 'Deceased owner\'s information cannot be changed',
+  text: `The phone number and mailing address of a deceased owner cannot be changed prior to deletion.
+    Deleting this owner will undo any changes you have made to their phone number or mailing address. `
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15446

*Description of changes:*
* Implements confirmation dialog and owner is being deceased that has changes
* Disable UNDO button during global edits as per ticket /bcgov/entity#15578

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
