### PR TITLE
Fixes for Transfer of Surviving Tenants

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -282,7 +282,6 @@
               <DeathCertificate
                 :deceasedOwner="row.item"
                 :validate="validateTransfer"
-                @isValid="isValidDeathCertificate = $event"
               />
             </v-expand-transition>
           </td>
@@ -358,7 +357,6 @@
                   <DeathCertificate
                     :deceasedOwner="row.item"
                     :validate="validateTransfer"
-                    @isValid="isValidDeathCertificate = $event"
                     :isDisabled="isGlobalEditingMode"
                   />
                 </template>
@@ -464,6 +462,7 @@ export default defineComponent({
       TransSaleOrGift,
       TransToExec,
       TransToAdmin,
+      TransJointTenants,
       getMhrTransferType
     } = useTransferOwners(!props.isMhrTransfer)
 
@@ -492,7 +491,6 @@ export default defineComponent({
       ownerToDecease: null as MhrRegistrationHomeOwnerIF,
       isEditingMode: computed((): boolean => localState.currentlyEditingHomeOwnerId >= 0),
       isAddingMode: computed((): boolean => props.isAdding),
-      isValidDeathCertificate: false,
       showTableError: computed((): boolean => {
         // For certain Transfers, we only need to check for global changes and do not show table error in other cases
         if (isTransferToExecutorProbateWill.value ||
@@ -753,7 +751,7 @@ export default defineComponent({
         localState.isValidAllocation &&
         !localState.hasGroupsWithNoOwners &&
         (isTransferDueToSaleOrGift.value ? !TransSaleOrGift.hasMixedOwners.value : true) &&
-        (isTransferToSurvivingJointTenant.value ? localState.isValidDeathCertificate : true) &&
+        (isTransferToSurvivingJointTenant.value ? TransJointTenants.isValidTransfer.value : true) &&
         ((isTransferToExecutorProbateWill.value || isTransferToExecutorUnder25Will.value)
           ? TransToExec.isValidTransfer.value : true)
       )

--- a/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
@@ -151,10 +151,6 @@ export default defineComponent({
       validate && (context.refs.deathCertificateForm as FormIF).validate()
     }, { immediate: true })
 
-    watch(() => localState.isDeathCertificateFormValid, async (val: boolean) => {
-      context.emit('isValid', val)
-    }, { immediate: true })
-
     // Update deceased owner deathCertificateNumber when value changes
     watch(() => localState.deathCertificateNumber, async (val: string) => {
       await nextTick()

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -298,7 +298,8 @@ export const useMhrInformation = () => {
             return owner.individualName ? { ...owner, individualName: normalizeObject(owner.individualName) } : owner
           }),
           // Determine group tenancy type
-          type: ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1
+          type: (ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1 ||
+            getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT)
             ? ApiHomeTenancyTypes.JOINT
             : getMhrTransferHomeOwnerGroups.value.length > 1
               ? ApiHomeTenancyTypes.NA

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -479,6 +479,23 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     }
   }
 
+  const TransJointTenants = {
+    isValidTransfer: computed((): boolean => {
+      const groupWithDeletedOwners: MhrRegistrationHomeOwnerGroupIF = getMhrTransferHomeOwnerGroups.value?.find(group =>
+        group.owners.some(owner => owner.action === ActionTypes.REMOVED))
+
+      if (!groupWithDeletedOwners) return false
+
+      const isValidGroup = groupWithDeletedOwners.owners
+        .filter(owner => owner.action === ActionTypes.REMOVED)
+        .every(owner =>
+          owner.hasDeathCertificate && !!owner.deathCertificateNumber && !!owner.deathDateTime)
+      const hasLivingOwners = !groupWithDeletedOwners.owners.every(owner => owner.action === ActionTypes.REMOVED)
+
+      return isValidGroup && hasLivingOwners
+    })
+  }
+
   // Transfer Affidavit flow and all the related conditions/logic
   const TransAffidavit = {
     setCompleted: (completed: boolean): void => {
@@ -612,6 +629,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     isDisabledForWillChanges,
     TransSaleOrGift,
     TransToExec, // Transfer Due to Death - Grant of Probate (with Will)
+    TransJointTenants,
     TransAffidavit, // Transfer to Executor under $25k - Affidavit
     TransToAdmin,
     isTransAffi,


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16197

*Description of changes:*
- Issue 1 - For SJT transfers, when navigating from the Review & Confirm page back to the first page, Death Certificate component would not re-validate properly, causing errors. 
- Issue 2 - submission fails due to bad payload structure, work in progress


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
