### PR TITLE
Remove Current Owners Handling + misc UX

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.39",
+      "version": "0.4.40",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -92,6 +92,7 @@
                   :rules="firsNameRules"
                   :disabled="isTransferDueToDeath"
                   :readonly="isTransferDueToDeath"
+                  @mousedown.prevent
                 />
               </v-col>
               <v-col cols="4">
@@ -104,6 +105,7 @@
                   :rules="maxLength(15)"
                   :disabled="isTransferDueToDeath"
                   :readonly="isTransferDueToDeath"
+                  @mousedown.prevent
                 />
               </v-col>
               <v-col cols="4">
@@ -116,6 +118,7 @@
                   :rules="lastNameRules"
                   :disabled="isTransferDueToDeath"
                   :readonly="isTransferDueToDeath"
+                  @mousedown.prevent
                 />
               </v-col>
             </v-row>
@@ -285,6 +288,7 @@
                 :rules="maxLength(70)"
                 :disabled="isTransferDueToDeath"
                 :readonly="isTransferDueToDeath"
+                @mousedown.prevent
               />
             </v-col>
           </v-row>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -293,7 +293,7 @@
             </v-expand-transition>
           </td>
         </tr>
-        <tr v-else-if="isRemovedHomeOwner(row.item) && showDeathCertificate && isReadonlyTable">
+        <tr v-else-if="isRemovedHomeOwner(row.item) && showDeathCertificate() && isReadonlyTable">
           <td :colspan="homeOwnersTableHeaders.length" class="deceased-review-info">
             <v-row no-gutters class="ml-8 my-n3">
               <v-col cols="12">
@@ -389,7 +389,9 @@ export default defineComponent({
       isDisabledForSJTChanges,
       isCurrentOwner,
       getCurrentOwnerStateById,
-      isTransferDueToDeath
+      isTransferDueToDeath,
+      groupHasRemovedAllCurrentOwners,
+      moveCurrentOwnersToPreviousOwners
     } = useTransferOwners(!props.isMhrTransfer)
 
     const { setUnsavedChanges } = useActions<any>(['setUnsavedChanges'])
@@ -457,6 +459,11 @@ export default defineComponent({
         { ...item, action: ActionTypes.REMOVED },
         item.groupId
       )
+
+      // When base ownership is SO/JT and all current owners have been removed: Move them to a previous owners group.
+      if (groupHasRemovedAllCurrentOwners(item.groupId) && showGroups.value) {
+        moveCurrentOwnersToPreviousOwners(item.groupId)
+      }
     }
 
     const undo = async (item: MhrRegistrationHomeOwnerIF): Promise<void> => {

--- a/ppr-ui/src/components/mhrTransfers/TransferType.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferType.vue
@@ -107,7 +107,6 @@
                 filled
                 :rules="declaredValueRules"
                 label="Amount in Canadian Dollars"
-                validate-on-blur
                 data-test-id="declared-value"
               />
               <span class="mt-4">.00</span>
@@ -171,7 +170,7 @@ export default defineComponent({
           required('Enter declared value of home'))
       }),
       showFormError: computed(() => props.validate && !localState.isValid),
-      transferTypeRules: []
+      transferTypeRules: required('Select transfer type')
     })
 
     const hasError = (ref: any): boolean => {
@@ -240,6 +239,8 @@ export default defineComponent({
             ]
           )
           break
+        default:
+          localState.transferTypeRules = required('Select transfer type')
       }
     })
 

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -191,7 +191,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
       }
     })
 
-    // Create a new ownership group defaulted to REMOVED and unshift it to group 1
+    // Create a new ownership group defaulted to REMOVED
     const previousOwnersGroup: MhrRegistrationHomeOwnerGroupIF = {
       groupId: 1,
       interest: 'Undivided',

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -1,9 +1,10 @@
-import { ActionTypes, ApiHomeTenancyTypes, ApiTransferTypes, HomeOwnerPartyTypes } from '@/enums'
-import { useGetters } from 'vuex-composition-helpers'
-import { MhrRegistrationHomeOwnerIF } from '@/interfaces'
-import { computed } from '@vue/composition-api'
+import { ActionTypes, ApiHomeTenancyTypes, ApiTransferTypes, HomeOwnerPartyTypes, HomeTenancyTypes } from '@/enums'
+import { useActions, useGetters } from 'vuex-composition-helpers'
+import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
+import { computed, reactive } from '@vue/composition-api'
 import { isEqual } from 'lodash'
 import { normalizeObject } from '@/utils'
+import { useHomeOwners } from '@/composables'
 
 /**
  * Composable to handle Ownership functionality and permissions specific to the varying Transfer of Ownership filings.
@@ -19,6 +20,25 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     'getMhrTransferHomeOwnerGroups',
     'getMhrTransferCurrentHomeOwnerGroups'
   ])
+
+  const {
+    setMhrTransferHomeOwnerGroups
+  } = useActions<any>([
+    'setMhrTransferHomeOwnerGroups'
+  ])
+
+  const {
+    getGroupById
+  } = useHomeOwners(true)
+
+  /** Local State for custom computed properties. **/
+  const localState = reactive({
+    isSOorJT: computed((): boolean => {
+      return getMhrTransferCurrentHomeOwnerGroups.value.length === 1 &&
+        (getMhrTransferCurrentHomeOwnerGroups.value[0].type === ApiHomeTenancyTypes.SOLE ||
+        getMhrTransferCurrentHomeOwnerGroups.value[0].type === ApiHomeTenancyTypes.JOINT)
+    })
+  })
 
   /** Returns true when the selected transfer type is a 'due to death' scenario **/
   const isTransferDueToDeath = computed((): boolean => {
@@ -148,6 +168,46 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     )
   }
 
+  /** Return true when all CURRENT owners of a group have been removed and some owners added in a SO/JT structure. **/
+  const groupHasRemovedAllCurrentOwners = (groupId: number) => {
+    const owners = getGroupById(groupId).owners
+
+    return localState.isSOorJT && owners.some(owner => owner.action === ActionTypes.ADDED) &&
+      owners.every(owner => !!owner.action)
+  }
+
+  /** Remove current owners from existing ownership and move them to New Previous Owners group.  **/
+  const moveCurrentOwnersToPreviousOwners = async (groupId: number) => {
+    // Retrieve and mark for removal all current owners
+    const currentOwners = getGroupById(groupId)?.owners.filter(owner => owner.action !== ActionTypes.ADDED)
+      .map(owner => { return { ...owner, action: ActionTypes.REMOVED } })
+
+    // Get current ownership structure and modify group ids and remove current owners
+    const updatedGroups = getMhrTransferHomeOwnerGroups.value.map(group => {
+      return {
+        ...group,
+        groupId: group.groupId + 1,
+        owners: group.owners.filter(owner => owner.action !== ActionTypes.REMOVED)
+      }
+    })
+
+    // Create a new ownership group defaulted to REMOVED and unshift it to group 1
+    const previousOwnersGroup: MhrRegistrationHomeOwnerGroupIF = {
+      groupId: 1,
+      interest: 'Undivided',
+      interestDenominator: null,
+      interestNumerator: null,
+      owners: currentOwners,
+      tenancySpecified: true,
+      type: HomeTenancyTypes.NA,
+      action: ActionTypes.REMOVED
+    }
+    updatedGroups.unshift(previousOwnersGroup)
+
+    // Set new ownership structure to store
+    await setMhrTransferHomeOwnerGroups(updatedGroups)
+  }
+
   /**
    * Return the base owners snapshot by id.
    * @param ownerId The owner identifier
@@ -196,7 +256,9 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     isTransferDueToDeath,
     isJointTenancyStructure,
     getCurrentOwnerStateById,
+    groupHasRemovedAllCurrentOwners,
     getCurrentOwnerGroupIdByOwnerId,
-    hasCurrentOwnerChanges
+    hasCurrentOwnerChanges,
+    moveCurrentOwnersToPreviousOwners
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15461

*Description of changes:*
* Updated handling for edge case outlined in above ticket
- The jist: Put all removed original owners into a 'previous owners' group when all original owners have been removed in a tenants in common scenario where it was originally a so/jt scenario.

* Misc UXA improvements on Trand validations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
