### PR TITLE
Correctly delete a Home Owner in Registration flow

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "0.4.44",
+      "version": "0.4.45",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/date-picker": "^1.1.18",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -461,10 +461,12 @@ export default defineComponent({
     const {
       getMhrRegistrationHomeOwnerGroups,
       getMhrTransferHomeOwnerGroups,
+      getMhrTransferHomeOwners,
       getMhrRegistrationValidationModel
     } = useGetters<any>([
       'getMhrRegistrationHomeOwnerGroups',
       'getMhrTransferHomeOwnerGroups',
+      'getMhrTransferHomeOwners',
       'getMhrRegistrationValidationModel'
     ])
     const {
@@ -495,8 +497,7 @@ export default defineComponent({
       editHomeOwner,
       showGroups,
       setShowGroups,
-      setGroupFractionalInterest,
-      getTransferOrRegistrationHomeOwners
+      setGroupFractionalInterest
     } = useHomeOwners(props.isMhrTransfer)
 
     const {
@@ -513,9 +514,8 @@ export default defineComponent({
 
     const defaultHomeOwner: MhrRegistrationHomeOwnerIF = {
       ...props.editHomeOwner,
-      ownerId: props.editHomeOwner?.ownerId || props.isMhrTransfer
-        ? getTransferOrRegistrationHomeOwners().length + 1
-        : DEFAULT_OWNER_ID++,
+      ownerId: props.editHomeOwner?.ownerId ||
+        (props.isMhrTransfer ? getMhrTransferHomeOwners.value.length + 1 : DEFAULT_OWNER_ID++),
       phoneNumber: props.editHomeOwner?.phoneNumber || '',
       phoneExtension: props.editHomeOwner?.phoneExtension || '',
       suffix: props.editHomeOwner?.suffix || '',

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -513,7 +513,9 @@ export default defineComponent({
 
     const defaultHomeOwner: MhrRegistrationHomeOwnerIF = {
       ...props.editHomeOwner,
-      ownerId: props.editHomeOwner?.ownerId || getTransferOrRegistrationHomeOwners().length + 1 || (DEFAULT_OWNER_ID++),
+      ownerId: props.editHomeOwner?.ownerId || props.isMhrTransfer
+        ? getTransferOrRegistrationHomeOwners().length + 1
+        : DEFAULT_OWNER_ID++,
       phoneNumber: props.editHomeOwner?.phoneNumber || '',
       phoneExtension: props.editHomeOwner?.phoneExtension || '',
       suffix: props.editHomeOwner?.suffix || '',


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15757

*Description of changes:*
- Fix for correctly deleting a Home Owners from the table in the Registration flow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
