### PR TITLE
Add comma for business owners

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -691,7 +691,7 @@ def __build_summary(row, add_in_user_list: bool = True, mhr_list=None):
                 if name[0:1] == OWNER_TYPE_INDIVIDUAL:
                     owner_names += __get_summary_name(name[1:]) + ',\n'
                 else:
-                    owner_names += name[1:] + '\n'
+                    owner_names += name[1:] + ',\n'
         # remove comma if exists at end of str
         if owner_names[-2] == ',':
             owner_names = owner_names[:-2]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15627

*Description of changes:*
Ticket came back from QA as commas were not being added for Business Owners in the Registration Table
- Added comma to second part of conditional that targets Business Owners
![image](https://user-images.githubusercontent.com/112968185/228005011-d89f10ee-fdf8-4877-bc42-3aec61e0a806.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
