### PR TITLE
Make status in tombstone dependent on parent

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
@@ -18,7 +18,7 @@
             <span class="float-right">Registration Status: </span>
           </v-col>
           <v-col class="pl-3" cols="6">
-            {{ statusType[0] + statusType.toLowerCase().slice(1) }}
+            {{ statusType }}
           </v-col>
         </v-row>
       </v-col>
@@ -52,6 +52,7 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { formatExpiryDate, pacificDate } from '@/utils'
 import { RegistrationTypeIF } from '@/interfaces' // eslint-disable-line
+import { mhApiStatusTypes } from '@/enums'
 
 export default defineComponent({
   name: 'TombstoneDischarge',
@@ -66,13 +67,15 @@ export default defineComponent({
       getRegistrationExpiryDate,
       getRegistrationNumber,
       getRegistrationType,
-      getMhrInformation
+      getMhrInformation,
+      getMhRegTableBaseRegs
     } = useGetters<any>([
       'getRegistrationCreationDate',
       'getRegistrationExpiryDate',
       'getRegistrationNumber',
       'getRegistrationType',
-      'getMhrInformation'
+      'getMhrInformation',
+      'getMhRegTableBaseRegs'
     ])
     const localState = reactive({
       creationDate: computed((): string => {
@@ -94,7 +97,11 @@ export default defineComponent({
         return 'No Expiry'
       }),
       statusType: computed((): string => {
-        return getMhrInformation.value?.statusType || 'N/A'
+        const parentReg = getMhrInformation.value.mhrNumber &&
+                          getMhRegTableBaseRegs.value?.find(reg => reg.mhrNumber === getMhrInformation.value.mhrNumber)
+        const status = parentReg?.statusType
+        if (status === mhApiStatusTypes.FROZEN) return 'Active'
+        else return status ? status[0] + status.toLowerCase().slice(1) : ''
       }),
       header: computed((): string => {
         const numberType = getRegistrationNumber.value ? 'Base' : 'Manufactured Home'

--- a/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
@@ -98,7 +98,7 @@ export default defineComponent({
       }),
       statusType: computed((): string => {
         const regStatus = getMhrInformation.value.statusType
-        return isFrozenMhr
+        return isFrozenMhr.value
           ? MhUIStatusTypes.ACTIVE
           : regStatus[0] + regStatus.toLowerCase().slice(1)
       }),

--- a/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
@@ -13,7 +13,7 @@
             {{ creationDate }}
           </v-col>
         </v-row>
-        <v-row v-else justify="end" no-gutters>
+        <v-row v-else-if="isMhrInformation" justify="end" no-gutters>
           <v-col :class="$style['info-label']" cols="6">
             <span class="float-right">Registration Status: </span>
           </v-col>
@@ -52,7 +52,7 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { formatExpiryDate, pacificDate } from '@/utils'
 import { RegistrationTypeIF } from '@/interfaces' // eslint-disable-line
-import { mhApiStatusTypes } from '@/enums'
+import { mhApiStatusTypes, mhUIStatusTypes } from '@/enums'
 
 export default defineComponent({
   name: 'TombstoneDischarge',
@@ -97,11 +97,12 @@ export default defineComponent({
         return 'No Expiry'
       }),
       statusType: computed((): string => {
-        const parentReg = getMhrInformation.value.mhrNumber &&
-                          getMhRegTableBaseRegs.value?.find(reg => reg.mhrNumber === getMhrInformation.value.mhrNumber)
-        const status = parentReg?.statusType
-        if (status === mhApiStatusTypes.FROZEN) return 'Active'
-        else return status ? status[0] + status.toLowerCase().slice(1) : ''
+        const parentReg = getMhRegTableBaseRegs.value?.find(reg => reg.mhrNumber === getMhrInformation.value.mhrNumber)
+        // if no parent statusType, fall back on current statusType
+        const regStatus = parentReg?.statusType || getMhrInformation.value.statusType
+        return regStatus === mhApiStatusTypes.FROZEN
+          ? mhUIStatusTypes.ACTIVE
+          : regStatus[0] + regStatus.toLowerCase().slice(1)
       }),
       header: computed((): string => {
         const numberType = getRegistrationNumber.value ? 'Base' : 'Manufactured Home'

--- a/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
@@ -52,7 +52,8 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { formatExpiryDate, pacificDate } from '@/utils'
 import { RegistrationTypeIF } from '@/interfaces' // eslint-disable-line
-import { mhApiStatusTypes, mhUIStatusTypes } from '@/enums'
+import { MhUIStatusTypes } from '@/enums'
+import { useMhrInformation } from '@/composables'
 
 export default defineComponent({
   name: 'TombstoneDischarge',
@@ -67,16 +68,15 @@ export default defineComponent({
       getRegistrationExpiryDate,
       getRegistrationNumber,
       getRegistrationType,
-      getMhrInformation,
-      getMhRegTableBaseRegs
+      getMhrInformation
     } = useGetters<any>([
       'getRegistrationCreationDate',
       'getRegistrationExpiryDate',
       'getRegistrationNumber',
       'getRegistrationType',
-      'getMhrInformation',
-      'getMhRegTableBaseRegs'
+      'getMhrInformation'
     ])
+    const { isFrozenMhr } = useMhrInformation()
     const localState = reactive({
       creationDate: computed((): string => {
         if (getRegistrationCreationDate.value) {
@@ -97,11 +97,9 @@ export default defineComponent({
         return 'No Expiry'
       }),
       statusType: computed((): string => {
-        const parentReg = getMhRegTableBaseRegs.value?.find(reg => reg.mhrNumber === getMhrInformation.value.mhrNumber)
-        // if no parent statusType, fall back on current statusType
-        const regStatus = parentReg?.statusType || getMhrInformation.value.statusType
-        return regStatus === mhApiStatusTypes.FROZEN
-          ? mhUIStatusTypes.ACTIVE
+        const regStatus = getMhrInformation.value.statusType
+        return isFrozenMhr
+          ? MhUIStatusTypes.ACTIVE
           : regStatus[0] + regStatus.toLowerCase().slice(1)
       }),
       header: computed((): string => {

--- a/ppr-ui/tests/unit/TombstoneDischarge.spec.ts
+++ b/ppr-ui/tests/unit/TombstoneDischarge.spec.ts
@@ -11,7 +11,7 @@ import { TombstoneDischarge } from '@/components/tombstone'
 
 // Other
 import { FinancingStatementIF } from '@/interfaces'
-import { mockedFinancingStatementComplete, mockedSelectSecurityAgreement } from './test-data'
+import { mockedFinancingStatementComplete, mockedMhrInformation, mockedSelectSecurityAgreement } from './test-data'
 import mockRouter from './MockRouter'
 import { RouteNames } from '@/enums'
 import { pacificDate } from '@/utils'
@@ -76,8 +76,11 @@ describe('Tombstone component', () => {
   })
 
   it('renders Tombstone component properly for Total Discharge', async () => {
+    await store.dispatch('setMhrInformation', mockedMhrInformation)
     wrapper = createComponent(RouteNames.REVIEW_DISCHARGE)
-    expect(wrapper.findComponent(TombstoneDischarge).exists()).toBe(true)
+    const tombstoneDischarge = wrapper.findComponent(TombstoneDischarge)
+    tombstoneDischarge.vm.$props.isMhrInformation = true
+    expect(tombstoneDischarge.exists()).toBe(true)
     const header = wrapper.findAll(tombstoneHeader)
     expect(header.length).toBe(1)
     expect(header.at(0).text()).toContain('Base Registration Number ' + registration.baseRegistrationNumber)

--- a/ppr-ui/tests/unit/test-data/mock-registration-new.ts
+++ b/ppr-ui/tests/unit/test-data/mock-registration-new.ts
@@ -17,7 +17,8 @@ import {
   PartyIF,
   RegistrationTypeIF,
   VehicleCollateralIF,
-  SearchPartyIF
+  SearchPartyIF,
+  MhRegistrationSummaryIF
 } from '@/interfaces'
 
 export const mockedSelectSecurityAgreement = (): RegistrationTypeIF => {
@@ -434,4 +435,16 @@ export const mockedFinancingStatementRepairers: FinancingStatementIF = {
   lifeYears: 1,
   trustIndenture: false,
   lifeInfinite: false
+}
+
+export const mockedMhrInformation: MhRegistrationSummaryIF = {
+  clientReferenceId: 'UT-MHREG-SOLE',
+  createDateTime: '2023-04-28T10:11:37-07:53',
+  mhrNumber: '150575',
+  ownerNames: 'MARY-ANNE BICKNELL',
+  path: '/mhr/api/v1/registrations/150575',
+  registrationDescription: 'MANUFACTURED HOME REGISTRATION',
+  statusType: 'ACTIVE',
+  submittingParty: 'ABC SUBMITTING COMPANY',
+  username: 'BUSINESS REGISTRY TEST 1'
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15934

*Description of changes:*
- Update to ticket 15934 to make Tombstone Registration Status display according to parent registration and/or frozen status


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
