### PR TITLE
Hide section 2 on confirm completion for QS

### DIFF
--- a/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
+++ b/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
@@ -72,7 +72,7 @@
                   , and the name on the death certificate matches the name displayed above exactly.
                   </p>
               </li>
-              <li class="pl-3 pb-3 mb-7">
+              <li v-if="isStaff" class="pl-3 pb-3 mb-7">
                 <p><strong>Transfer or Change Ownership form</strong> has been recieved and retained</p>
               </li>
               <li v-if="transferType === ApiTransferTypes.SALE_OR_GIFT" class="pl-3 pb-3 mb-7">
@@ -139,14 +139,17 @@ export default defineComponent({
   emits: ['confirmCompletion'],
   setup (props, { emit }) {
     const {
-      getMhrTransferType
+      getMhrTransferType,
+      isRoleStaff
     } = useGetters<any>([
-      'getMhrTransferType'
+      'getMhrTransferType',
+      'isRoleStaff'
     ])
     const localState = reactive({
       showErrorComponent: computed((): boolean => {
         return (props.setShowErrors && !localState.confirmCompletion)
       }),
+      isStaff: isRoleStaff.value,
       confirmCompletion: false,
       transferType: getMhrTransferType.value?.transferType
     })

--- a/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
+++ b/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
@@ -72,7 +72,7 @@
                   , and the name on the death certificate matches the name displayed above exactly.
                   </p>
               </li>
-              <li v-if="isStaff" class="pl-3 pb-3 mb-7">
+              <li v-if="isRoleStaff" class="pl-3 pb-3 mb-7">
                 <p><strong>Transfer or Change Ownership form</strong> has been recieved and retained</p>
               </li>
               <li v-if="transferType === ApiTransferTypes.SALE_OR_GIFT" class="pl-3 pb-3 mb-7">
@@ -149,7 +149,6 @@ export default defineComponent({
       showErrorComponent: computed((): boolean => {
         return (props.setShowErrors && !localState.confirmCompletion)
       }),
-      isStaff: isRoleStaff.value,
       confirmCompletion: false,
       transferType: getMhrTransferType.value?.transferType
     })
@@ -162,6 +161,7 @@ export default defineComponent({
     )
 
     return {
+      isRoleStaff,
       ApiTransferTypes,
       ...toRefs(localState)
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15417

*Description of changes:*
- Hide section 2 (Transfer or Change Ownership form line) in Confirm Completion component for qualified suppliers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
