### PR TITLE
Affidavit Transfer modal fixes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/dialogs/BaseDialog.vue
+++ b/ppr-ui/src/components/dialogs/BaseDialog.vue
@@ -21,12 +21,13 @@
           </v-btn>
         </v-col>
       </v-row>
-      <div class="pt-7">
+      <div class="pt-7 action-buttons">
         <!-- can be replaced with <template v-slot:buttons> -->
         <slot name="buttons">
           <dialog-buttons
             :setAcceptText="options.acceptText"
             :setCancelText="options.cancelText"
+            :reverseButtons="reverseActionButtons"
             @proceed="proceed($event)"
           />
         </slot>
@@ -58,7 +59,11 @@ export default defineComponent({
   props: {
     setAttach: { default: '' },
     setDisplay: { default: false },
-    setOptions: Object as () => DialogOptionsIF
+    setOptions: Object as () => DialogOptionsIF,
+    reverseActionButtons: {
+      type: Boolean,
+      default: false
+    }
   },
   emits: ['proceed'],
   setup (props, { emit }) {

--- a/ppr-ui/src/components/dialogs/common/DialogButtons.vue
+++ b/ppr-ui/src/components/dialogs/common/DialogButtons.vue
@@ -1,12 +1,21 @@
 <template>
-  <v-row justify="center" no-gutters>
+  <v-row justify="center" no-gutters :class="{ 'reverse': reverseButtons }">
     <v-col v-if="cancelText" cols="auto">
-      <v-btn id="cancel-btn" class="outlined dialog-btn" outlined @click="proceed(false)">
+      <v-btn
+        id="cancel-btn"
+        class="dialog-btn"
+        :class="reverseButtons ? 'ml-3 primary' : 'outlined'"
+        outlined
+        @click="proceed(false)">
         {{ cancelText }}
       </v-btn>
     </v-col>
-    <v-col v-if="acceptText" :class="{ 'pl-3': cancelText }" cols="auto">
-      <v-btn id="accept-btn" class="primary dialog-btn" @click="proceed(true)">
+    <v-col v-if="acceptText" cols="auto">
+      <v-btn
+        id="accept-btn"
+        class="dialog-btn"
+        :class="reverseButtons ? 'outlined' : 'ml-3 primary'"
+        @click="proceed(true)">
         {{ acceptText }}
       </v-btn>
     </v-col>
@@ -26,7 +35,8 @@ export default defineComponent({
   name: 'DialogButtons',
   props: {
     setAcceptText: String,
-    setCancelText: String
+    setCancelText: String,
+    reverseButtons: Boolean
   },
   emits: ['proceed'],
   setup (props, { emit }) {
@@ -54,5 +64,10 @@ export default defineComponent({
 @import '@/assets/styles/theme.scss';
 #accept-btn {
   font-weight: normal;
+}
+
+.reverse {
+  display: flex;
+  flex-direction: row-reverse;
 }
 </style>

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -301,15 +301,16 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
   // Transfer Due to Sale or Gift flow and all the related conditions/logic
   const TransSaleOrGift: any = {
     hasMixedOwners: computed((): boolean => {
-      return getMhrTransferHomeOwnerGroups.value
-        .every((group: MhrRegistrationHomeOwnerGroupIF) => !TransSaleOrGift.hasMixedOwnersInGroup(group.groupId))
+      return !getMhrTransferHomeOwnerGroups.value
+        .every((group: MhrRegistrationHomeOwnerGroupIF) =>
+          !TransSaleOrGift.hasMixedOwnersInGroup(group.groupId))
     }),
     hasMixedOwnersInGroup: (groupId: number): boolean => {
       const ownerTypes: HomeOwnerPartyTypes[] = getMhrTransferHomeOwnerGroups.value
         .find(group => group.groupId === groupId).owners
         .filter(owner => owner.action !== ActionTypes.REMOVED)
         .map(owner => owner.partyType)
-      return uniq(ownerTypes).length > 1
+      return ownerTypes.length === 1 ? false : uniq(ownerTypes).length > 1
     }
   }
 

--- a/ppr-ui/src/resources/dialogOptions/transferRequiredDialog.ts
+++ b/ppr-ui/src/resources/dialogOptions/transferRequiredDialog.ts
@@ -1,8 +1,8 @@
 import { DialogOptionsIF } from '@/interfaces'
 
 export const transferRequiredDialog: DialogOptionsIF = {
-  acceptText: 'Start Transfer Due to Sale or Gift',
-  cancelText: 'Complete Later',
+  cancelText: 'Start Transfer Due to Sale or Gift',
+  acceptText: 'Complete Later',
   title: 'Your changes have been registered. A Transfer Due to Sale or Gift is now required.',
   label: '',
   // text string is dynamic and mhr_number will be replaced with the MHR number of the Transfer

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -19,6 +19,7 @@
     <BaseDialog
       :setOptions="transferRequiredDialogOptions"
       :setDisplay="showStartTransferRequiredDialog"
+      reverseActionButtons
       @proceed="handleStartTransferRequiredDialogResp($event)"
     />
 
@@ -788,15 +789,16 @@ export default defineComponent({
     }
 
     // For Transfer Sale or Gift after Affidavit is completed
-    const handleStartTransferRequiredDialogResp = async (val: boolean): Promise<void> => {
-      if (!val) {
+    const handleStartTransferRequiredDialogResp = async (proceed: boolean): Promise<void> => {
+      if (proceed) {
         // Complete Later button cancels and navigates to dashboard
         setUnsavedChanges(false) // prevent unsaved changes dialog from showing up
         goToDash()
+      } else {
+        // Start Gift/Sale Transfer simply closes the dialog, since the data is already pre-filled
+        localState.showStartTransferRequiredDialog = false
+        await scrollToFirstError(false, 'home-owners-header')
       }
-      // Start Gift/Sale Transfer simply closes the dialog, since the data is already pre-filled
-      localState.showStartTransferRequiredDialog = false
-      await scrollToFirstError(false, 'home-owners-header')
     }
 
     const quickMhrSearch = async (mhrNumber: string): Promise<void> => {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15806

*Description of changes:*
- Affidavit modal Close button should have a different behaviour (as per UXA) - to make it work, we need to swap action buttons, and to do that, we need to rework `BaseDialog` to accept `reverseActionButtons` prop
- Other fixes for validation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
