### PR TITLE
Fix Group Select in Home Owners

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.40",
+      "version": "0.4.41",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -157,11 +157,11 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
 
     let numOfAdditionalGroupsInDropdown = 0
 
-    const homeOwnerGroups = getTransferOrRegistrationHomeOwnerGroups()
+    const homeOwnerGroups = getTransferOrRegistrationHomeOwnerGroups() as MhrRegistrationHomeOwnerGroupIF[]
     const removedOwners = homeOwnerGroups.filter(group => group.action === ActionTypes.REMOVED)
     const activeOwners = homeOwnerGroups.filter(group => group.action !== ActionTypes.REMOVED)
 
-    if (isAddingHomeOwner) {
+    if (isAddingHomeOwner && (showGroups.value || isMhrTransfer)) {
       numOfAdditionalGroupsInDropdown = 1
     } else {
       numOfAdditionalGroupsInDropdown =
@@ -176,7 +176,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
       })
 
     // Remove first group option when there is existing SO/JT
-    if (!showGroups.value && homeOwnerGroups.length) dropDownItems.shift()
+    if (!showGroups.value && homeOwnerGroups.length && isMhrTransfer) dropDownItems.shift()
 
     // Handle Edit Defaults
     if (!dropDownItems.length) return [{ text: 'Group 1', value: DEFAULT_GROUP_ID }]


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15621

*Description of changes:*
- Fix for Group selection in the dropdown when a SO/JT is removed from the Home owners table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
