### PR TITLE
MHR party compressed name update.

### DIFF
--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -77,7 +77,13 @@
         of the document registration date.
       </div>
       <div class="cover-data mt-4"><span class="cover-data-bold">Manufactured Home Registration Number:</span> {{ mhrNumber }}</div>
-      <div class="cover-data mt-4"><span class="cover-data-bold">Registration Type:</span> {{ documentDescription }}</div>
+      <div class="cover-data mt-4"><span class="cover-data-bold">Registration Type:</span>
+        {% if registrationType == 'MHREG' %}    
+          {{ documentDescription|title }}
+        {% else %}
+          {{ documentDescription }}
+        {% endif %}        
+      </div>
       <div class="cover-data"><span class="cover-data-bold">Document Registration Number:</span>
         {% if documentRegistrationNumber is defined and documentRegistrationNumber != '' %}
          {{ documentRegistrationNumber }}

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -350,7 +350,9 @@ class Report:  # pylint: disable=too-few-public-methods
         elif self._report_key == ReportTypes.MHR_REGISTRATION_COVER:
             self._report_data['regCover'] = report_utils.set_registration_cover(self._report_data)
             self._report_data['createDateTime'] = Report._to_report_datetime(self._report_data['createDateTime'])
-            self._report_data['documentDescription'] = TO_TRANSFER_DESC.get(self._report_data.get('registrationType'))
+            if str(self._report_data.get('registrationType', '')).startswith('TRAN'):
+                self._report_data['documentDescription'] = \
+                    TO_TRANSFER_DESC.get(self._report_data.get('registrationType'))
         elif self._report_key == ReportTypes.MHR_TRANSFER:
             self._report_data['documentDescription'] = TO_TRANSFER_DESC.get(self._report_data.get('registrationType'))
         else:

--- a/mhr_api/tests/unit/models/test_mhr_party.py
+++ b/mhr_api/tests/unit/models/test_mhr_party.py
@@ -178,7 +178,7 @@ def test_create_from_json(session):
     assert party.change_registration_id == 1000
     assert party.party_type == MhrPartyTypes.SUBMITTING
     assert party.status_type == MhrOwnerStatusTypes.ACTIVE
-    assert party.compressed_name
+    assert not party.compressed_name
     assert party.business_name or party.last_name
     if party.last_name:
         assert party.first_name
@@ -200,7 +200,7 @@ def test_create_from_registration_json(session):
         assert party.change_registration_id == 1000
         assert party.party_type in MhrPartyTypes
         assert party.status_type in MhrOwnerStatusTypes
-        assert party.compressed_name
+        assert not party.compressed_name
         assert party.business_name or party.last_name
         if party.last_name:
             assert party.first_name

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -691,7 +691,7 @@ def test_create_new_from_json(session):
         assert party.change_registration_id > 0
         assert party.party_type in MhrPartyTypes
         assert party.status_type in MhrOwnerStatusTypes
-        assert party.compressed_name
+        assert not party.compressed_name
     assert registration.locations
     location = registration.locations[0]
     assert location.registration_id > 0
@@ -734,6 +734,11 @@ def test_save_new(session):
     json_data['documentId'] = '88878888'
     registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
     registration.save()
+    for party in registration.parties:
+        assert party.compressed_name
+    for group in registration.owner_groups:
+        for party in group.owners:
+            assert party.compressed_name
     mh_json = registration.new_registration_json
     assert mh_json
     reg_new = MhrRegistration.find_by_mhr_number(registration.mhr_number, 'PS12345')
@@ -903,6 +908,16 @@ def test_save_transfer(session, mhr_num, user_group, account_id):
                                                                               'userid',
                                                                               user_group)
     registration.save()
+    for party in registration.parties:
+        if not party.compressed_name:
+            current_app.logger.error(party.json)
+        assert party.compressed_name
+    for group in registration.owner_groups:
+        for party in group.owners:
+            if not party.compressed_name:
+                current_app.logger.error(party.json)
+            assert party.compressed_name
+
     reg_new = MhrRegistration.find_by_mhr_number(registration.mhr_number,
                                                  account_id,
                                                  False,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15269

*Description of changes:*
- For MHR registrations, as part of the data migration set up use a db function to generate the PostgreSQL owner (party) search key value.  
- Also fix a recent transfer change to the cover letter report to format the MH registration type correctly. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
