### PR TITLE
Fixs error bar shown with valid owners

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.25",
+      "version": "1.1.26",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -435,18 +435,15 @@ export default defineComponent({
       deleteGroup,
       isGlobalEditingMode,
       setGlobalEditingMode,
-      hasEmptyGroup,
       hasMinimumGroups,
       editHomeOwner,
       getGroupById,
       undoGroupChanges,
-      getHomeTenancyType,
       getGroupNumberById,
       hasMixedOwnersInAGroup,
       hasMixedOwnersInGroup,
       hasRemovedAllHomeOwners,
       hasRemovedAllHomeOwnerGroups,
-      hasUndefinedGroupInterest,
       getTotalOwnershipAllocationStatus,
       getTransferOrRegistrationHomeOwners,
       getTransferOrRegistrationHomeOwnerGroups
@@ -512,17 +509,13 @@ export default defineComponent({
           return props.validateTransfer && props.isMhrTransfer && !hasUnsavedChanges.value
         }
 
-        const groups = getTransferOrRegistrationHomeOwnerGroups()
-
         return ((props.validateTransfer || (!props.isMhrTransfer && localState.reviewedOwners)) &&
           (
             !hasMinimumGroups() ||
-            hasEmptyGroup.value ||
             (props.isMhrTransfer && !hasUnsavedChanges.value) ||
             !localState.isValidAllocation ||
             localState.hasGroupsWithNoOwners ||
-            (!localState.isUngroupedTenancy && hasUndefinedGroupInterest(groups)) ||
-            (hasMixedOwnersInAGroup() && groups[0].groupId === 0)
+            (hasMixedOwnersInAGroup() && !showGroups.value)
           )
         )
       }),
@@ -541,10 +534,7 @@ export default defineComponent({
         return groups.some(group => group.owners.filter(owner => owner.action !== ActionTypes.REMOVED).length === 0)
       }),
       isValidAllocation: computed((): boolean => {
-        return localState.isUngroupedTenancy || !getTotalOwnershipAllocationStatus().hasTotalAllocationError
-      }),
-      isUngroupedTenancy: computed((): boolean => {
-        return [HomeTenancyTypes.SOLE, HomeTenancyTypes.JOINT].includes(getHomeTenancyType())
+        return !showGroups.value || !getTotalOwnershipAllocationStatus().hasTotalAllocationError
       }),
       getPartyTypeForActiveTransfer: computed(() => transferOwnerPartyTypes[getMhrTransferType.value?.transferType])
     })
@@ -786,7 +776,6 @@ export default defineComponent({
       openForEditing,
       isCurrentlyEditing,
       showGroups,
-      hasEmptyGroup,
       hasActualOwners,
       remove,
       deleteGroup,

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -189,8 +189,8 @@ export function useHomeOwners (isMhrTransfer: boolean = false) {
 
   const hasMinimumGroups = (): boolean => {
     const groups = getTransferOrRegistrationHomeOwnerGroups().filter(group => group.action !== ActionTypes.REMOVED)
-    const hasNoGroups = [HomeTenancyTypes.SOLE, HomeTenancyTypes.JOINT].includes(getHomeTenancyType())
-    return hasNoGroups || !groups || groups.length >= 2
+    return !groups || groups.length >= 2 ||
+    (!showGroups.value && groups.length === 1)
   }
 
   const hasMixedOwnersInGroup = (groupId: number): boolean => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16395

*Description of changes:*
- Removes overlapping `showTableError` conditions
- Updates validation to allow for no groups shown and 2+ owners of type administrator/bankrupcy trustee/executor

*Screenshots:*

- Before change when returning from review and confirm
![image](https://github.com/bcgov/ppr/assets/77707952/9bdda0b3-a009-47ef-8ead-0b9982fa18ff)


- After change when returning from review and confirm 
![image](https://github.com/bcgov/ppr/assets/77707952/23305a12-8377-4675-af9d-50bd6550fa8f)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
