### PR TITLE
Remove dynamic Additional Name in Owners table

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -129,11 +129,7 @@
                   {{ row.item.organizationName }}
                 </div>
               </div>
-              <div v-if="row.item.suffix"
-                class="font-light suffix"
-                :class="{ 'suffix-error': showSuffixError &&
-                  row.item.partyType === getPartyTypeForActiveTransfer &&
-                  row.item.action === ActionTypes.ADDED }">
+              <div v-if="row.item.suffix" class="font-light suffix">
                 {{ row.item.suffix }}
               </div>
               <div v-else-if="row.item.description"
@@ -403,7 +399,6 @@ import { DeathCertificate, SupportingDocuments, HomeOwnersGroupError } from '@/c
 import { BaseDialog } from '@/components/dialogs'
 import TableGroupHeader from '@/components/mhrRegistration/HomeOwners/TableGroupHeader.vue'
 import { mhrDeceasedOwnerChanges } from '@/resources/dialogOptions'
-import { transferOwnerPartyTypes, transfersErrors } from '@/resources'
 import { yyyyMmDdToPacificDate } from '@/utils/date-helper'
 import { InfoChip } from '@/components/common'
 /* eslint-disable no-unused-vars */
@@ -487,8 +482,7 @@ export default defineComponent({
       TransSaleOrGift,
       TransToExec,
       TransToAdmin,
-      TransJointTenants,
-      getMhrTransferType
+      TransJointTenants
     } = useTransferOwners(!props.isMhrTransfer)
 
     const { getValidation, MhrSectVal, MhrCompVal } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
@@ -498,7 +492,6 @@ export default defineComponent({
       currentlyEditingHomeOwnerId: -1,
       reviewed: false,
       showOwnerChangesDialog: false,
-      showSuffixError: false,
       ownerToDecease: null as MhrRegistrationHomeOwnerIF,
       isEditingMode: computed((): boolean => localState.currentlyEditingHomeOwnerId >= 0),
       isAddingMode: computed((): boolean => props.isAdding),
@@ -537,8 +530,7 @@ export default defineComponent({
       }),
       isValidAllocation: computed((): boolean => {
         return !showGroups.value || !getTotalOwnershipAllocationStatus().hasTotalAllocationError
-      }),
-      getPartyTypeForActiveTransfer: computed(() => transferOwnerPartyTypes[getMhrTransferType.value?.transferType])
+      })
     })
 
     const isInvalidRegistrationOwnerGroup = (groupId: number) =>
@@ -755,13 +747,6 @@ export default defineComponent({
     watch(() => props.homeOwners, (val) => {
       setUnsavedChanges(val.some(owner => !!owner.action || !owner.ownerId))
 
-      // update suffix for executor(s) in certain Transfers flows
-      if (isTransferToExecutorProbateWill.value ||
-        isTransferToExecutorUnder25Will.value ||
-        isTransferToAdminNoWill.value) {
-        localState.showSuffixError = TransToExec.updateExecutorSuffix()
-      }
-
       context.emit('isValidTransferOwners',
         hasMinimumGroups() &&
         localState.isValidAllocation &&
@@ -837,8 +822,6 @@ export default defineComponent({
       TransToAdmin,
       getMhrInfoValidation,
       isTransferGroupValid,
-      transfersErrors,
-      getMhrTransferType,
       getHomeOwnerIcon,
       isPartyTypeNotEAT,
       ...toRefs(localState)

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -467,12 +467,6 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
         groupId: deletedOwnerGroup.groupId // new Owner will be added to the same group as deleted Owner
       } as MhrRegistrationHomeOwnerIF)
     },
-    updateExecutorSuffix: (): boolean => {
-      const deceasedOwners = getMhrTransferHomeOwners.value
-        .filter(owner => owner.action === ActionTypes.REMOVED)
-
-      return TransToExec.addRemoveExecutorSuffix(deceasedOwners[0] || null)
-    },
     // find owners that 1. belong to groupId, 2. that are also removed, 3. have Grant of Probate as supporting document
     // switch their supporting document to Death Certificate if they have Grant of Probate selected
     resetGrantOfProbate: (groupId, excludedOwnerId) => {
@@ -484,38 +478,6 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
             owner.supportingDocument = SupportingDocumentsOptions.DEATH_CERT
           }
         })
-    },
-    addRemoveExecutorSuffix: (owner: MhrRegistrationHomeOwnerIF): boolean => {
-      const transferType = getMhrTransferType.value?.transferType
-      let showSuffixError = false
-
-      const allExecutors = getMhrTransferHomeOwners.value
-        .filter(owner => owner.partyType === transferOwnerPartyTypes[transferType] &&
-          owner.action === ActionTypes.ADDED)
-
-      if (allExecutors.length === 1 && owner !== null) {
-        let suffix = ''
-
-        if ([HomeOwnerPartyTypes.OWNER_IND, HomeOwnerPartyTypes.OWNER_BUS].includes(owner.partyType)) {
-          const { first, middle, last } = owner.individualName || {}
-          suffix = owner.organizationName?.length > 0
-            ? transferOwnerPrefillAdditionalName[transferType] + owner.organizationName
-            : transferOwnerPrefillAdditionalName[transferType] + [first, middle, last].filter(Boolean).join(' ')
-        } else {
-          suffix = owner.description
-        }
-
-        allExecutors[0].suffix = suffix
-        showSuffixError = false
-      } else {
-        allExecutors.forEach((executor: MhrRegistrationHomeOwnerIF) => {
-          // reset suffix or description
-          const additionalName = transferOwnerPrefillAdditionalName[transferType] + 'N/A'
-          executor.suffix = executor.suffix ? additionalName : executor.description = additionalName
-          showSuffixError = true
-        })
-      }
-      return showSuffixError
     }
   }
 

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -889,8 +889,6 @@ describe('Home Owners', () => {
 
     const addedExecutor = homeOwners.find(getTestId('owner-info-' + mockedAddedExecutor.ownerId))
     expect(addedExecutor.exists()).toBeTruthy()
-    // check that additional name (suffix) of the deleted Executor is displayed for the new Executor
-    expect(addedExecutor.text()).toContain(mockedExecutor.description)
   })
 
   it('TRANS Affidavit: validations with different error messages', async () => {
@@ -970,7 +968,6 @@ describe('Home Owners', () => {
     await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
 
     await selectTransferType(TRANSFER_TYPE)
-
 
     // delete the sole owner
     await homeOwners.find(getTestId('table-delete-btn')).trigger('click')


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16581

*Description of changes:*
- Additional Name will no longer be updated when switching supporting document types between owners for all transfer types. Additional name can only be changed by editing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
