### PR TITLE
Displays Undivided if interest is an empty string

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -296,8 +296,9 @@ export default defineComponent({
     const getOwnershipInterest = (): string => {
       const { interest, interestNumerator, interestDenominator } = localState.group
       if (!interestNumerator || !interestDenominator) return 'N/A'
+      const interestText = toTitleCase(interest) || 'Undivided'
 
-      return `${toTitleCase(interest)} ${interestNumerator}/${interestDenominator}`
+      return `${interestText} ${interestNumerator}/${interestDenominator}`
     }
 
     const done = (): void => {

--- a/ppr-ui/src/utils/format-helper.ts
+++ b/ppr-ui/src/utils/format-helper.ts
@@ -46,7 +46,7 @@ export function fromDisplayPhone (phoneNumber: string): string {
  * @returns a title case string word
  */
 export function toTitleCase (value: string): string {
-  return (value[0]?.toUpperCase() + value.slice(1)?.toLowerCase()) || ''
+  return value ? (value[0].toUpperCase() + value.slice(1).toLowerCase()) : ''
 }
 
 /**


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16393

*Description of changes:*
- If interest has a numerator and denominator and its an (empty string/undefined/null) sets the interest text displayed to Undivided
- Updates helper function to deal with empty string case.

Before:
![image](https://github.com/bcgov/ppr/assets/77707952/e0bf67d1-4228-4707-8350-7b514deaa532)

After:
![image](https://github.com/bcgov/ppr/assets/77707952/ac938864-bdc4-4535-a097-5bff99ce745d)

Javascript fun:

`undefined` + `''` = `'undefined'`

![image](https://github.com/bcgov/ppr/assets/77707952/52fc3c24-2559-447f-89ff-28276f521cec)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
