### PR TITLE
Sets missing draftMhr values to default

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -168,8 +168,10 @@ export const useNewMhrRegistration = () => {
    */
   const initDraftMhr = async (draft: MhrRegistrationIF): Promise<void> => {
     // Set description
-    for (const [key, val] of Object.entries(draft.description)) {
-      setMhrHomeDescription({ key: key, value: val })
+    for (const [key, val] of Object.entries(initNewMhr().description)) {
+      draft.description[key]
+        ? setMhrHomeDescription({ key: key, value: draft.description[key] })
+        : setMhrHomeDescription({ key: key, value: val }) // set missing description values to default
     }
     // Set Submitting Party
     setMhrRegistrationSubmittingParty(draft.submittingParty)

--- a/ppr-ui/src/resources/mhr-transfers/transfer-supporting-documents.ts
+++ b/ppr-ui/src/resources/mhr-transfers/transfer-supporting-documents.ts
@@ -15,7 +15,7 @@ export const transferOwnerPartyTypes = {
 export const transferOwnerPrefillAdditionalName = {
   [ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL]: 'Executor of the will of ',
   [ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL]: 'Executor of the will of ',
-  [ApiTransferTypes.TO_ADMIN_NO_WILL]: 'Administrator of the will of '
+  [ApiTransferTypes.TO_ADMIN_NO_WILL]: 'Administrator of the estate of '
 }
 
 export const transferSupportingDocuments = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16248

*Description of changes:*
- Sets draft description values to default if missing, to overwrite store values

*Context:*

Fill in the information for home description, then save draft, and then open another draft without that information filled out.

![Screenshot 2023-05-23 163358](https://github.com/bcgov/ppr/assets/77707952/c123b645-e869-4635-b4cb-6d4c81a42f64)


*Before:*

![Screenshot 2023-05-23 163606](https://github.com/bcgov/ppr/assets/77707952/9dd93d4b-31d3-4f98-b7e0-0fddd15c34d1)

*After:*

![Screenshot 2023-05-23 163228](https://github.com/bcgov/ppr/assets/77707952/2bcd46ae-269f-4d93-93f5-8e97b6aff774)

*Detailed Explanation of cause:*

When we save a draft we clear empty values from the payload:

![Screenshot 2023-05-23 165427](https://github.com/bcgov/ppr/assets/77707952/499573b5-311a-425e-a3bf-0e1d86f5ff09)

When we open up a draft we  retrieve the draft from the API and overwrite previous draft information in store:

![Screenshot 2023-05-23 163258](https://github.com/bcgov/ppr/assets/77707952/4acac09f-4781-48b1-ab13-f82e4aebae5a)
![Screenshot 2023-05-23 163249](https://github.com/bcgov/ppr/assets/77707952/a247aaae-79e5-4378-8055-d49a5dea7c41)

However, for home description step we call `Object.entries()` because some object and keys are not included in a draft, it does not overwrite does stored values:

![Screenshot 2023-05-23 163304](https://github.com/bcgov/ppr/assets/77707952/7a80a22b-3afb-4f14-a206-820b838244bf)

My fix is to overwrite them with default values if they are missing, or otherwise use the values retrieved from the draft.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
