### PR TITLE
Remove and Add Administrators for LETA Transfers

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -493,6 +493,7 @@ export default defineComponent({
       phoneNumber: props.editHomeOwner?.phoneNumber || '',
       phoneExtension: props.editHomeOwner?.phoneExtension || '',
       suffix: props.editHomeOwner?.suffix || '',
+      description: props.editHomeOwner?.description || '',
       address: {
         street: props.editHomeOwner?.address.street || '',
         streetAdditional: props.editHomeOwner?.address.streetAdditional || '',

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -728,7 +728,9 @@ export default defineComponent({
 
     // Hide bottom border for the owner's row that requires additional input (Death Certificate etc.)
     const hideRowBottomBorder = (rowItem: MhrRegistrationHomeOwnerIF): boolean => {
-      return isRemovedHomeOwner(rowItem) && (showDeathCertificate() || showSupportingDocuments())
+      return isRemovedHomeOwner(rowItem) &&
+      isPartyTypeNotEAT(rowItem) && // show the bottom border line for Execs, Admins and Trustees
+      (showDeathCertificate() || showSupportingDocuments())
     }
 
     const getHomeOwnerIcon = (partyType: HomeOwnerPartyTypes, isBusiness = false): string => {

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -443,7 +443,6 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
       const transferType = getMhrTransferType.value?.transferType
       const allOwners = getMhrTransferHomeOwners.value
       const deletedOwnerGroup = find(getMhrTransferHomeOwnerGroups.value, { owners: [{ action: ActionTypes.REMOVED }] })
-      const supportingDocOfTheTransferType = TransToExec.getSupportingDocForActiveTransfer()
 
       // first try to find the deleted reg owner
       const deletedOwner = find(deletedOwnerGroup.owners, {

--- a/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
@@ -40,7 +40,7 @@ export const mockedExecutor: MhrRegistrationHomeOwnerIF = {
     middle: 'A',
     last: 'Smith'
   },
-  suffix: 'Executor of the will of John Smith',
+  description: 'Executor of the will of John Smith',
   phoneNumber: '(545) 333-2211',
   phoneExtension: '1234',
   partyType: HomeOwnerPartyTypes.EXECUTOR,
@@ -68,11 +68,25 @@ export const mockedAddedExecutor: MhrRegistrationHomeOwnerIF = {
     middle: 'A',
     last: 'Smith'
   },
-  suffix: 'Sr.',
+  description: 'Sr.',
   phoneNumber: '(545) 333-2211',
   phoneExtension: '1234',
   partyType: HomeOwnerPartyTypes.EXECUTOR,
   action: ActionTypes.ADDED,
+  address: mockedAddress
+}
+
+export const mockedAdministrator: MhrRegistrationHomeOwnerIF = {
+  ownerId: 35,
+  individualName: {
+    first: 'Admin',
+    middle: 'M',
+    last: 'Smith'
+  },
+  description: 'ADMINISTRATOR 123',
+  phoneNumber: '(123) 777-6666',
+  phoneExtension: '7656',
+  partyType: HomeOwnerPartyTypes.ADMINISTRATOR,
   address: mockedAddress
 }
 
@@ -83,7 +97,7 @@ export const mockedAddedAdministrator: MhrRegistrationHomeOwnerIF = {
     middle: 'A',
     last: 'Smith'
   },
-  suffix: 'Sr.',
+  description: 'Sr.',
   phoneNumber: '(545) 333-2211',
   phoneExtension: '1234',
   partyType: HomeOwnerPartyTypes.ADMINISTRATOR,


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16292

*Description of changes:*
- Remove Administrators functionality, a lot of it is already done as part of removing Executors in #1358
- Added unit tests, and updated existing
- Small styling fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
