### PR TITLE
MHR API registration with party types.

### DIFF
--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -67,7 +67,7 @@
         {% endif %}          
     </div>
     <div class="container mt-11 ml-3">
-      <div class="cover-data-bold">Verification of Service</div>
+      <div class="cover-data-bold">Verification Statement</div>
       {% if attentionReference is defined and attentionReference != '' %}    
         <div class="cover-data mt-4">Attention: {{ attentionReference }}</div>
       {% endif %}

--- a/mhr_api/report-templates/template-parts/registration/sections.html
+++ b/mhr_api/report-templates/template-parts/registration/sections.html
@@ -16,8 +16,8 @@
             <tr class="no-page-break">
                <td><div class="mb-3">{{loop.index}}.</div></td>
                <td><div class="mb-3">{{section.serialNumber}}</div></td>
-               <td><div class="mb-3">{{section.lengthFeet}} feet {{section.lengthInches}} inches</div></td>
-               <td><div class="mb-3">{{section.widthFeet}} feet {{section.widthInches}} inches</div></td>
+               <td><div class="mb-3">{{section.lengthFeet}} feet {% if section.lengthInches is defined %}{{section.lengthInches}}{% else %}0{% endif %} inches</div></td>
+               <td><div class="mb-3">{{section.widthFeet}} feet {% if section.widthInches is defined %}{{section.widthInches}}{% else %}0{% endif %} inches</div></td>
             </tr>
          {% endfor %}
       </table>

--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.20.0
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.11
-git+https://github.com/bcgov/registry-schemas.git@1.7.4#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.7.5#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.7.4#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.7.5#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -34,7 +34,7 @@ select o.manhomid, o.owngrpid, o.ownerid, o.ownseqno, o.verified, o.ownrfone, o.
 """
 EXECUTOR_SUFFIX = 'EXEC'
 TRUST_SUFFIX = 'TRUST'
-TRUSTEE_SUFFIX = 'TRUSTEE'
+TRUSTEE_SUFFIX = 'BANKRUPT'
 ADMIN_SUFFIX = 'ADMIN'
 
 
@@ -196,8 +196,8 @@ class Db2Owner(db.Model):
                 party_type = MhrPartyTypes.EXECUTOR
             elif suffix.find(TRUSTEE_SUFFIX) != -1:
                 party_type = MhrPartyTypes.TRUSTEE
-            elif suffix.find(TRUST_SUFFIX) != -1:
-                party_type = MhrPartyTypes.TRUST
+            # elif suffix.find(TRUST_SUFFIX) != -1:
+            #    party_type = MhrPartyTypes.TRUST
             elif suffix.find(ADMIN_SUFFIX) != -1:
                 party_type = MhrPartyTypes.ADMINISTRATOR
         return party_type
@@ -239,7 +239,9 @@ class Db2Owner(db.Model):
             suffix = suffix.strip().upper()
         if new_info.get('partyType') and new_info.get('description'):
             suffix = str(new_info.get('description')).strip().upper()
-            if suffix.find(new_info.get('partyType')) < 0:
+            if new_info.get('partyType') == MhrPartyTypes.TRUSTEE and suffix.find(TRUSTEE_SUFFIX) < 0:
+                suffix = TRUSTEE_SUFFIX + ' ' + suffix
+            elif suffix.find(new_info.get('partyType')) < 0:
                 suffix = new_info.get('partyType') + ' ' + suffix
         if len(suffix) > 70:
             suffix = suffix[0:70]

--- a/mhr_api/src/mhr_api/models/mhr_party.py
+++ b/mhr_api/src/mhr_api/models/mhr_party.py
@@ -144,7 +144,9 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
         return parties
 
     @staticmethod
-    def create_from_json(json_data, party_type: str, registration_id: int = None, change_registration_id: int = None):
+    def create_from_json(json_data, party_type: str,  # pylint: disable=too-many-branches
+                         registration_id: int = None,
+                         change_registration_id: int = None):
         """Create a party object from a json schema object: map json to db."""
         # current_app.logger.info(json_data)
         party: MhrParty = MhrParty()
@@ -175,6 +177,10 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
             party.phone_number = json_data['phoneNumber'].strip()
         if json_data.get('phoneExtension'):
             party.phone_extension = json_data['phoneExtension'].strip()
+        if json_data.get('description'):
+            party.description = json_data['description'].strip().upper()
+        if json_data.get('suffix'):
+            party.suffix = json_data['suffix'].strip().upper()
 
         party.address = Address.create_from_json(json_data['address'])
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.3.5'  # pylint: disable=invalid-name
+__version__ = '1.3.6'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -51,16 +51,17 @@ TEST_DATA_PARTY_TYPE = [
    ('B', 'TEST', '', MhrPartyTypes.OWNER_BUS),
    ('B', 'TEST', 'EXECUTOR TEST', MhrPartyTypes.EXECUTOR),
    ('B', 'TEST', 'EXECUTRIX TEST', MhrPartyTypes.EXECUTOR),
-   ('B', 'TEST', 'TRUSTEE TEST', MhrPartyTypes.TRUSTEE),
-   ('B', 'TEST', 'TRUST TEST', MhrPartyTypes.TRUST),
+   ('B', 'TEST', 'BANKRUPTCY TRUSTEE TEST', MhrPartyTypes.TRUSTEE),
+   # ('B', 'TEST', 'TRUST TEST', MhrPartyTypes.TRUST),
    ('B', 'TEST', 'ADMINISTRATOR TEST', MhrPartyTypes.ADMINISTRATOR)
 ]
 # testdata pattern is ({party_type}, {description}, {suffix})
 TEST_DATA_PARTY_TYPE_CREATE = [
    (MhrPartyTypes.ADMINISTRATOR, 'Administrator of estate of John Smith', 'ADMINISTRATOR OF ESTATE OF JOHN SMITH'),
    (MhrPartyTypes.EXECUTOR, 'estate of John Smith', 'EXECUTOR ESTATE OF JOHN SMITH'),
-   (MhrPartyTypes.TRUSTEE, 'Trustee of estate of John Smith', 'TRUSTEE OF ESTATE OF JOHN SMITH'),
-   (MhrPartyTypes.TRUST, 'estate of John Smith', 'TRUST ESTATE OF JOHN SMITH')
+   # (MhrPartyTypes.TRUST, 'estate of John Smith', 'TRUST ESTATE OF JOHN SMITH'),
+   (MhrPartyTypes.TRUSTEE, 'Trustee of estate of John Smith, a bankrupt', 'TRUSTEE OF ESTATE OF JOHN SMITH, A BANKRUPT'),
+   (MhrPartyTypes.TRUSTEE, 'Trustee of estate of John Smith', 'BANKRUPT TRUSTEE OF ESTATE OF JOHN SMITH')
 ]
 
 @pytest.mark.parametrize('exists,manuhome_id,owner_id,type', TEST_DATA)

--- a/mhr_api/tests/unit/utils/test_registration_data.py
+++ b/mhr_api/tests/unit/utils/test_registration_data.py
@@ -1,0 +1,596 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""New MH registration test data defined here."""
+
+
+SO_VALID = [
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'SOLE'
+    }
+]
+JT_VALID = [
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            },
+            {
+            'individualName': {
+                'first': 'John',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'JOINT'
+    }
+]
+SO_OWNER_MULTIPLE = [
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            },
+            {
+            'individualName': {
+                'first': 'John',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'SOLE'
+    }
+]
+SO_GROUP_MULTIPLE = [
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'SOLE'
+    },
+    {
+        'groupId': 3,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'SOLE'
+    }
+]
+JT_OWNER_SINGLE = [
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'JOINT'
+    }
+]
+TC_GROUPS_VALID = [
+    {
+        'groupId': 1,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'COMMON',
+        'interest': 'UNDIVIDED 1/2',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    },
+    {
+        'groupId': 2,
+        'owners': [
+            {
+            'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }, {
+            'individualName': {
+                'first': 'Jane',
+                'last': 'Smith'
+            },
+            'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+            },
+            'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'JOINT',
+        'interest': 'UNDIVIDED',
+        'interestNumerator': 1,
+        'interestDenominator': 2
+    }
+]
+TC_GROUP_VALID = {
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567'
+        }, {
+        'individualName': {
+            'first': 'Jane',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        }
+        }
+    ],
+    'type': 'JOINT',
+    'interest': 'UNDIVIDED',
+    'interestNumerator': 1,
+    'interestDenominator': 2
+}
+INTEREST_VALID_1 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 2 }
+]
+INTEREST_VALID_2 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
+]
+INTEREST_VALID_3 = [
+    { 'numerator': 1, 'denominator': 10 }, { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 5 }
+]
+INTEREST_INVALID_1 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }
+]
+INTEREST_INVALID_2 = [
+    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
+]
+LOCATION_PARK = {
+    'locationType': 'MH_PARK',
+    'address': {
+      'street': '1117 GLENDALE AVENUE',
+      'city': 'SALMO',
+      'region': 'BC',
+      'country': 'CA',
+      'postalCode': ''
+    },
+    'leaveProvince': False,
+    'parkName': 'GLENDALE TRAILER PARK',
+    'pad': '2',
+    'additionalDescription': 'TEST PARK'
+}
+LOCATION_RESERVE = {
+    'locationType': 'RESERVE',
+    'bandName': 'BAND NAME',
+    'reserveNumber': '12',
+    'address': {
+        'street': '7612 LUDLOM RD.',
+        'city': 'DEKA LAKE',
+        'region': 'BC',
+        'country': 'CA',
+        'postalCode': ''
+    },
+    'leaveProvince': False,
+    'additionalDescription': 'TEST RESERVE'
+}
+LOCATION_OTHER = {
+    'locationType': 'OTHER',
+    'address': {
+        'street': '7612 LUDLOM RD.',
+        'city': 'DEKA LAKE',
+        'region': 'BC',
+        'country': 'CA',
+        'postalCode': ''
+    },
+    'pidNumber': '007351119',
+    'leaveProvince': False,
+    'additionalDescription': 'TEST OTHER'
+}
+LOCATION_STRATA = {
+    'locationType': 'STRATA',
+    'address': {
+        'street': '7612 LUDLOM RD.',
+        'city': 'DEKA LAKE',
+        'region': 'BC',
+        'country': 'CA',
+        'postalCode': ''
+    },
+    'leaveProvince': False,
+    'pidNumber': '007351119',
+    'taxCertificate': True,
+    'taxExpiryDate': '2035-01-31T08:00:00+00:00',
+    'additionalDescription': 'TEST STRATA'
+}
+LOCATION_MANUFACTURER = {
+    'locationType': 'MANUFACTURER',
+    'address': {
+      'street': '1117 GLENDALE AVENUE',
+      'city': 'SALMO',
+      'region': 'BC',
+      'country': 'CA',
+      'postalCode': ''
+    },
+    'leaveProvince': False,
+    'dealerName': 'DEALER-MANUFACTURER NAME',
+    'additionalDescription': 'TEST MANUFACTURER'
+}
+SO_VALID_EXEC = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'EXECUTOR',
+        'description': 'EXECUTOR of the deceased.'
+    }
+    ],
+    'type': 'SOLE'
+}
+SO_VALID_TRUSTEE = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'TRUSTEE',
+        'description': 'Trustee of the deceased, a bankrupt.'
+    }
+    ],
+    'type': 'SOLE'
+}
+SO_VALID_ADMIN = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'ADMINISTRATOR',
+        'description': 'ADMINISTRATOR of the deceased.'
+    }
+    ],
+    'type': 'SOLE'
+}
+JT_VALID_EXEC = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'EXECUTOR',
+        'description': 'EXECUTOR of the deceased.'
+    }, {
+        'individualName': {
+            'first': 'Jane',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'EXECUTOR',
+        'description': 'EXECUTOR of the deceased.'
+    }
+    ],
+    'type': 'NA'
+}
+JT_VALID_TRUSTEE = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'TRUSTEE',
+        'description': 'Trustee of the deceased, a bankrupt.'
+    },{
+        'individualName': {
+            'first': 'Jane',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'TRUSTEE',
+        'description': 'Trustee of the deceased, a bankrupt.'
+    }
+    ],
+    'type': 'NA'
+}
+JT_VALID_ADMIN = {
+    'groupId': 1,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'ADMINISTRATOR',
+        'description': 'ADMINISTRATOR of the deceased.'
+    },{
+        'individualName': {
+            'first': 'Jane',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'ADMINISTRATOR',
+        'description': 'ADMINISTRATOR of the deceased.'
+    }
+    ],
+    'type': 'NA'
+}
+TC_VALID_EXEC = {
+    'groupId': 2,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'EXECUTOR',
+        'description': 'EXECUTOR of the deceased.'
+    }
+    ],
+    'type': 'NA'
+}
+TC_VALID_TRUSTEE = {
+    'groupId': 2,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'TRUSTEE',
+        'description': 'Trustee of the deceased, a bankrupt.'
+    }
+    ],
+    'type': 'NA'
+}
+TC_VALID_ADMIN = {
+    'groupId': 2,
+    'owners': [
+        {
+        'individualName': {
+            'first': 'James',
+            'last': 'Smith'
+        },
+        'address': {
+            'street': '3122B LYNNLARK PLACE',
+            'city': 'VICTORIA',
+            'region': 'BC',
+            'postalCode': ' ',
+            'country': 'CA'
+        },
+        'phoneNumber': '6041234567',
+        'partyType': 'ADMINISTRATOR',
+        'description': 'ADMINISTRATOR of the deceased.'
+    }
+    ],
+    'type': 'NA'
+}

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -24,6 +24,34 @@ from mhr_api.models import MhrRegistration
 from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrTenancyTypes, MhrDocumentTypes, MhrLocationTypes
 from mhr_api.models.utils import is_legacy
 from mhr_api.services.authz import QUALIFIED_USER_GROUP
+from tests.unit.utils.test_registration_data import (
+    SO_VALID,
+    JT_VALID,
+    SO_OWNER_MULTIPLE,
+    SO_GROUP_MULTIPLE,
+    JT_OWNER_SINGLE,
+    TC_GROUPS_VALID,
+    TC_GROUP_VALID,
+    INTEREST_VALID_1,
+    INTEREST_VALID_2,
+    INTEREST_VALID_3,
+    INTEREST_INVALID_1,
+    INTEREST_INVALID_2,
+    LOCATION_PARK,
+    LOCATION_RESERVE,
+    LOCATION_OTHER,
+    LOCATION_STRATA,
+    LOCATION_MANUFACTURER,
+    SO_VALID_EXEC,
+    SO_VALID_TRUSTEE,
+    SO_VALID_ADMIN,
+    JT_VALID_EXEC,
+    JT_VALID_TRUSTEE,
+    JT_VALID_ADMIN,
+    TC_VALID_EXEC,
+    TC_VALID_TRUSTEE,
+    TC_VALID_ADMIN
+)
 
 
 DESC_VALID = 'Valid'
@@ -39,343 +67,6 @@ DOC_ID_VALID = '63166035'
 DOC_ID_INVALID_CHECKSUM = '63166034'
 INVALID_TEXT_CHARSET = 'TEST \U0001d5c4\U0001d5c6/\U0001d5c1 INVALID'
 INVALID_CHARSET_MESSAGE = 'The character set is not supported'
-SO_VALID = [
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'SOLE'
-    }
-]
-JT_VALID = [
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            },
-            {
-            'individualName': {
-                'first': 'John',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'JOINT'
-    }
-]
-SO_OWNER_MULTIPLE = [
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            },
-            {
-            'individualName': {
-                'first': 'John',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'SOLE'
-    }
-]
-SO_GROUP_MULTIPLE = [
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'SOLE'
-    },
-    {
-        'groupId': 3,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'SOLE'
-    }
-]
-JT_OWNER_SINGLE = [
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'JOINT'
-    }
-]
-TC_GROUPS_VALID = [
-    {
-        'groupId': 1,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'COMMON',
-        'interest': 'UNDIVIDED 1/2',
-        'interestNumerator': 1,
-        'interestDenominator': 2
-    },
-    {
-        'groupId': 2,
-        'owners': [
-            {
-            'individualName': {
-                'first': 'James',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }, {
-            'individualName': {
-                'first': 'Jane',
-                'last': 'Smith'
-            },
-            'address': {
-                'street': '3122B LYNNLARK PLACE',
-                'city': 'VICTORIA',
-                'region': 'BC',
-                'postalCode': ' ',
-                'country': 'CA'
-            },
-            'phoneNumber': '6041234567'
-            }
-        ],
-        'type': 'JOINT',
-        'interest': 'UNDIVIDED',
-        'interestNumerator': 1,
-        'interestDenominator': 2
-    }
-]
-TC_GROUP_VALID = {
-    'owners': [
-        {
-        'individualName': {
-            'first': 'James',
-            'last': 'Smith'
-        },
-        'address': {
-            'street': '3122B LYNNLARK PLACE',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'postalCode': ' ',
-            'country': 'CA'
-        },
-        'phoneNumber': '6041234567'
-        }, {
-        'individualName': {
-            'first': 'Jane',
-            'last': 'Smith'
-        },
-        'address': {
-            'street': '3122B LYNNLARK PLACE',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'postalCode': ' ',
-            'country': 'CA'
-        }
-        }
-    ],
-    'type': 'JOINT',
-    'interest': 'UNDIVIDED',
-    'interestNumerator': 1,
-    'interestDenominator': 2
-}
-INTEREST_VALID_1 = [
-    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 2 }
-]
-INTEREST_VALID_2 = [
-    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
-]
-INTEREST_VALID_3 = [
-    { 'numerator': 1, 'denominator': 10 }, { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 5 }
-]
-INTEREST_INVALID_1 = [
-    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 1, 'denominator': 4 }
-]
-INTEREST_INVALID_2 = [
-    { 'numerator': 1, 'denominator': 2 }, { 'numerator': 2, 'denominator': 4 }, { 'numerator': 1, 'denominator': 4 }
-]
-LOCATION_PARK = {
-    'locationType': 'MH_PARK',
-    'address': {
-      'street': '1117 GLENDALE AVENUE',
-      'city': 'SALMO',
-      'region': 'BC',
-      'country': 'CA',
-      'postalCode': ''
-    },
-    'leaveProvince': False,
-    'parkName': 'GLENDALE TRAILER PARK',
-    'pad': '2',
-    'additionalDescription': 'TEST PARK'
-}
-LOCATION_RESERVE = {
-    'locationType': 'RESERVE',
-    'bandName': 'BAND NAME',
-    'reserveNumber': '12',
-    'address': {
-        'street': '7612 LUDLOM RD.',
-        'city': 'DEKA LAKE',
-        'region': 'BC',
-        'country': 'CA',
-        'postalCode': ''
-    },
-    'leaveProvince': False,
-    'additionalDescription': 'TEST RESERVE'
-}
-LOCATION_OTHER = {
-    'locationType': 'OTHER',
-    'address': {
-        'street': '7612 LUDLOM RD.',
-        'city': 'DEKA LAKE',
-        'region': 'BC',
-        'country': 'CA',
-        'postalCode': ''
-    },
-    'pidNumber': '007351119',
-    'leaveProvince': False,
-    'additionalDescription': 'TEST OTHER'
-}
-LOCATION_STRATA = {
-    'locationType': 'STRATA',
-    'address': {
-        'street': '7612 LUDLOM RD.',
-        'city': 'DEKA LAKE',
-        'region': 'BC',
-        'country': 'CA',
-        'postalCode': ''
-    },
-    'leaveProvince': False,
-    'pidNumber': '007351119',
-    'taxCertificate': True,
-    'taxExpiryDate': '2035-01-31T08:00:00+00:00',
-    'additionalDescription': 'TEST STRATA'
-}
-LOCATION_MANUFACTURER = {
-    'locationType': 'MANUFACTURER',
-    'address': {
-      'street': '1117 GLENDALE AVENUE',
-      'city': 'SALMO',
-      'region': 'BC',
-      'country': 'CA',
-      'postalCode': ''
-    },
-    'leaveProvince': False,
-    'dealerName': 'DEALER-MANUFACTURER NAME',
-    'additionalDescription': 'TEST MANUFACTURER'
-}
 
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content})
 TEST_REG_DATA = [
@@ -544,6 +235,25 @@ TEST_DATA_GROUP_INTEREST = [
 # testdata pattern is ({description}, {mhr_number}, {message content})
 TEST_DATA_LIEN_COUNT = [
     ('Valid request', '100000', '')
+]
+# testdata pattern is ({description}, {valid}, {group1}, {group2}, {g1_type}, {o2_party_type}, {message})
+TEST_PARTY_TYPE_DATA = [
+    ('Valid SO exec', True, SO_VALID_EXEC, None, None, None, None),
+    ('Valid SO trustee', True, SO_VALID_TRUSTEE, None, None, None, None),
+    ('Valid SO admin', True, SO_VALID_ADMIN, None, None, None, None),
+    ('Valid JT exec', True, JT_VALID_EXEC, None, None, None, None),
+    ('Valid JT trustee', True, JT_VALID_TRUSTEE, None, None, None, None),
+    ('Valid JT admin', True, JT_VALID_ADMIN, None, None, None, None),
+    ('Valid TC exec', True, JT_VALID_EXEC, TC_VALID_EXEC, None, None, None),
+    ('Valid TC trustee', True, JT_VALID_TRUSTEE, TC_VALID_TRUSTEE, None, None, None),
+    ('Valid TC admin', True, JT_VALID_ADMIN, TC_VALID_ADMIN, None, None, None),
+    ('Invalid SO type NA', False, SO_VALID_EXEC, None, 'NA', None, validator.TENANCY_TYPE_NA_INVALID),
+    ('Invalid SO exec no desc', False, SO_VALID_EXEC, None, None, None, validator.OWNER_DESCRIPTION_REQUIRED),
+    ('Invalid common type JOINT', False, JT_VALID_EXEC, TC_VALID_EXEC, 'JOINT', None,
+     validator.TENANCY_PARTY_TYPE_INVALID),
+    ('Invalid JT party types 1', False, JT_VALID_EXEC, None, None, 'ADMINISTRATOR', validator.GROUP_PARTY_TYPE_INVALID),
+    ('Invalid JT party types 2', False, JT_VALID_TRUSTEE, None, None, 'EXECUTOR', validator.GROUP_PARTY_TYPE_INVALID),
+    ('Invalid JT party types 3', False, JT_VALID_ADMIN, None, None, 'TRUSTEE', validator.GROUP_PARTY_TYPE_INVALID)
 ]
 
 
@@ -953,3 +663,41 @@ def test_validate_location_other(session, desc, park, dealer, pad, reserve, band
         assert error_msg.find(message_content) != -1
     else:
         assert not error_msg
+
+
+@pytest.mark.parametrize('desc,valid,group1,group2,g1_type,o1_party_type,message_content', TEST_PARTY_TYPE_DATA)
+def test_validate_registration_party(session, desc, valid, group1, group2, g1_type, o1_party_type, message_content):
+    """Assert that new MH registration owner group party type validation works as expected."""
+    # setup
+    json_data = get_valid_registration(MhrTenancyTypes.SOLE)
+    owner_groups = []
+    group_1 = copy.deepcopy(group1)
+    group_2 = copy.deepcopy(group2) if group2 else None
+    if g1_type:
+        group_1['type'] = g1_type
+    if o1_party_type:
+        group_1['owners'][1]['partyType'] = o1_party_type
+    if group_2:
+        group_1['interest'] = 'UNDIVIDED'
+        group_1['interestNumerator'] = 1
+        group_1['interestDenominator'] = 2
+    if desc == 'Invalid SO exec no desc':
+        del group_1['owners'][0]['description']
+    owner_groups.append(group_1)
+    if group_2:
+        group_2['interest'] = 'UNDIVIDED'
+        group_2['interestNumerator'] = 1
+        group_2['interestDenominator'] = 2
+        owner_groups.append(group_2)
+    json_data['ownerGroups'] = owner_groups
+    valid_format, errors = schema_utils.validate(json_data, 'registration', 'mhr')
+    # Additional validation not covered by the schema.
+    error_msg = validator.validate_registration(json_data, False)
+    # if error_msg:
+    #    current_app.logger.debug(error_msg)
+    if valid:
+        assert valid_format and error_msg == ''
+    else:
+        assert error_msg != ''
+        if message_content:
+            assert error_msg.find(message_content) != -1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16179
                 /bcgov/entity#16184

*Description of changes:*
- 16179 MHREG allow TRUSTEE, EXECUTOR, ADMIN party types.
- 16184 Reg report home section inches display value of 0 if no property.
- 16124 Staff cover letter wording change.
- Update registries schema version to 1.7.5 (add new registration types).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
