### PR TITLE
Fix error state for Groups in Transfers

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -476,6 +476,7 @@ export default defineComponent({
       isTransferToAdminNoWill,
       groupHasRemovedAllCurrentOwners,
       moveCurrentOwnersToPreviousOwners,
+      hasMinOneExecOrAdminInGroup,
       TransSaleOrGift,
       TransToExec,
       TransToAdmin,
@@ -552,7 +553,7 @@ export default defineComponent({
       !localState.showTableError && !props.isReadonlyTable
 
     const isInvalidTransferOwnerGroup = (groupId: number, hasExecOrAdminInGroup: boolean) => {
-      if (props.validateTransfer && !hasUnsavedChanges.value) return false
+      if (props.validateTransfer && (!hasUnsavedChanges.value || hasMinOneExecOrAdminInGroup(groupId))) return false
 
       const hasRemovedOwners = TransToExec.hasSomeOwnersRemoved(groupId)
       // groups that are not edited are valid
@@ -693,22 +694,12 @@ export default defineComponent({
           ? TransToAdmin.hasAddedAdministratorsInGroup(groupId)
           : TransToExec.hasAddedExecutorsInGroup(groupId)
 
-        let hasAtLeastOneExecOrAdmin = false
-
-        // for WILL and LETA transfers, id one Exec or Admin is removed,
-        // do not shot group message that all owners must be removed
-        if (isTransferToExecutorProbateWill.value) {
-          hasAtLeastOneExecOrAdmin = TransToExec.hasAtLeastOneExecInGroup(groupId)
-        } else if (isTransferToAdminNoWill.value) {
-          hasAtLeastOneExecOrAdmin = TransToAdmin.hasAtLeastOneAdminInGroup(groupId)
-        }
-
         return (
           (TransToExec.hasSomeOwnersRemoved(groupId) || hasAddedRoleInGroup) &&
           !(hasAddedRoleInGroup &&
           TransToExec.hasAllCurrentOwnersRemoved(groupId) &&
           !TransToExec.isAllGroupOwnersWithDeathCerts(groupId)) &&
-          !hasAtLeastOneExecOrAdmin
+          !hasMinOneExecOrAdminInGroup(groupId)
         )
       }
 

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -574,6 +574,17 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     }
   }
 
+  // For WIll and LETA Transfers, at least one Exec or Admin is required to proceed
+  // Used for hiding group message (that all owners must be removed)
+  const hasMinOneExecOrAdminInGroup = (groupId) => {
+    if (isTransferToExecutorProbateWill.value) {
+      return TransToExec.hasAtLeastOneExecInGroup(groupId)
+    } else if (isTransferToAdminNoWill.value) {
+      return TransToAdmin.hasAtLeastOneAdminInGroup(groupId)
+    }
+    return false
+  }
+
   /** Return true if the specified owner is part of the current/base ownership structure **/
   const isCurrentOwner = (owner: MhrRegistrationHomeOwnerIF): boolean => {
     return getMhrTransferCurrentHomeOwnerGroups.value.some(group =>
@@ -712,6 +723,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     hasCurrentOwnerChanges,
     hasCurrentGroupChanges,
     moveCurrentOwnersToPreviousOwners,
+    hasMinOneExecOrAdminInGroup,
     ...toRefs(localState)
   }
 }


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16290
- bcgov/entity#16292

*Description of changes:*
- UXA feedback to hide error state for Groups for LETA and WILL Transfers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
