### PR TITLE
MHR search report conditionally include expired caution unit notes.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -86,7 +86,7 @@ WHERE account_id = :query_value
                     FROM mhr_extra_registrations mer
                    WHERE mer.account_id = mr.account_id
                      AND mer.mhr_number = mr.mhr_number
-                     AND mer.removed_ind = 'Y')
+                     AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y'))
 )
 """
 QUERY_ACCOUNT_REGISTRATIONS_SUMMARY = """
@@ -120,12 +120,12 @@ SELECT (SELECT COUNT(mr.id)
                               FROM mhr_extra_registrations mer
                              WHERE mer.mhr_number = mr.mhr_number
                                AND mer.account_id = mr.account_id
-                               AND mer.removed_ind = 'Y')) AS reg_count,
+                               AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y'))) AS reg_count,
        (SELECT COUNT(mer.id)
            FROM mhr_extra_registrations mer
           WHERE mer.account_id = :query_value
             AND mer.mhr_number = :query_value2
-            AND mer.removed_ind != 'Y') as extra_reg_count,
+            AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) as extra_reg_count,
        (SELECT  mr.account_id
            FROM mhr_registrations mr
           WHERE mr.account_id = :query_value

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -108,7 +108,6 @@ def validate_registration(json_data, staff: bool = False):
         owner_count: int = len(json_data.get('ownerGroups')) if json_data.get('ownerGroups') else 0
         error_msg += validate_owner_groups(json_data.get('ownerGroups'), True, None, None, owner_count)
         error_msg += validate_location(json_data)
-        error_msg += validate_description(json_data)
     except Exception as validation_exception:   # noqa: B902; eat all errors
         current_app.logger.error('validate_registration exception: ' + str(validation_exception))
         error_msg += VALIDATOR_ERROR
@@ -457,8 +456,6 @@ def validate_submitting_party(json_data):
         error_msg += validate_text(party.get('businessName'), desc + ' business name')
     elif party.get('personName'):
         error_msg += validate_individual_name(party.get('personName'), desc)
-    if party.get('address'):
-        error_msg += validate_address(party.get('address'), desc)
     return error_msg
 
 
@@ -472,8 +469,6 @@ def validate_owner(owner):
         error_msg += validate_text(owner.get('organizationName'), desc + ' organization name')
     elif owner.get('individualName'):
         error_msg += validate_individual_name(owner.get('individualName'), desc)
-    if owner.get('address'):
-        error_msg += validate_address(owner.get('address'), desc)
     return error_msg
 
 
@@ -630,12 +625,6 @@ def validate_location(json_data):
     location = json_data.get('location')
     if not location:
         location = json_data.get('newLocation')
-    desc: str = 'location'
-    error_msg += validate_text(location.get('parkName'), desc + ' park name')
-    error_msg += validate_text(location.get('dealerName'), desc + ' dealer name')
-    error_msg += validate_text(location.get('additionalDescription'), desc + ' additional description')
-    error_msg += validate_text(location.get('exceptionPlan'), desc + ' exception plan')
-    error_msg += validate_text(location.get('bandName'), desc + ' band name')
     if location.get('locationType') and location['locationType'] == MhrLocationTypes.RESERVE:
         if not location.get('bandName'):
             error_msg += BAND_NAME_REQUIRED
@@ -647,20 +636,6 @@ def validate_location(json_data):
     elif location.get('locationType') and location['locationType'] == MhrLocationTypes.MH_PARK:
         if not location.get('parkName'):
             error_msg += LOCATION_PARK_NAME_REQUIRED
-    if location.get('address'):
-        error_msg += validate_address(location.get('address'), desc)
-    return error_msg
-
-
-def validate_description(json_data):
-    """Verify description values are valid."""
-    error_msg = ''
-    if not json_data.get('description'):
-        return error_msg
-    description = json_data.get('description')
-    desc: str = 'description'
-    error_msg += validate_text(description.get('rebuiltRemarks'), desc + ' rebuilt remarks')
-    error_msg += validate_text(description.get('otherRemarks'), desc + ' other remarks')
     return error_msg
 
 
@@ -669,14 +644,6 @@ def validate_individual_name(name_json, desc: str = ''):
     error_msg = validate_text(name_json.get('first'), desc + ' first')
     error_msg += validate_text(name_json.get('last'), desc + ' last')
     error_msg += validate_text(name_json.get('middle'), desc + ' middle')
-    return error_msg
-
-
-def validate_address(address_json, desc: str = ''):
-    """Verify address is valid."""
-    error_msg = validate_text(address_json.get('street'), desc + ' street')
-    error_msg += validate_text(address_json.get('streetAdditional'), desc + ' streetAdditional')
-    error_msg += validate_text(address_json.get('city'), desc + ' city')
     return error_msg
 
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.3.1'  # pylint: disable=invalid-name
+__version__ = '1.3.2'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -276,11 +276,11 @@ LOCATION_OTHER = {
 
 # testdata pattern is ({description}, {park_name}, {dealer}, {additional}, {except_plan}, {band_name}, {message content})
 TEST_LOCATION_DATA = [
-    ('Invalid park name', INVALID_TEXT_CHARSET, None, None, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid dealer name', None, INVALID_TEXT_CHARSET, None, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid additional description', None, None, INVALID_TEXT_CHARSET, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid exception plan', None, None, None, INVALID_TEXT_CHARSET, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid band name', None, None, None, None, INVALID_TEXT_CHARSET, INVALID_CHARSET_MESSAGE)
+    ('Non utf-8 park name', INVALID_TEXT_CHARSET, None, None, None, None, None),
+    ('Non utf-8 dealer name', None, INVALID_TEXT_CHARSET, None, None, None, None),
+    ('Non utf-8 additional description', None, None, INVALID_TEXT_CHARSET, None, None, None),
+    ('Non utf-8 exception plan', None, None, None, INVALID_TEXT_CHARSET, None, None),
+    ('Non utf-8 band name', None, None, None, None, INVALID_TEXT_CHARSET, None)
 ]
 # test data pattern is ({description}, {valid}, {staff}, {doc_id}, {message_content}, {status}, {group})
 TEST_PERMIT_DATA = [
@@ -417,9 +417,10 @@ def test_validate_location(session, desc, park_name, dealer, additional, except_
     elif band_name:
         location['bandName'] = band_name
     error_msg = validator.validate_location(json_data)
-    assert error_msg != ''
     if message_content:
         assert error_msg.find(message_content) != -1
+    else:
+        assert not error_msg
 
 
 @pytest.mark.parametrize('desc,pid,valid,message_content', TEST_DATA_PID)

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -341,9 +341,9 @@ TEST_PARTY_DATA = [
     ('Reg invalid first name', None, INVALID_TEXT_CHARSET, 'middle', 'last', INVALID_CHARSET_MESSAGE, REGISTRATION),
     ('Reg invalid middle name', None, 'first', INVALID_TEXT_CHARSET, 'last', INVALID_CHARSET_MESSAGE, REGISTRATION),
     ('Reg invalid last name', None, 'first', 'middle', INVALID_TEXT_CHARSET, INVALID_CHARSET_MESSAGE, REGISTRATION),
-    ('Reg invalid street', None, 'first', 'middle', 'last', INVALID_CHARSET_MESSAGE, REGISTRATION),
-    ('Reg invalid streetAdditional', None, 'first', 'middle', 'last', INVALID_CHARSET_MESSAGE, REGISTRATION),
-    ('Reg invalid city', None, 'first', 'middle', 'last', INVALID_CHARSET_MESSAGE, REGISTRATION),
+    ('Reg street non utf-8', None, 'first', 'middle', 'last', None, REGISTRATION),
+    ('Reg streetAdditional non utf-8', None, 'first', 'middle', 'last', None, REGISTRATION),
+    ('Reg city non utf-8', None, 'first', 'middle', 'last', None, REGISTRATION),
     ('Trans invalid org/bus name', INVALID_TEXT_CHARSET, None, None, None, INVALID_CHARSET_MESSAGE, TRANSFER),
     ('Trans invalid first name', None, INVALID_TEXT_CHARSET, 'middle', 'last', INVALID_CHARSET_MESSAGE, TRANSFER),
     ('Trans invalid middle name', None, 'first', INVALID_TEXT_CHARSET, 'last', INVALID_CHARSET_MESSAGE, TRANSFER),
@@ -351,16 +351,16 @@ TEST_PARTY_DATA = [
 ]
 # testdata pattern is ({description}, {park_name}, {dealer}, {additional}, {except_plan}, {band_name}, {message content})
 TEST_LOCATION_DATA = [
-    ('Invalid park name', INVALID_TEXT_CHARSET, None, None, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid dealer name', None, INVALID_TEXT_CHARSET, None, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid additional description', None, None, INVALID_TEXT_CHARSET, None, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid exception plan', None, None, None, INVALID_TEXT_CHARSET, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid band name', None, None, None, None, INVALID_TEXT_CHARSET, INVALID_CHARSET_MESSAGE)
+    ('Non utf-8 park name', INVALID_TEXT_CHARSET, None, None, None, None, None),
+    ('Non utf-8 dealer name', None, INVALID_TEXT_CHARSET, None, None, None, None),
+    ('Non utf-8 additional description', None, None, INVALID_TEXT_CHARSET, None, None, None),
+    ('Non utf-8 exception plan', None, None, None, INVALID_TEXT_CHARSET, None, None),
+    ('Non utf-8 band name', None, None, None, None, INVALID_TEXT_CHARSET, None)
 ]
 # testdata pattern is ({description}, {rebuilt}, {other}, {message content})
 TEST_DESCRIPTION_DATA = [
-    ('Invalid rebuilt remarks', INVALID_TEXT_CHARSET, None, INVALID_CHARSET_MESSAGE),
-    ('Invalid other remarks', None, INVALID_TEXT_CHARSET, INVALID_CHARSET_MESSAGE)
+    ('Non utf-8 rebuilt remarks', INVALID_TEXT_CHARSET, None, None),
+    ('Non utf-8 other remarks', None, INVALID_TEXT_CHARSET, None)
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content}, {status})
 TEST_EXEMPTION_DATA = [
@@ -526,9 +526,10 @@ def test_validate_submitting(session, desc, bus_name, first, middle, last, messa
         error_msg = validator.validate_registration(json_data, False)
     else:
         error_msg = validator.validate_transfer(None, json_data, False)
-    assert error_msg != ''
     if message_content:
         assert error_msg.find(message_content) != -1
+    else:
+        assert not error_msg
 
 
 @pytest.mark.parametrize('desc,bus_name,first,middle,last,message_content,data', TEST_PARTY_DATA)
@@ -562,9 +563,10 @@ def test_validate_owner(session, desc, bus_name, first, middle, last, message_co
         error_msg = validator.validate_registration(json_data, False)
     else:
         error_msg = validator.validate_transfer(None, json_data, False)
-    assert error_msg != ''
     if message_content:
         assert error_msg.find(message_content) != -1
+    else:
+        assert not error_msg
 
 
 @pytest.mark.parametrize('desc,park_name,dealer,additional,except_plan,band_name,message_content', TEST_LOCATION_DATA)
@@ -584,9 +586,10 @@ def test_validate_reg_location(session, desc, park_name, dealer, additional, exc
     elif band_name:
         location['bandName'] = band_name
     error_msg = validator.validate_registration(json_data, False)
-    assert error_msg != ''
     if message_content:
         assert error_msg.find(message_content) != -1
+    else:
+        assert not error_msg
 
 
 @pytest.mark.parametrize('desc,rebuilt,other,message_content', TEST_DESCRIPTION_DATA)
@@ -600,9 +603,10 @@ def test_validate_reg_description(session, desc, rebuilt, other, message_content
     elif other:
         description['otherRemarks'] = other
     error_msg = validator.validate_registration(json_data, False)
-    assert error_msg != ''
     if message_content:
         assert error_msg.find(message_content) != -1
+    else:
+        assert not error_msg
 
 
 @pytest.mark.parametrize('desc,valid,street,city,message_content', TEST_LEGACY_REG_DATA)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15876

*Description of changes:*
- MHR search report conditionally include expired caution unit notes when continued or extended.
- Attach search report examples to the ticket.
- Update individual reg account summary query (to support non UI endpoints).
- Update char set data validation to match PPR: do not check address, description, or location text.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
