### PR TITLE
Fix Home Owners group denominator for Transfers

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.38",
+      "version": "0.4.39",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -551,7 +551,7 @@ export default defineComponent({
     if (allFractionalData.length === 0 || props.editHomeOwner == null || hasMultipleOwnersInGroup) {
       // Default LCM to be used if all denominators are the identical. UX feature for MHR's only
       const defaultLcm = allFractionalData
-        .every(group => group.interestDenominator === allFractionalData[0]?.interestDenominator) && !props.isMhrTransfer
+        .every(group => group.interestDenominator === allFractionalData[0]?.interestDenominator)
         ? allFractionalData[0]?.interestDenominator
         : null
 


### PR DESCRIPTION
*Issue #:*
- bcgov/entity#15125

*Description of changes:*
- Fix the default Total Denominator for Home Owners group in the Transfer flow, so it is pre-populated when creating a new Group from the dropdown


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
