### PR TITLE
Fixs draft showing when filtering by other statusTypes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.22",
+      "version": "1.1.23",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -624,7 +624,7 @@ export default defineComponent({
     }
 
     const isEnabledMhr = (item: MhRegistrationSummaryIF) => {
-      return [APIStatusTypes.MHR_ACTIVE, MhApiStatusTypes.FROZEN].includes(item.statusType as APIStatusTypes) &&
+      return [MhApiStatusTypes.ACTIVE, MhApiStatusTypes.FROZEN].includes(item.statusType as MhApiStatusTypes) &&
         localState.enableOpenEdit && (item.registrationDescription === APIMhrDescriptionTypes.REGISTER_NEW_UNIT ||
           item.registrationDescription === APIMhrDescriptionTypes.CONVERTED)
     }
@@ -706,7 +706,7 @@ export default defineComponent({
       // RegistrationSummaryIF | DraftResultIF | MhrDraftApiIF
       return props.isPpr
         ? item.type !== undefined
-        : (item.statusType === APIStatusTypes.DRAFT || item.statusType === undefined || !item.mhrNumber)
+        : (item.statusType === MhApiStatusTypes.DRAFT || item.statusType === undefined || !item.mhrNumber)
     }
 
     const isExpired = (item: RegistrationSummaryIF): boolean => {

--- a/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDischarge.vue
@@ -52,7 +52,7 @@ import { useGetters } from 'vuex-composition-helpers'
 // local
 import { formatExpiryDate, pacificDate } from '@/utils'
 import { RegistrationTypeIF } from '@/interfaces' // eslint-disable-line
-import { APIStatusTypes, MhUIStatusTypes } from '@/enums'
+import { MhApiStatusTypes, MhUIStatusTypes } from '@/enums'
 import { useMhrInformation } from '@/composables'
 
 export default defineComponent({
@@ -99,7 +99,7 @@ export default defineComponent({
       statusType: computed((): string => {
         const regStatus = getMhrInformation.value.statusType
 
-        return isFrozenMhr.value || regStatus === APIStatusTypes.DRAFT
+        return isFrozenMhr.value || regStatus === MhApiStatusTypes.DRAFT
           ? MhUIStatusTypes.ACTIVE
           : regStatus[0] + regStatus.toLowerCase().slice(1)
       }),

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -325,9 +325,13 @@ export const useNewMhrRegistration = () => {
     let mhrTableData = []
     // Collect MH Transfer and Registration Drafts
     const sortedDraftFilings = orderBy(mhrDrafts, ['createDateTime'], ['desc'])
-    const mhRegDrafts = mhrDrafts.filter(draft =>
-      !draft.mhrNumber && draft.registrationType === APIMhrTypes.MANUFACTURED_HOME_REGISTRATION
-    )
+    let mhRegDrafts = []
+
+    if (!sortOptions?.status || sortOptions?.status === MhApiStatusTypes.DRAFT) {
+      mhRegDrafts = mhrDrafts.filter(draft =>
+        !draft.mhrNumber && draft.registrationType === APIMhrTypes.MANUFACTURED_HOME_REGISTRATION
+      )
+    }
 
     // add Transfer drafts to parent registrations.
     mhrHistory.forEach(transfer => {

--- a/ppr-ui/tests/unit/TableRow.spec.ts
+++ b/ppr-ui/tests/unit/TableRow.spec.ts
@@ -538,6 +538,7 @@ describe('Mhr TableRow tests', () => {
           break
         case MhApiStatusTypes.DRAFT:
           expect(rowData.at(3).text()).toContain(MhUIStatusTypes.DRAFT)
+          expect(rowData.at(rowData.length - 1).text()).toContain('Edit')
           break
         case MhApiStatusTypes.EXEMPT:
           expect(rowData.at(3).text()).toContain(MhUIStatusTypes.EXEMPT)
@@ -578,6 +579,7 @@ describe('Mhr TableRow tests', () => {
           break
         case MhApiStatusTypes.DRAFT:
           expect(rowData.at(3).text()).toContain(MhUIStatusTypes.DRAFT)
+          expect(rowData.at(rowData.length - 1).text()).toContain('Edit')
           break
         case MhApiStatusTypes.EXEMPT:
           expect(rowData.at(3).text()).toContain('')


### PR DESCRIPTION
*Issue #:*
-  bcgov/entity#16279
-  bcgov/entity#16358

*Description of changes:*
- Only adds Draft registrations when there is no statusTypes filter or filtering by draft
- Updates StatusTypes to fix bugs
- Adds and updates tests


*Before change:*

![Screenshot 2023-05-18 082527](https://github.com/bcgov/ppr/assets/77707952/4e60d764-2a92-440c-970f-f7d1030a8885)
![Screenshot 2023-05-18 082649](https://github.com/bcgov/ppr/assets/77707952/33adc3eb-5a78-4965-a75e-b9e91b0f307f)

*After change:*

![Screenshot 2023-05-18 082854](https://github.com/bcgov/ppr/assets/77707952/53d0fb95-78bf-451e-8990-f05b39d28560)
![Screenshot 2023-05-18 082940](https://github.com/bcgov/ppr/assets/77707952/eccd39af-bdeb-405c-9638-12755bbeb7eb)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
