### PR TITLE
MHR API latest transfer death validation rule updates.

### DIFF
--- a/mhr_api/src/mhr_api/config.py
+++ b/mhr_api/src/mhr_api/config.py
@@ -186,6 +186,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     SUBSCRIPTION_API_KEY = os.getenv('SUBSCRIPTION_API_KEY')
     GATEWAY_API_KEY = os.getenv('GATEWAY_API_KEY')
     GATEWAY_LTSA_URL = os.getenv('GATEWAY_LTSA_URL')
+    DB2_RACF_ID = os.getenv('DB2_DATABASE_USERNAME')
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -172,9 +172,12 @@ class Db2Owner(db.Model):
             owner['status'] = 'EXEMPT'
         else:
             owner['status'] = 'PREVIOUS'
-        if self.suffix:
-            owner['suffix'] = self.suffix
         owner['partyType'] = self.get_party_type()
+        # Make legacy json consistent with new json.
+        if owner['partyType'] in (MhrPartyTypes.EXECUTOR, MhrPartyTypes.TRUSTEE, MhrPartyTypes.ADMINISTRATOR):
+            owner['description'] = self.suffix
+        elif self.suffix:
+            owner['suffix'] = self.suffix
         return owner
 
     @property
@@ -191,9 +194,12 @@ class Db2Owner(db.Model):
         if self.phone_number:
             owner['phoneNumber'] = self.phone_number
         owner['address'] = address_utils.get_address_from_db2_owner(self.legacy_address, self.postal_code)
-        if self.suffix:
-            owner['suffix'] = self.suffix
         owner['partyType'] = self.get_party_type()
+        # Make legacy json consistent with new json.
+        if owner['partyType'] in (MhrPartyTypes.EXECUTOR, MhrPartyTypes.TRUSTEE, MhrPartyTypes.ADMINISTRATOR):
+            owner['description'] = self.suffix
+        elif self.suffix:
+            owner['suffix'] = self.suffix
         return owner
 
     def get_party_type(self) -> str:

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.3.7'  # pylint: disable=invalid-name
+__version__ = '1.3.8'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -337,8 +337,11 @@ def test_create_new_from_json(session):
     assert manuhome.mhr_number == registration.mhr_number
     assert manuhome.reg_document_id == json_data['documentId'] 
     assert manuhome.mh_status == Db2Manuhome.StatusTypes.REGISTERED
+    assert manuhome.update_id == current_app.config.get('DB2_RACF_ID')
     assert manuhome.reg_documents
     assert len(manuhome.reg_documents) == 1
+    doc: Db2Document = manuhome.reg_documents[0]
+    assert doc.update_id == manuhome.update_id
     assert manuhome.reg_location
     assert manuhome.reg_location.status == 'A'
     assert manuhome.reg_descript
@@ -384,6 +387,7 @@ def test_create_transfer_from_json(session, mhr_num, user_group, doc_id_prefix, 
     assert doc.id == registration.doc_id
     assert doc.document_type == Db2Document.DocumentTypes.TRANS
     assert doc.document_reg_id == registration.doc_reg_number
+    assert doc.update_id == current_app.config.get('DB2_RACF_ID')
     assert manuhome.reg_owner_groups
     assert len(manuhome.reg_owner_groups) > 2
     for group in manuhome.reg_owner_groups:

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -117,6 +117,10 @@ def test_party_type(session, owner_type, name, suffix, party_type):
     assert owner_json.get('partyType') == party_type
     owner_json = owner.new_registration_json
     assert owner_json.get('partyType') == party_type
+    if owner_json.get('partyType') in (MhrPartyTypes.OWNER_BUS, MhrPartyTypes.OWNER_IND):
+        assert not owner_json.get('description')
+    else:
+        assert owner_json.get('description')
 
 
 @pytest.mark.parametrize('party_type,description,suffix', TEST_DATA_PARTY_TYPE_CREATE)
@@ -128,6 +132,10 @@ def test_party_type_create(session, party_type, description, suffix):
     owner: Db2Owner = Db2Owner.create_from_registration(reg, json_data, 1, 1)
     assert owner.get_party_type() == party_type
     assert owner.suffix == suffix
+    owner_json = owner.registration_json
+    assert owner_json.get('description')
+    owner_json = owner.new_registration_json
+    assert owner_json.get('description')
 
 
 def test_owner_json(session):

--- a/mhr_api/tests/unit/utils/test_transfer_data.py
+++ b/mhr_api/tests/unit/utils/test_transfer_data.py
@@ -655,7 +655,70 @@ WILL_DELETE_GROUPS2 = [
         'type': 'JOINT'
     }
 ]
+WILL_DELETE_GROUPS3 = [
+    {
+        'groupId': 6,
+        'owners': [
+            {
+                'partyType': 'EXECUTOR',
+                'description': 'EXECUTOR OF THE ESTATE OF MARY LILLIAN MURRAY, DECEASED',
+                'individualName': {
+                    'first': 'JOANNE',
+                    'last': 'KOLLN'
+                 },
+                'address': {
+                    'street': '5382 BABCOCK ROAD',
+                    'city': '100 MILE HOUSE',
+                    'region': 'BC',
+                    'postalCode': 'V0K 2E1',
+                    'country': 'CA'
+                },
+                'phoneNumber': '6041234567'
+            }, {
+                'partyType': 'EXECUTOR',
+                'description': 'EXECUTOR OF THE ESTATE OF MARY LILLIAN MURRAY, DECEASED',
+                'individualName': {
+                    'first': 'KENNETH',
+                    'last': 'UNRAU'
+                },
+                'address': {
+                    'street': '45 - 1322 DOG CREEK ROAD',
+                    'city': 'WILLIAMS LAKE',
+                    'region': 'BC',
+                    'postalCode': 'V2G 3G9',
+                    'country': 'CA'
+                },
+                'phoneNumber': '6041234567'
+            }
+        ],
+        'type': 'NA'
+    }
+]
 ADMIN_DELETE_GROUPS = WILL_DELETE_GROUPS
+ADMIN_DELETE_GROUPS1 = [
+    {
+        'groupId': 5,
+        'owners': [
+            {
+              'partyType': 'ADMINISTRATOR',
+              'description': 'ADMINISTRATOR OF THE ESTATE OF BEVERLY JOY STROM, DECEASED',
+              'individualName': {
+                    'first': 'JOHN',
+                    'last': 'KIDDER'
+                 },
+                'address': {
+                    'street': '26624 - 29B AVENUE',
+                    'city': 'ALDERGROVE',
+                    'region': 'BC',
+                    'postalCode': 'V4W 3B5',
+                    'country': 'CA'
+                }
+            }
+        ],
+        'type': 'SOLE'
+    }
+]
+
 ADMIN_ADD_GROUPS = [
     {
         'groupId': 2,

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -43,8 +43,10 @@ from tests.unit.utils.test_transfer_data import (
     WILL_DELETE_GROUPS,
     WILL_DELETE_GROUPS1,
     WILL_DELETE_GROUPS2,
+    WILL_DELETE_GROUPS3,
     ADMIN_ADD_GROUPS,
     ADMIN_DELETE_GROUPS,
+    ADMIN_DELETE_GROUPS1,
     ADD_OWNER,
     SO_GROUP,
     ADD_GROUP,
@@ -130,6 +132,7 @@ TEST_TRANSFER_DATA_TRAND = [
 # testdata pattern is ({description},{valid},{mhr_num},{account_id},{delete_groups},{add_groups},{message content},{staff})
 TEST_TRANSFER_DATA_ADMIN = [
     ('Valid', True,  '001020', '2523', ADMIN_DELETE_GROUPS, ADMIN_ADD_GROUPS, None, True),
+    ('Valid delete ADMIN', True,  '094474', '2523', ADMIN_DELETE_GROUPS1, ADMIN_ADD_GROUPS, None, True),
     ('Invalid non-staff', False,  '001020', '2523', ADMIN_DELETE_GROUPS, ADMIN_ADD_GROUPS,
      validator.REG_STAFF_ONLY, False),
     ('Valid party type EXECUTOR', True,  '001020', '2523', ADMIN_DELETE_GROUPS, ADMIN_ADD_GROUPS, None, True),
@@ -176,6 +179,7 @@ TEST_TRANSFER_DATA_AFFIDAVIT = [
 # testdata pattern is ({description},{valid},{mhr_num},{account_id},{delete_groups},{add_groups},{message content},{staff})
 TEST_TRANSFER_DATA_WILL = [
     ('Valid', True,  '001020', '2523', WILL_DELETE_GROUPS, EXEC_ADD_GROUPS, None, True),
+    ('Valid delete EXEC', True,  '092494', '2523', WILL_DELETE_GROUPS3, EXEC_ADD_GROUPS, None, True),
     ('Invalid non-staff', False,  '001020', '2523', WILL_DELETE_GROUPS, EXEC_ADD_GROUPS,
      validator.REG_STAFF_ONLY, False),
     ('Invalid add owner', False,  '001020', '2523', WILL_DELETE_GROUPS, EXEC_ADD_GROUPS,


### PR DESCRIPTION
*Issue #:* 
- /bcgov/entity#16331
- /bcgov/entity#16466
*Description of changes:*
- TRANS_WILL can delete EXECUTOR with/without NA tenancy type.
- TRANS_ADMIN can delete ADMINISTRATOR with/without NA tenancy type.
- 16466 DB2 manuhome and document table records save API RACF id to the updateid column.
- Update DB2 owner JSON to match Postgres JSON. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
