### PR TITLE
Group numbering bug fix

### DIFF
--- a/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
+++ b/ppr-ui/src/components/mhrTransfers/ConfirmCompletion.vue
@@ -70,7 +70,7 @@
                       ><u> issued from Canada or the United States</u></span>
                     </template>
                     If the death certificate was issued outside of Canada or the US, the transfer will have to be sent
-                    to the Manufactured Home Registry
+                    to the Manufactured Home Registry.
                   </v-tooltip>
                   , and the name on the death certificate matches the name displayed above exactly.
                   </p>

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -221,12 +221,10 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
     }
     // For Mhr Transfers with Removed Groups, assign a sequential groupId
     // If WILL flow, add new executor to existing group instead of incrementing the group
-    let transferDefaultId = null
+    let transferDefaultId = groupId
     if (getMhrTransferType.value?.transferType !== ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL) {
       transferDefaultId = homeOwnerGroups.find(group => group.action !== ActionTypes.REMOVED)?.groupId ||
       homeOwnerGroups.filter(group => group.action === ActionTypes.REMOVED).length + 1
-    } else {
-      transferDefaultId = groupId
     }
 
     const fallBackId = isMhrTransfer ? transferDefaultId : DEFAULT_GROUP_ID

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -359,6 +359,23 @@ describe('Home Owners', () => {
         .text()
     ).toBe(HomeTenancyTypes.SOLE)
 
+    // add executor
+    homeOwnerGroup[0].owners.push(mockedExecutor)
+    await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
+
+    // Tenancy type should be N/A due to mix of Executor and living owner
+    expect(wrapper.findComponent(HomeOwners).vm.$data.getHomeOwners.length).toBe(2)
+    expect(
+      wrapper
+        .findComponent(HomeOwners)
+        .find(getTestId('home-owner-tenancy-type'))
+        .text()
+    ).toBe(HomeTenancyTypes.NA)
+
+    // reset owners
+    homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson] }]
+    await store.dispatch('setMhrTransferHomeOwnerGroups', homeOwnerGroup)
+
     // delete original owner
     await homeOwnersTable.find(getTestId('table-delete-btn')).trigger('click')
 

--- a/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
@@ -1,4 +1,4 @@
-import { ActionTypes, HomeTenancyTypes } from '@/enums'
+import { ActionTypes, HomeTenancyTypes, HomeOwnerPartyTypes } from '@/enums'
 import {
   AddressIF,
   MhrRegistrationFractionalOwnershipIF,
@@ -31,6 +31,35 @@ export const mockedEmptyGroup: MhrRegistrationHomeOwnerGroupIF = {
   owners: [],
   // TODO: Mhr-Submission - UPDATE after the correct type can be determined
   type: Object.keys(HomeTenancyTypes).find(key => HomeTenancyTypes[key] as string === HomeTenancyTypes.SOLE)
+}
+
+export const mockedExecutor: MhrRegistrationHomeOwnerIF = {
+  ownerId: 10,
+  individualName: {
+    first: 'John',
+    middle: 'A',
+    last: 'Smith'
+  },
+  suffix: 'Sr.',
+  phoneNumber: '(545) 333-2211',
+  phoneExtension: '1234',
+  partyType: HomeOwnerPartyTypes.EXECUTOR,
+  address: mockedAddress
+}
+
+export const mockedAddedExecutor: MhrRegistrationHomeOwnerIF = {
+  ownerId: 10,
+  individualName: {
+    first: 'John',
+    middle: 'A',
+    last: 'Smith'
+  },
+  suffix: 'Sr.',
+  phoneNumber: '(545) 333-2211',
+  phoneExtension: '1234',
+  partyType: HomeOwnerPartyTypes.EXECUTOR,
+  action: ActionTypes.ADDED,
+  address: mockedAddress
 }
 
 export const mockedPerson: MhrRegistrationHomeOwnerIF = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14866

*Description of changes:*
QA found grouping issues which resulted in incorrect tenancy types being displayed. Refactored how executors are added to groups in the WILL flow. Newly added owners will now always be added to the group from which the owner was deceased, as opposed to creating a new group (happened when all original owners were deleted/marked deceased).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
