### PR TITLE
Changes to add commas between multiple owner names

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -689,9 +689,12 @@ def __build_summary(row, add_in_user_list: bool = True, mhr_list=None):
         for name in owner_list:
             if name.strip() != '':
                 if name[0:1] == OWNER_TYPE_INDIVIDUAL:
-                    owner_names += __get_summary_name(name[1:]) + '\n'
+                    owner_names += __get_summary_name(name[1:]) + ',\n'
                 else:
                     owner_names += name[1:] + '\n'
+        # remove comma if exists at end of str
+        if owner_names[-2] == ',':
+            owner_names = owner_names[:-2]      
     summary = {
         'mhrNumber': mhr_number,
         'registrationDescription': LEGACY_REGISTRATION_DESCRIPTION.get(str(row[5]),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15627

*Description of changes:*
- Fix to add commas between owner names on MHR Table in dashboard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
