### PR TITLE
Fix to add Executor to same group in AFFE Transfer

### DIFF
--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -249,7 +249,8 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
     // Allow update to "REMOVED" group if WILL flow
     if (groupToUpdate.owners &&
         (groupToUpdate.action !== ActionTypes.REMOVED ||
-         getMhrTransferType.value?.transferType === ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL)) {
+         (getMhrTransferType.value?.transferType === ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL ||
+          getMhrTransferType.value?.transferType === ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL))) {
       groupToUpdate.owners.push(owner)
     } else {
       // No groups exist, need to create a new one


### PR DESCRIPTION
*Description of changes:*
- Quick fix in AFFE Transfers to add Executors to same group

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
