### PR TITLE
Fix scroll to first element on filter

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.29",
+      "version": "1.1.30",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -513,13 +513,18 @@ export default defineComponent({
       const draftItem = item as DraftResultIF
       const firstBaseReg = localState.registrationHistory[0].baseRegistrationNumber
       const firstDocId = localState.registrationHistory[0].documentId
-      if (item.baseRegistrationNumber && item.baseRegistrationNumber === firstBaseReg) {
-        return true
-      }
-      if (!item.baseRegistrationNumber && draftItem.documentId === firstDocId) {
-        return true
-      }
-      return false
+      return item.baseRegistrationNumber
+        ? item.baseRegistrationNumber === firstBaseReg
+        : draftItem.documentId === firstDocId
+    }
+
+    const isFirstItemMhr = (item: MhRegistrationSummaryIF | MhrDraftIF): boolean => {
+      const draftItem = item as MhrDraftIF
+      const firstMhrNumber = localState.registrationHistory[0].mhrNumber
+      const firstDocId = localState.registrationHistory[0].draftNumber
+      return item.mhrNumber
+        ? item.mhrNumber === firstMhrNumber
+        : draftItem.draftNumber === firstDocId
     }
 
     const isNewRegItem =
@@ -563,8 +568,10 @@ export default defineComponent({
       }
     }
 
-    const setRowRef = (item: RegistrationSummaryIF | DraftResultIF): string => {
-      const isFirst = isFirstItem(item)
+    const setRowRef = (item: RegistrationSummaryIF | DraftResultIF | MhRegistrationSummaryIF | MhrDraftIF): string => {
+      const isFirst = props.isPpr
+        ? isFirstItem(item as RegistrationSummaryIF)
+        : isFirstItemMhr(item as MhRegistrationSummaryIF)
       const isNewReg = isNewRegItem(item)
       if (isFirst && isNewReg) return 'newAndFirstItem'
       if (isFirst) return 'firstItem'

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -510,21 +510,19 @@ export default defineComponent({
     }
 
     const isFirstItem = (item: RegistrationSummaryIF | DraftResultIF): boolean => {
-      const draftItem = item as DraftResultIF
       const firstBaseReg = localState.registrationHistory[0].baseRegistrationNumber
       const firstDocId = localState.registrationHistory[0].documentId
       return item.baseRegistrationNumber
         ? item.baseRegistrationNumber === firstBaseReg
-        : draftItem.documentId === firstDocId
+        : (item as DraftResultIF).documentId === firstDocId
     }
 
     const isFirstItemMhr = (item: MhRegistrationSummaryIF | MhrDraftIF): boolean => {
-      const draftItem = item as MhrDraftIF
       const firstMhrNumber = localState.registrationHistory[0].mhrNumber
       const firstDocId = localState.registrationHistory[0].draftNumber
       return item.mhrNumber
         ? item.mhrNumber === firstMhrNumber
-        : draftItem.draftNumber === firstDocId
+        : item.draftNumber === firstDocId
     }
 
     const isNewRegItem =
@@ -570,8 +568,8 @@ export default defineComponent({
 
     const setRowRef = (item: RegistrationSummaryIF | DraftResultIF | MhRegistrationSummaryIF | MhrDraftIF): string => {
       const isFirst = props.isPpr
-        ? isFirstItem(item as RegistrationSummaryIF)
-        : isFirstItemMhr(item as MhRegistrationSummaryIF)
+        ? isFirstItem(item as RegistrationSummaryIF | DraftResultIF)
+        : isFirstItemMhr(item as MhRegistrationSummaryIF | MhrDraftIF)
       const isNewReg = isNewRegItem(item)
       if (isFirst && isNewReg) return 'newAndFirstItem'
       if (isFirst) return 'firstItem'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16455

*Description of changes:*
- Updates function to correctly identify first item in MHR

*Screenshots:*

Before when you filter by active (scrolls down):

![image](https://github.com/bcgov/ppr/assets/77707952/90f48f94-509f-4072-8fdf-267300d7816d)


After when you filter by active (stays at top of table or scrolls to top of table):
![image](https://github.com/bcgov/ppr/assets/77707952/18d38421-fd60-46c2-baff-572d7920b785)


*Note for reviewers:*
- There is still some scroll issues, where the scrollIntoView function does not work when the browser is it a specific view on the table, I tried debugging it but it seems to be fairly complex and very low occurrence bug. But whenever the scrollIntoView function does trigger it now scrolls to the right item.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
