### PR TITLE
Does not show exempt and historical children + Code clean up

### DIFF
--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -137,7 +137,7 @@
     >
       <div v-if="!isChild || isDraft(item) || !isPpr">
         {{  isMhrTransfer(item) ?
-        'Completed' : getStatusDescription(item.statusType) }}
+        'Completed' : getStatusDescription(item.statusType, isChild, isPpr) }}
         <p v-if="!isChild && item.hasDraft" class="ma-0">
           <i>{{ isPpr ? '* Draft Amendment' : '* Draft Changes' }}</i>
         </p>

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -360,10 +360,10 @@ export const useNewMhrRegistration = () => {
             createDateTime: draft.createDateTime,
             error: draft.error,
             registrationDescription: draft.registrationDescription,
-            hasDraft: sortOptions?.status === APIStatusTypes.DRAFT,
+            hasDraft: false,
             ownerNames: '',
             path: draft.path,
-            statusType: APIStatusTypes.DRAFT,
+            statusType: MhApiStatusTypes.DRAFT,
             username: '',
             documentId: draft.draftNumber
           }

--- a/ppr-ui/src/composables/useRegistration.ts
+++ b/ppr-ui/src/composables/useRegistration.ts
@@ -1,5 +1,5 @@
 import { reactive, toRefs } from '@vue/composition-api'
-import { MhStatusTypes, StatusTypes } from '@/resources'
+import { MhrAPIToUIStatusTypesMap, PprAPIToUIStatusTypesMap } from '@/resources'
 import {
   APIAmendmentTypes,
   APIRegistrationTypes,
@@ -42,21 +42,12 @@ export const useRegistration = (setSort: RegistrationSortIF) => {
     }
   }
 
-  const getStatusDescription = (status: APIStatusTypes | MhApiStatusTypes): string => {
+  const getStatusDescription = (status: APIStatusTypes | MhApiStatusTypes,
+    isChild: boolean, isPpr: boolean): string => {
     if (!status) return UIStatusTypes.DRAFT
     if (status === MhApiStatusTypes.FROZEN) return MhUIStatusTypes.ACTIVE
-
-    for (const statusType of StatusTypes) {
-      if (statusType.value === status) {
-        return statusType.text
-      }
-    }
-
-    for (const mhStatusType of MhStatusTypes) {
-      if (mhStatusType.value === status) {
-        return mhStatusType.text
-      }
-    }
+    if (isChild && (status === MhApiStatusTypes.HISTORICAL || status === MhApiStatusTypes.EXEMPT)) return ''
+    return isPpr ? PprAPIToUIStatusTypesMap[status] : MhrAPIToUIStatusTypesMap[status]
   }
 
   const getRegisteringName = (name: string): string => {

--- a/ppr-ui/src/resources/statusTypes.ts
+++ b/ppr-ui/src/resources/statusTypes.ts
@@ -7,7 +7,6 @@ export const StatusTypes = [
   },
   {
     value: APIStatusTypes.ACTIVE,
-    mhrValue: APIStatusTypes.MHR_ACTIVE,
     text: UIStatusTypes.ACTIVE
   },
   {
@@ -38,3 +37,17 @@ export const MhStatusTypes = [
     text: MhUIStatusTypes.HISTORICAL
   }
 ]
+
+export const PprAPIToUIStatusTypesMap = {
+  [APIStatusTypes.DRAFT]: UIStatusTypes.DRAFT,
+  [APIStatusTypes.ACTIVE]: UIStatusTypes.ACTIVE,
+  [APIStatusTypes.EXPIRED]: UIStatusTypes.EXPIRED,
+  [APIStatusTypes.DISCHARGED]: UIStatusTypes.DISCHARGED
+}
+
+export const MhrAPIToUIStatusTypesMap = {
+  [MhApiStatusTypes.DRAFT]: MhUIStatusTypes.DRAFT,
+  [MhApiStatusTypes.ACTIVE]: MhUIStatusTypes.ACTIVE,
+  [MhApiStatusTypes.EXEMPT]: MhUIStatusTypes.EXEMPT,
+  [MhApiStatusTypes.HISTORICAL]: MhUIStatusTypes.HISTORICAL
+}

--- a/ppr-ui/tests/unit/TableRow.spec.ts
+++ b/ppr-ui/tests/unit/TableRow.spec.ts
@@ -159,7 +159,7 @@ describe('TableRow tests', () => {
             expect(rowData.at(1).find(btnExpTxt).exists()).toBe(false)
           }
           // status type
-          expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType))
+          expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType, false, true))
           // expire days
           if ([APIStatusTypes.DISCHARGED, APIStatusTypes.EXPIRED].includes(baseReg.statusType as APIStatusTypes)) {
             expect(rowData.at(8).text()).toContain('—')
@@ -216,7 +216,7 @@ describe('TableRow tests', () => {
         // submitted date
         expect(rowData.at(2).text()).toBe('Not Registered')
         // status type
-        expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType))
+        expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType, isChild, true))
         // expire days
         if (isChild) expect(rowData.at(8).text()).toEqual('')
         else expect(rowData.at(8).text()).toBe('N/A')
@@ -432,7 +432,7 @@ describe('Mhr TableRow tests', () => {
             expect(rowData.at(1).find(btnExpTxt).exists()).toBe(false)
           }
           // status type
-          expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType))
+          expect(rowData.at(3).text()).toContain(wrapper.vm.getStatusDescription(baseReg.statusType, isChild, false))
           // expire days
           expect(rowData.at(8).text()).toContain(wrapper.vm.showExpireDays(baseReg))
           // action btn
@@ -524,10 +524,7 @@ describe('Mhr TableRow tests', () => {
       { ...mockedMhRegistration, statusType: MhApiStatusTypes.FROZEN }
     ]
 
-    for (let i = 0; i < registrations.length; i++) {
-      // both below are the same variable, but typed differently
-      const reg = registrations[i] as MhRegistrationSummaryIF
-
+    for (const reg of registrations) {
       await wrapper.setProps({
         setItem: reg
       })
@@ -550,6 +547,46 @@ describe('Mhr TableRow tests', () => {
           break
         case MhApiStatusTypes.HISTORICAL:
           expect(rowData.at(3).text()).toContain(MhUIStatusTypes.HISTORICAL)
+          break
+        default:
+          fail('No/Unknown MhStatusType')
+      }
+    }
+  })
+
+  it('displays the correct status for all mhStatusTypes as children', async () => {
+    const registrations: (MhRegistrationSummaryIF)[] = [
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.EXEMPT },
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.HISTORICAL },
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.ACTIVE },
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.DRAFT },
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.FROZEN }
+    ]
+
+    for (const reg of registrations) {
+      await wrapper.setProps({
+        setItem: reg,
+        setChild: true
+      })
+
+      expect(wrapper.vm.item).toEqual(reg)
+      const rowData = wrapper.findAll(tableRow + ' td')
+      expect(rowData.exists()).toBe(true)
+      switch (reg.statusType) {
+        case MhApiStatusTypes.ACTIVE:
+          expect(rowData.at(3).text()).toContain(MhUIStatusTypes.ACTIVE)
+          break
+        case MhApiStatusTypes.DRAFT:
+          expect(rowData.at(3).text()).toContain(MhUIStatusTypes.DRAFT)
+          break
+        case MhApiStatusTypes.EXEMPT:
+          expect(rowData.at(3).text()).toContain('')
+          break
+        case MhApiStatusTypes.FROZEN:
+          expect(rowData.at(3).text()).toContain(MhUIStatusTypes.ACTIVE)
+          break
+        case MhApiStatusTypes.HISTORICAL:
+          expect(rowData.at(3).text()).toContain('')
           break
         default:
           fail('No/Unknown MhStatusType')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15910

*Description of changes:*
- Adds condition to check for exempt and historical children statusTypes and return an empty string
- Utilizes a map/object in the `getStatusDescription` to avoid looping and simplify code
- changes the hasDraft condition inthe `addHistoryDraftsToMhr` function to false, has it causes "* Draft Changes" to display when filtering by draft statusType for drafts. 
- Adds and updates tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
