### PR TITLE
Adds registration land lease component

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
@@ -1,0 +1,73 @@
+<template>
+  <v-card flat rounded id="mhr-home-land-ownership" class=" mhr-home-land-ownership">
+    <v-row no-gutters>
+      <v-col cols="12" sm="2">
+        <label class="generic-label" for="ownership">
+        Land Lease or Ownership
+        </label>
+      </v-col>
+      <v-col cols="12" sm="10">
+        <v-checkbox
+          id="ownership"
+          :label="landOwnershipLabel"
+          v-model="isOwnLand"
+          class="my-0 py-0 px-0 ownership-checkbox"
+          data-test-id="ownership-checkbox"
+        />
+       </v-col>
+    </v-row>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
+import { useGetters, useActions } from 'vuex-composition-helpers'
+
+export default defineComponent({
+  name: 'HomeLandOwnership',
+  setup () {
+    const {
+      getMhrRegistrationOwnLand
+    } = useGetters<any>([
+      'getMhrRegistrationOwnLand'
+    ])
+
+    const {
+      setMhrRegistrationOwnLand
+    } = useActions<any>([
+      'setMhrRegistrationOwnLand'
+    ])
+
+    const localState = reactive({
+      isOwnLand: Boolean(getMhrRegistrationOwnLand.value || false),
+      landOwnershipLabel: `The manufactured home is located on land that the homeowners own,
+                or on which they have a registered lease of 3 years or more.`
+    })
+
+    watch(() => localState.isOwnLand, (val: boolean) => {
+      setMhrRegistrationOwnLand(val)
+    })
+
+    return {
+      ...toRefs(localState)
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+.mhr-home-land-ownership::v-deep {
+  padding: 40px 30px 32px;
+
+  .ownership-checkbox {
+    margin-left: 70px;
+    label {
+      line-height: 24px;
+    }
+    .v-input__slot {
+      align-items: flex-start;
+    }
+  }
+}
+</style>

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
@@ -3,14 +3,14 @@
     <v-row no-gutters>
       <v-col cols="12" sm="2">
         <label class="generic-label" for="ownership">
-        Land Lease or Ownership
+          Land Lease or Ownership
         </label>
       </v-col>
       <v-col cols="12" sm="10">
         <v-checkbox
           id="ownership"
           label="The manufactured home is located on land that the homeowners own,
-                or on which they have a registered lease of 3 years or more."
+                 or on which they have a registered lease of 3 years or more."
           v-model="isOwnLand"
           class="my-0 py-0 px-0 ownership-checkbox"
           data-test-id="ownership-checkbox"
@@ -40,7 +40,7 @@ export default defineComponent({
     ])
 
     const localState = reactive({
-      isOwnLand: Boolean(getMhrRegistrationOwnLand.value || false)
+      isOwnLand: !!getMhrRegistrationOwnLand.value
     })
 
     watch(() => localState.isOwnLand, (val: boolean) => {

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
@@ -9,7 +9,8 @@
       <v-col cols="12" sm="10">
         <v-checkbox
           id="ownership"
-          :label="landOwnershipLabel"
+          label="The manufactured home is located on land that the homeowners own,
+                or on which they have a registered lease of 3 years or more."
           v-model="isOwnLand"
           class="my-0 py-0 px-0 ownership-checkbox"
           data-test-id="ownership-checkbox"
@@ -39,9 +40,7 @@ export default defineComponent({
     ])
 
     const localState = reactive({
-      isOwnLand: Boolean(getMhrRegistrationOwnLand.value || false),
-      landOwnershipLabel: `The manufactured home is located on land that the homeowners own,
-                or on which they have a registered lease of 3 years or more.`
+      isOwnLand: Boolean(getMhrRegistrationOwnLand.value || false)
     })
 
     watch(() => localState.isOwnLand, (val: boolean) => {

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/index.ts
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/index.ts
@@ -1,3 +1,4 @@
 export { default as HomeLocationType } from './HomeLocationType.vue'
 export { default as HomeCivicAddress } from './HomeCivicAddress.vue'
 export { default as HomeLocationDescription } from './HomeLocationDescription.vue'
+export { default as HomeLandOwnership } from './HomeLandOwnership.vue'

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -206,7 +206,7 @@
           </template>
 
           <!-- Civic Address -->
-          <v-row no-gutters class="px-6 pt-1" >
+          <v-row no-gutters class="px-6 pt-1 pb-6" >
             <v-col cols="3" class="pt-1">
               <h3>Civic Address</h3>
             </v-col>
@@ -223,6 +223,28 @@
               </p>
             </v-col>
           </v-row>
+
+          <div class="px-4">
+            <v-divider />
+          </div>
+
+          <!-- Land Details -->
+          <v-row no-gutters class="px-6 pt-6" >
+            <v-col cols="3" class="pt-1">
+              <h3>Land Details</h3>
+            </v-col>
+          </v-row>
+
+          <!-- Lease or Land Ownership -->
+          <v-row no-gutters class="px-6 pt-1" >
+            <v-col cols="3" class="pt-1">
+              <h3>Lease or Land Ownership</h3>
+            </v-col>
+            <v-col cols="9" class="pt-1">
+              <span v-html="landOwnershipLabel"></span>
+            </v-col>
+          </v-row>
+
       </section>
     </div>
   </v-card>
@@ -247,11 +269,13 @@ export default defineComponent({
     const {
       getMhrRegistrationLocation,
       getMhrRegistrationValidationModel,
-      getIsManualLocation
+      getIsManualLocation,
+      getMhrRegistrationOwnLand
     } = useGetters<any>([
       'getMhrRegistrationLocation',
       'getMhrRegistrationValidationModel',
-      'getIsManualLocation'
+      'getIsManualLocation',
+      'getMhrRegistrationOwnLand'
     ])
 
     const {
@@ -301,6 +325,10 @@ export default defineComponent({
         return !!location.lot || !!location.parcel || !!location.block || !!location.districtLot || !!location.partOf ||
           !!location.section || !!location.township || !!location.range || !!location.meridian ||
           !!location.landDistrict || !!location.plan || !!location.exceptionPlan
+      }),
+      landOwnershipLabel: computed(() => {
+        return `The manufactured home is <b>${getMhrRegistrationOwnLand.value ? '' : 'not'}</b> located on land that the
+            homeowners own, or on which they have a registered lease of 3 years or more.`
       })
     })
 

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -25,6 +25,7 @@ export const useNewMhrRegistration = () => {
     getMhrAttentionReferenceNum,
     getMhrRegistrationLocation,
     getMhrRegistrationHomeOwnerGroups,
+    getMhrRegistrationOwnLand,
     getStaffPayment,
     getMhrDraftNumber
   } = useGetters<any>([
@@ -35,6 +36,7 @@ export const useNewMhrRegistration = () => {
     'getMhrAttentionReferenceNum',
     'getMhrRegistrationLocation',
     'getMhrRegistrationHomeOwnerGroups',
+    'getMhrRegistrationOwnLand',
     'getCertifyInformation',
     'getStaffPayment',
     'getMhrDraftNumber'
@@ -46,6 +48,7 @@ export const useNewMhrRegistration = () => {
     setMhrHomeDescription,
     setMhrAttentionReferenceNum,
     setMhrRegistrationDocumentId,
+    setMhrRegistrationOwnLand,
     setMhrRegistrationSubmittingParty,
     setMhrRegistrationHomeOwnerGroups
   } = useActions<any>([
@@ -55,6 +58,7 @@ export const useNewMhrRegistration = () => {
     'setMhrHomeDescription',
     'setMhrAttentionReferenceNum',
     'setMhrRegistrationDocumentId',
+    'setMhrRegistrationOwnLand',
     'setMhrRegistrationSubmittingParty',
     'setMhrRegistrationHomeOwnerGroups'
   ])
@@ -91,6 +95,7 @@ export const useNewMhrRegistration = () => {
       ownerGroups: [],
       attentionReference: '',
       isManualLocationInfo: false,
+      ownLand: false,
       location: {
         parkName: '',
         pad: '',
@@ -177,6 +182,8 @@ export const useNewMhrRegistration = () => {
     setMhrRegistrationSubmittingParty(draft.submittingParty)
     // Set Document Id
     setMhrRegistrationDocumentId(draft.documentId)
+    // Set Land Ownership
+    setMhrRegistrationOwnLand(draft.ownLand)
     // Set attention
     setMhrAttentionReferenceNum(draft.attentionReference)
     // Set HomeOwners
@@ -289,6 +296,7 @@ export const useNewMhrRegistration = () => {
   const buildApiData = (): NewMhrRegistrationApiIF => {
     const data: NewMhrRegistrationApiIF = {
       documentId: getMhrRegistrationDocumentId.value,
+      ownLand: getMhrRegistrationOwnLand.value,
       submittingParty: parseSubmittingParty(),
       ownerGroups: parseOwnerGroups(),
       location: parseLocation(),

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationIF.ts
@@ -13,6 +13,7 @@ export interface MhrRegistrationIF {
   ownerGroups: MhrRegistrationHomeOwnerGroupIF[]
   attentionReference: string
   isManualLocationInfo: boolean
+  ownLand: boolean
   location: MhrRegistrationHomeLocationIF
   description: MhrRegistrationDescriptionIF
   notes: [
@@ -61,6 +62,7 @@ export interface NewMhrRegistrationApiIF {
   description: MhrRegistrationDescriptionIF
   attentionReference?: string
   isManualLocationInfo?: boolean
+  ownLand?: boolean
   notes?: [
     {
       documentType: string

--- a/ppr-ui/src/store/actions/actions-model.ts
+++ b/ppr-ui/src/store/actions/actions-model.ts
@@ -344,6 +344,11 @@ export const setMhrLocation: ActionIF = ({ commit }, { key, value }): void => {
   commit('mutateUnsavedChanges', true)
 }
 
+export const setMhrRegistrationOwnLand: ActionIF = ({ commit }, ownLand: boolean): void => {
+  commit('mutateMhrRegistrationOwnLand', ownLand)
+  commit('mutateUnsavedChanges', true)
+}
+
 export const setIsManualLocation: ActionIF = ({ commit }, isManual: boolean): void => {
   commit('mutateIsManualLocation', isManual)
 }

--- a/ppr-ui/src/store/getters/state-getters.ts
+++ b/ppr-ui/src/store/getters/state-getters.ts
@@ -637,6 +637,10 @@ export const getIsManualLocation = (state: StateIF): boolean => {
   return state.stateModel.mhrRegistration.isManualLocationInfo
 }
 
+export const getMhrRegistrationOwnLand = (state: StateIF): boolean => {
+  return state.stateModel.mhrRegistration.ownLand
+}
+
 export const getMhrRegistrationHomeOwnerGroups = (state: StateIF): MhrRegistrationHomeOwnerGroupIF[] => {
   return state.stateModel.mhrRegistration.ownerGroups
 }

--- a/ppr-ui/src/store/mutations/mutations-model.ts
+++ b/ppr-ui/src/store/mutations/mutations-model.ts
@@ -405,6 +405,10 @@ export const mutateCivicAddress = (state: StateIF, { key, value }) => {
   state.stateModel.mhrRegistration.location.address[key] = value
 }
 
+export const mutateMhrRegistrationOwnLand = (state: StateIF, value) => {
+  state.stateModel.mhrRegistration.ownLand = value
+}
+
 export const mutateMhrHomeOwnerGroups = (
   state: StateIF,
   groups: Array<MhrRegistrationHomeOwnerGroupIF>

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -188,6 +188,7 @@ export const stateModel: StateModelIF = {
     },
     ownerGroups: [],
     isManualLocationInfo: false,
+    ownLand: false,
     attentionReference: '',
     location: {
       parkName: '',

--- a/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
@@ -25,20 +25,28 @@
         :class="{ 'border-error-left': validateCivicAddress }"
       />
     </section>
+    <section id="mhr-home-land-ownership-wrapper" class="mt-10">
+      <h2>Land Details</h2>
+      <p class="mt-2">
+        Confirm the land lease or ownership information for the home.
+      </p>
+      <HomeLandOwnership />
+    </section>
   </div>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, reactive, toRefs, watch } from '@vue/composition-api'
 import { useGetters } from 'vuex-composition-helpers'
-import { HomeLocationType, HomeCivicAddress } from '@/components/mhrRegistration'
+import { HomeLocationType, HomeCivicAddress, HomeLandOwnership } from '@/components/mhrRegistration'
 import { useMhrValidations } from '@/composables/mhrRegistration/useMhrValidations'
 
 export default defineComponent({
   name: 'HomeLocation',
   components: {
     HomeLocationType,
-    HomeCivicAddress
+    HomeCivicAddress,
+    HomeLandOwnership
   },
   props: {},
   setup () {

--- a/ppr-ui/tests/unit/HomeLandOwnership.spec.ts
+++ b/ppr-ui/tests/unit/HomeLandOwnership.spec.ts
@@ -1,0 +1,59 @@
+// Libraries
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import { getVuexStore } from '@/store'
+import CompositionApi, { nextTick } from '@vue/composition-api'
+import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
+
+// Components
+import { HomeLandOwnership } from '@/components/mhrRegistration'
+import flushPromises from 'flush-promises'
+import { getTestId } from './utils'
+
+Vue.use(Vuetify)
+
+const vuetify = new Vuetify({})
+const store = getVuexStore()
+
+/**
+ * Creates and mounts a component, so that it can be tested.
+ *
+ * @returns a Wrapper<SearchBar> object with the given parameters.
+ */
+function createComponent (): Wrapper<any> {
+  const localVue = createLocalVue()
+  localVue.use(CompositionApi)
+  localVue.use(Vuetify)
+  document.body.setAttribute('data-app', 'true')
+  return mount(HomeLandOwnership, {
+    localVue,
+    propsData: {},
+    store,
+    vuetify
+  })
+}
+
+describe('Home Land Ownership', () => {
+  let wrapper: Wrapper<any>
+
+  beforeEach(async () => {
+    wrapper = createComponent()
+    await nextTick()
+    await flushPromises()
+  })
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders base component', async () => {
+    expect(wrapper.findComponent(HomeLandOwnership).exists()).toBe(true)
+  })
+
+  it('ownership checkbox performs as expected', async () => {
+    expect(store.getters.getMhrRegistrationOwnLand).toBe(false)
+    expect(wrapper.find(getTestId('ownership-checkbox'))).toBeTruthy()
+    wrapper.find(getTestId('ownership-checkbox')).setChecked()
+    await nextTick()
+    expect(store.getters.getMhrRegistrationOwnLand).toBe(true)
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16437

*Description of changes:*
- Adds `HomeLandOwnership` component as the registration land lease component
- Updates the review confirm screen for a staff registration
- Updates store/interface/payload/draft/registration information to include the ownLand attribute
- Adds simple tests for the component

*Note for reviewers:*
- Please let me know if you would like me to do any variable/component renaming

*Design:*
[Design](https://www.figma.com/file/Mb5s5wavlBp7vSJJ7xFihi/MHR-Registration-Updates?type=design&node-id=345-30809&t=t5dLbrWvH41gXuXx-0)

*Screenshots:*
 
Component:
![Land-Ownership-Component](https://github.com/bcgov/ppr/assets/77707952/eb8563c6-fe2e-4ec7-86c0-62c684ecc5f5)
![Land-Ownership-Component-Checked](https://github.com/bcgov/ppr/assets/77707952/dc7f4338-50ca-4aca-93c8-f929c771f405)

Review and confirm page:


Checked:
![Checked-Review-And-Confirm](https://github.com/bcgov/ppr/assets/77707952/8e0d811f-c77b-4be6-8a94-de8d73603b44)


Unchecked:
![unchecked-review-and-confirm](https://github.com/bcgov/ppr/assets/77707952/ce02979e-3b0d-4d19-ae9e-96bd16ca8051)

Opening the registration afterwards:
![ownLand-Open-Registration](https://github.com/bcgov/ppr/assets/77707952/a42c623a-b6fc-4494-b257-c440f9cf4f2e)

After opening a draft with component checked:
![after-opening-a-draft](https://github.com/bcgov/ppr/assets/77707952/7d01db5d-8cab-4ee3-9db7-598d7ce98f8f)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
