### PR TITLE
Use legacy number series for MHR number generation.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -1,0 +1,273 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds DB2 query strings."""
+
+
+UPDATE_LTSA_PID = """
+UPDATE location
+   SET bcaajuri = :status_value
+ WHERE pidnumb IN (?)
+"""
+QUERY_LTSA_PID = """
+SELECT DISTINCT l.pidnumb
+  FROM location l, manuhome m
+ WHERE m.mhstatus in ('R', 'E')
+   AND m.manhomid = l.manhomid
+   AND l.status = 'A'
+   AND TRIM(l.pidnumb) != ''
+   AND LENGTH(TRIM(l.pidnumb)) = 9
+   AND TRIM(bcaajuri) = ''
+   AND mhregnum not like '150%'
+FETCH FIRST 500 ROWS ONLY
+"""
+QUERY_ACCOUNT_MHR_LEGACY = """
+SELECT DISTINCT mer.mhr_number, 'N' AS account_reg,
+                (SELECT mlc.registration_type
+                   FROM mhr_lien_check_vw mlc
+                  WHERE mlc.mhr_number = mer.mhr_number) AS lien_registration_type
+ FROM mhr_extra_registrations mer
+WHERE account_id = :query_value
+  AND (removed_ind IS NULL OR removed_ind != 'Y')
+UNION (
+SELECT DISTINCT mr.mhr_number, 'Y' AS account_reg,
+                (SELECT mlc.registration_type
+                   FROM mhr_lien_check_vw mlc
+                  WHERE mlc.mhr_number = mr.mhr_number) AS lien_registration_type
+  FROM mhr_registrations mr
+WHERE account_id = :query_value
+  AND mr.registration_type = 'MHREG'
+  AND NOT EXISTS (SELECT mer.mhr_number
+                    FROM mhr_extra_registrations mer
+                   WHERE mer.account_id = mr.account_id
+                     AND mer.mhr_number = mr.mhr_number
+                     AND (mer.removed_ind IS NOT NULL AND mer.removed_ind = 'Y'))
+)
+"""
+QUERY_ACCOUNT_REGISTRATIONS_SUMMARY = """
+SELECT mr.id, mr.registration_ts, mr.account_id, mr.registration_type, mr.mhr_number,
+       (SELECT d.document_id FROM mhr_documents d WHERE d.registration_id = mr.id FETCH FIRST 1 ROWS ONLY)
+       AS document_id,
+       mrr.create_ts as doc_ts, mrr.doc_storage_url, mrt.registration_type_desc,
+       (SELECT CASE WHEN mr.user_id IS NULL THEN ''
+          ELSE (SELECT u.firstname || ' ' || u.lastname FROM users u WHERE u.username = mr.user_id
+                FETCH FIRST 1 ROWS ONLY)
+           END) AS username
+  FROM mhr_registrations mr, mhr_registration_reports mrr, mhr_registration_types mrt
+ WHERE mr.mhr_number IN (SELECT DISTINCT mer.mhr_number
+                           FROM mhr_extra_registrations mer
+                          WHERE account_id = :query_value
+                            AND (removed_ind IS NULL OR removed_ind != 'Y')
+                          UNION (
+                         SELECT DISTINCT mr.mhr_number
+                           FROM mhr_registrations mr
+                          WHERE account_id = :query_value
+                            AND mr.registration_type = 'MHREG'))
+  and mr.id = mrr.registration_id
+  and mrt.registration_type = mr.registration_type
+order by mr.id desc
+"""
+QUERY_MHR_NUMBER_LEGACY = """
+SELECT (SELECT COUNT(mr.id)
+           FROM mhr_registrations mr
+          WHERE mr.account_id = :query_value
+            AND mr.mhr_number = :query_value2
+            AND mr.registration_type IN ('MHREG')
+            AND NOT EXISTS (SELECT mer.mhr_number
+                              FROM mhr_extra_registrations mer
+                             WHERE mer.mhr_number = mr.mhr_number
+                               AND mer.account_id = mr.account_id
+                               AND (mer.removed_ind IS NOT NULL AND mer.removed_ind = 'Y'))) AS reg_count,
+       (SELECT COUNT(mer.id)
+           FROM mhr_extra_registrations mer
+          WHERE mer.account_id = :query_value
+            AND mer.mhr_number = :query_value2
+            AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) as extra_reg_count,
+       (SELECT  mr.account_id
+           FROM mhr_registrations mr
+          WHERE mr.account_id = :query_value
+            AND mr.mhr_number = :query_value2
+            AND mr.registration_type IN ('MHREG')),
+      (SELECT mlc.registration_type
+         FROM mhr_lien_check_vw mlc
+        WHERE mlc.mhr_number = :query_value2)
+"""
+DOC_ID_COUNT_QUERY = """
+SELECT COUNT(documtid)
+  FROM document
+ WHERE documtid = :query_value
+"""
+QUERY_ACCOUNT_ADD_REGISTRATION = """
+SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
+          FROM owner o2, owngroup og2
+         WHERE o2.manhomid = mh.manhomid
+           AND og2.manhomid = mh.manhomid
+           AND og2.owngrpid = o2.owngrpid
+           AND og2.status IN ('3')) as owner_names,
+       TRIM(d.affirmby),
+       d.documtid as document_id,
+       d.docuregi as doc_reg_number,
+       (SELECT d2.docutype
+          FROM document d2
+         WHERE d2.mhregnum = d.mhregnum
+           AND d2.regidate = (SELECT MAX(d3.regidate)
+                                FROM document d3
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+  FROM manuhome mh, document d
+ WHERE mh.mhregnum = :query_mhr_number
+   AND mh.mhregnum = d.mhregnum
+"""
+QUERY_ACCOUNT_ADD_REGISTRATION_DOC = """
+SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
+          FROM owner o2, owngroup og2
+         WHERE o2.manhomid = mh.manhomid
+           AND og2.manhomid = mh.manhomid
+           AND og2.owngrpid = o2.owngrpid
+           AND og2.status IN ('3')) as owner_names,
+       TRIM(d.affirmby),
+       d.documtid as document_id,
+       d.docuregi as doc_reg_number,
+       (SELECT d4.docutype
+          FROM document d4
+         WHERE d4.mhregnum = d.mhregnum
+           AND d4.regidate = (SELECT MAX(d3.regidate)
+                                FROM document d3
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+  FROM manuhome mh, document d, document d2
+ WHERE d2.docuregi = :query_value
+   AND d2.mhregnum = mh.mhregnum
+   AND mh.mhregnum = d.mhregnum
+"""
+QUERY_ACCOUNT_REGISTRATIONS = """
+SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
+          FROM owner o2, owngroup og2
+         WHERE o2.manhomid = mh.manhomid
+           AND og2.manhomid = mh.manhomid
+           AND og2.owngrpid = o2.owngrpid
+           AND og2.regdocid = d.documtid) as owner_names,
+       TRIM(d.affirmby),
+       d.documtid as document_id,
+       d.docuregi as doc_reg_number,
+       (SELECT d2.docutype
+          FROM document d2
+         WHERE d2.mhregnum = d.mhregnum
+           AND d2.regidate = (SELECT MAX(d3.regidate)
+                                FROM document d3
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+  FROM manuhome mh, document d
+ WHERE mh.mhregnum IN (?)
+   AND mh.mhregnum = d.mhregnum
+ ORDER BY d.regidate DESC
+"""
+QUERY_ACCOUNT_REGISTRATIONS_SORT = """
+SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
+          FROM owner o2, owngroup og2
+         WHERE o2.manhomid = mh.manhomid
+           AND og2.manhomid = mh.manhomid
+           AND og2.owngrpid = o2.owngrpid
+           AND og2.regdocid = d.documtid) as owner_names,
+       TRIM(d.affirmby),
+       d.documtid as document_id,
+       d.docuregi as doc_reg_number,
+       (SELECT d2.docutype
+          FROM document d2
+         WHERE d2.mhregnum = d.mhregnum
+           AND d2.regidate = (SELECT MAX(d3.regidate)
+                                FROM document d3
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
+       (SELECT TRIM(o2.ownrname)
+          FROM owner o2, owngroup og2
+         WHERE o2.manhomid = mh.manhomid
+           AND og2.manhomid = mh.manhomid
+           AND og2.owngrpid = o2.owngrpid
+           AND og2.regdocid = d.documtid
+           FETCH FIRST 1 ROWS ONLY) as owner_name_sort
+  FROM manuhome mh, document d
+ WHERE mh.mhregnum IN (?)
+   AND mh.mhregnum = d.mhregnum
+"""
+PERMIT_COUNT_QUERY = """
+SELECT COUNT(documtid)
+  FROM document
+ WHERE mhregnum = :query_value1
+   AND docutype = '103 '
+   AND trim(name) = :query_value2
+"""
+REG_ORDER_BY_DATE = ' ORDER BY d.regidate DESC'
+REG_ORDER_BY_MHR_NUMBER = ' ORDER BY mh.mhregnum'
+REG_ORDER_BY_REG_TYPE = ' ORDER BY TRIM(d.docutype)'
+REG_ORDER_BY_STATUS = ' ORDER BY mh.mhstatus'
+REG_ORDER_BY_SUBMITTING_NAME = ' ORDER BY TRIM(d.name)'
+REG_ORDER_BY_CLIENT_REF = ' ORDER BY TRIM(d.olbcfoli)'
+REG_ORDER_BY_USERNAME = ' ORDER BY TRIM(d.affirmby)'
+REG_ORDER_BY_OWNER_NAME = ' ORDER BY owner_name_sort'
+REG_ORDER_BY_EXPIRY_DAYS = ' ORDER BY mh.mhregnum'
+REG_FILTER_REG_TYPE = " AND d.docutype = '?'"
+REG_FILTER_REG_TYPE_COLLAPSE = """
+ AND (d.docutype = '?' OR (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
+                                                                  FROM document d2
+                                                                 WHERE d2.mhregnum = mh.mhregnum
+                                                                   AND d2.docutype = '?')))
+"""
+REG_FILTER_STATUS = " AND mh.mhstatus = '?'"
+REG_FILTER_SUBMITTING_NAME = " AND TRIM(d.name) LIKE '%?%'"
+REG_FILTER_SUBMITTING_NAME_COLLAPSE = """
+ AND (TRIM(d.name) LIKE '%?%' OR
+      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
+                                              FROM document d2
+                                             WHERE d2.mhregnum = mh.mhregnum
+                                               AND TRIM(d2.name) LIKE '%?%')))
+"""
+REG_FILTER_CLIENT_REF = " AND UPPER(TRIM(d.olbcfoli)) LIKE '%?%'"
+REG_FILTER_CLIENT_REF_COLLAPSE = """
+ AND (UPPER(TRIM(d.olbcfoli)) LIKE '%?%' OR
+      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
+                                              FROM document d2
+                                             WHERE d2.mhregnum = mh.mhregnum
+                                               AND TRIM(d2.olbcfoli) LIKE '%?%')))
+"""
+REG_FILTER_USERNAME = " AND TRIM(d.affirmby) LIKE '%?%'"
+REG_FILTER_USERNAME_COLLAPSE = """
+ AND (TRIM(d.affirmby) LIKE '%?%' OR
+      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
+                                              FROM document d2
+                                             WHERE d2.mhregnum = mh.mhregnum
+                                               AND TRIM(d2.affirmby) LIKE '%?%')))
+"""
+REG_FILTER_DATE = ' AND d.regidate BETWEEN :query_start AND :query_end'
+REG_FILTER_DATE_COLLAPSE = """
+ AND (d.regidate BETWEEN :query_start AND :query_end OR
+      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
+                                              FROM document d2
+                                             WHERE d2.mhregnum = mh.mhregnum
+                                               AND d2.regidate BETWEEN :query_start AND :query_end)))
+"""
+SORT_DESCENDING = ' DESC'
+SORT_ASCENDING = ' ASC'
+DEFAULT_SORT_ORDER = ' ORDER BY d.regidate DESC'
+
+NEXT_MHR_NUM_SELECT_FOR_UPDATE = """
+SELECT contnum
+  FROM contnumb
+ WHERE contkey = 'SERMREG'
+ FOR UPDATE
+"""
+NEXT_MHR_NUM_UPDATE = """
+UPDATE contnumb
+   SET contnum = :query_val
+ WHERE contkey = 'SERMREG'
+"""

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -20,6 +20,44 @@ from mhr_api.models import Db2Manuhome, Db2Document, utils as model_utils, regis
 from mhr_api.models.registration_utils import AccountRegistrationParams
 from mhr_api.models.type_tables import MhrDocumentType, MhrRegistrationTypes
 from mhr_api.models.db import db
+from mhr_api.models.db2.queries import (
+    UPDATE_LTSA_PID,
+    QUERY_LTSA_PID,
+    QUERY_ACCOUNT_MHR_LEGACY,
+    QUERY_ACCOUNT_REGISTRATIONS_SUMMARY,
+    QUERY_MHR_NUMBER_LEGACY,
+    DOC_ID_COUNT_QUERY,
+    QUERY_ACCOUNT_ADD_REGISTRATION,
+    QUERY_ACCOUNT_ADD_REGISTRATION_DOC,
+    QUERY_ACCOUNT_REGISTRATIONS,
+    QUERY_ACCOUNT_REGISTRATIONS_SORT,
+    PERMIT_COUNT_QUERY,
+    REG_ORDER_BY_DATE,
+    REG_ORDER_BY_MHR_NUMBER,
+    REG_ORDER_BY_REG_TYPE,
+    REG_ORDER_BY_STATUS,
+    REG_ORDER_BY_SUBMITTING_NAME,
+    REG_ORDER_BY_CLIENT_REF,
+    REG_ORDER_BY_USERNAME,
+    REG_ORDER_BY_OWNER_NAME,
+    REG_ORDER_BY_EXPIRY_DAYS,
+    REG_FILTER_REG_TYPE,
+    REG_FILTER_REG_TYPE_COLLAPSE,
+    REG_FILTER_STATUS,
+    REG_FILTER_SUBMITTING_NAME,
+    REG_FILTER_SUBMITTING_NAME_COLLAPSE,
+    REG_FILTER_CLIENT_REF,
+    REG_FILTER_CLIENT_REF_COLLAPSE,
+    REG_FILTER_USERNAME,
+    REG_FILTER_USERNAME_COLLAPSE,
+    REG_FILTER_DATE,
+    REG_FILTER_DATE_COLLAPSE,
+    SORT_DESCENDING,
+    SORT_ASCENDING,
+    DEFAULT_SORT_ORDER,
+    NEXT_MHR_NUM_SELECT_FOR_UPDATE,
+    NEXT_MHR_NUM_UPDATE
+)
 
 
 FROM_LEGACY_REGISTRATION_TYPE = {
@@ -92,252 +130,7 @@ TO_REGISTRATION_TYPE = {
 }
 UPDATE_PID_STATUS_SUCCESS = 'A'
 UPDATE_PID_STATUS_ERROR = 'E'
-UPDATE_LTSA_PID = """
-UPDATE location
-   SET bcaajuri = :status_value
- WHERE pidnumb IN (?)
-"""
-QUERY_LTSA_PID = """
-SELECT DISTINCT l.pidnumb
-  FROM location l, manuhome m
- WHERE m.mhstatus in ('R', 'E')
-   AND m.manhomid = l.manhomid
-   AND l.status = 'A'
-   AND TRIM(l.pidnumb) != ''
-   AND LENGTH(TRIM(l.pidnumb)) = 9
-   AND TRIM(bcaajuri) = ''
-   AND mhregnum not like '150%'
-FETCH FIRST 500 ROWS ONLY
-"""
-QUERY_ACCOUNT_MHR_LEGACY = """
-SELECT DISTINCT mer.mhr_number, 'N' AS account_reg,
-                (SELECT mlc.registration_type
-                   FROM mhr_lien_check_vw mlc
-                  WHERE mlc.mhr_number = mer.mhr_number) AS lien_registration_type
- FROM mhr_extra_registrations mer
-WHERE account_id = :query_value
-  AND (removed_ind IS NULL OR removed_ind != 'Y')
-UNION (
-SELECT DISTINCT mr.mhr_number, 'Y' AS account_reg,
-                (SELECT mlc.registration_type
-                   FROM mhr_lien_check_vw mlc
-                  WHERE mlc.mhr_number = mr.mhr_number) AS lien_registration_type
-  FROM mhr_registrations mr
-WHERE account_id = :query_value
-  AND mr.registration_type = 'MHREG'
-  AND NOT EXISTS (SELECT mer.mhr_number
-                    FROM mhr_extra_registrations mer
-                   WHERE mer.account_id = mr.account_id
-                     AND mer.mhr_number = mr.mhr_number
-                     AND (mer.removed_ind IS NOT NULL AND mer.removed_ind = 'Y'))
-)
-"""
-QUERY_ACCOUNT_REGISTRATIONS_SUMMARY = """
-SELECT mr.id, mr.registration_ts, mr.account_id, mr.registration_type, mr.mhr_number,
-       (SELECT d.document_id FROM mhr_documents d WHERE d.registration_id = mr.id FETCH FIRST 1 ROWS ONLY)
-       AS document_id,
-       mrr.create_ts as doc_ts, mrr.doc_storage_url, mrt.registration_type_desc,
-       (SELECT CASE WHEN mr.user_id IS NULL THEN ''
-          ELSE (SELECT u.firstname || ' ' || u.lastname FROM users u WHERE u.username = mr.user_id
-                FETCH FIRST 1 ROWS ONLY)
-           END) AS username
-  FROM mhr_registrations mr, mhr_registration_reports mrr, mhr_registration_types mrt
- WHERE mr.mhr_number IN (SELECT DISTINCT mer.mhr_number
-                           FROM mhr_extra_registrations mer
-                          WHERE account_id = :query_value
-                            AND (removed_ind IS NULL OR removed_ind != 'Y')
-                          UNION (
-                         SELECT DISTINCT mr.mhr_number
-                           FROM mhr_registrations mr
-                          WHERE account_id = :query_value
-                            AND mr.registration_type = 'MHREG'))
-  and mr.id = mrr.registration_id
-  and mrt.registration_type = mr.registration_type
-order by mr.id desc
-"""
-QUERY_MHR_NUMBER_LEGACY = """
-SELECT (SELECT COUNT(mr.id)
-           FROM mhr_registrations mr
-          WHERE mr.account_id = :query_value
-            AND mr.mhr_number = :query_value2
-            AND mr.registration_type IN ('MHREG')
-            AND NOT EXISTS (SELECT mer.mhr_number
-                              FROM mhr_extra_registrations mer
-                             WHERE mer.mhr_number = mr.mhr_number
-                               AND mer.account_id = mr.account_id
-                               AND (mer.removed_ind IS NOT NULL AND mer.removed_ind = 'Y'))) AS reg_count,
-       (SELECT COUNT(mer.id)
-           FROM mhr_extra_registrations mer
-          WHERE mer.account_id = :query_value
-            AND mer.mhr_number = :query_value2
-            AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) as extra_reg_count,
-       (SELECT  mr.account_id
-           FROM mhr_registrations mr
-          WHERE mr.account_id = :query_value
-            AND mr.mhr_number = :query_value2
-            AND mr.registration_type IN ('MHREG')),
-      (SELECT mlc.registration_type
-         FROM mhr_lien_check_vw mlc
-        WHERE mlc.mhr_number = :query_value2)
-"""
-DOC_ID_COUNT_QUERY = """
-SELECT COUNT(documtid)
-  FROM document
- WHERE documtid = :query_value
-"""
-QUERY_ACCOUNT_ADD_REGISTRATION = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
-       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
-          FROM owner o2, owngroup og2
-         WHERE o2.manhomid = mh.manhomid
-           AND og2.manhomid = mh.manhomid
-           AND og2.owngrpid = o2.owngrpid
-           AND og2.status IN ('3')) as owner_names,
-       TRIM(d.affirmby),
-       d.documtid as document_id,
-       d.docuregi as doc_reg_number,
-       (SELECT d2.docutype
-          FROM document d2
-         WHERE d2.mhregnum = d.mhregnum
-           AND d2.regidate = (SELECT MAX(d3.regidate)
-                                FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
-  FROM manuhome mh, document d
- WHERE mh.mhregnum = :query_mhr_number
-   AND mh.mhregnum = d.mhregnum
-"""
-QUERY_ACCOUNT_ADD_REGISTRATION_DOC = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
-       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
-          FROM owner o2, owngroup og2
-         WHERE o2.manhomid = mh.manhomid
-           AND og2.manhomid = mh.manhomid
-           AND og2.owngrpid = o2.owngrpid
-           AND og2.status IN ('3')) as owner_names,
-       TRIM(d.affirmby),
-       d.documtid as document_id,
-       d.docuregi as doc_reg_number,
-       (SELECT d4.docutype
-          FROM document d4
-         WHERE d4.mhregnum = d.mhregnum
-           AND d4.regidate = (SELECT MAX(d3.regidate)
-                                FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
-  FROM manuhome mh, document d, document d2
- WHERE d2.docuregi = :query_value
-   AND d2.mhregnum = mh.mhregnum
-   AND mh.mhregnum = d.mhregnum
-"""
-QUERY_ACCOUNT_REGISTRATIONS = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
-       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
-          FROM owner o2, owngroup og2
-         WHERE o2.manhomid = mh.manhomid
-           AND og2.manhomid = mh.manhomid
-           AND og2.owngrpid = o2.owngrpid
-           AND og2.regdocid = d.documtid) as owner_names,
-       TRIM(d.affirmby),
-       d.documtid as document_id,
-       d.docuregi as doc_reg_number,
-       (SELECT d2.docutype
-          FROM document d2
-         WHERE d2.mhregnum = d.mhregnum
-           AND d2.regidate = (SELECT MAX(d3.regidate)
-                                FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
-  FROM manuhome mh, document d
- WHERE mh.mhregnum IN (?)
-   AND mh.mhregnum = d.mhregnum
- ORDER BY d.regidate DESC
-"""
-QUERY_ACCOUNT_REGISTRATIONS_SORT = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
-       (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
-          FROM owner o2, owngroup og2
-         WHERE o2.manhomid = mh.manhomid
-           AND og2.manhomid = mh.manhomid
-           AND og2.owngrpid = o2.owngrpid
-           AND og2.regdocid = d.documtid) as owner_names,
-       TRIM(d.affirmby),
-       d.documtid as document_id,
-       d.docuregi as doc_reg_number,
-       (SELECT d2.docutype
-          FROM document d2
-         WHERE d2.mhregnum = d.mhregnum
-           AND d2.regidate = (SELECT MAX(d3.regidate)
-                                FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
-       (SELECT TRIM(o2.ownrname)
-          FROM owner o2, owngroup og2
-         WHERE o2.manhomid = mh.manhomid
-           AND og2.manhomid = mh.manhomid
-           AND og2.owngrpid = o2.owngrpid
-           AND og2.regdocid = d.documtid
-           FETCH FIRST 1 ROWS ONLY) as owner_name_sort
-  FROM manuhome mh, document d
- WHERE mh.mhregnum IN (?)
-   AND mh.mhregnum = d.mhregnum
-"""
-PERMIT_COUNT_QUERY = """
-SELECT COUNT(documtid)
-  FROM document
- WHERE mhregnum = :query_value1
-   AND docutype = '103 '
-   AND trim(name) = :query_value2
-"""
-REG_ORDER_BY_DATE = ' ORDER BY d.regidate DESC'
-REG_ORDER_BY_MHR_NUMBER = ' ORDER BY mh.mhregnum'
-REG_ORDER_BY_REG_TYPE = ' ORDER BY TRIM(d.docutype)'
-REG_ORDER_BY_STATUS = ' ORDER BY mh.mhstatus'
-REG_ORDER_BY_SUBMITTING_NAME = ' ORDER BY TRIM(d.name)'
-REG_ORDER_BY_CLIENT_REF = ' ORDER BY TRIM(d.olbcfoli)'
-REG_ORDER_BY_USERNAME = ' ORDER BY TRIM(d.affirmby)'
-REG_ORDER_BY_OWNER_NAME = ' ORDER BY owner_name_sort'
-REG_ORDER_BY_EXPIRY_DAYS = ' ORDER BY mh.mhregnum'
-REG_FILTER_REG_TYPE = " AND d.docutype = '?'"
-REG_FILTER_REG_TYPE_COLLAPSE = """
- AND (d.docutype = '?' OR (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
-                                                                  FROM document d2
-                                                                 WHERE d2.mhregnum = mh.mhregnum
-                                                                   AND d2.docutype = '?')))
-"""
-REG_FILTER_STATUS = " AND mh.mhstatus = '?'"
-REG_FILTER_SUBMITTING_NAME = " AND TRIM(d.name) LIKE '%?%'"
-REG_FILTER_SUBMITTING_NAME_COLLAPSE = """
- AND (TRIM(d.name) LIKE '%?%' OR
-      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
-                                              FROM document d2
-                                             WHERE d2.mhregnum = mh.mhregnum
-                                               AND TRIM(d2.name) LIKE '%?%')))
-"""
-REG_FILTER_CLIENT_REF = " AND UPPER(TRIM(d.olbcfoli)) LIKE '%?%'"
-REG_FILTER_CLIENT_REF_COLLAPSE = """
- AND (UPPER(TRIM(d.olbcfoli)) LIKE '%?%' OR
-      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
-                                              FROM document d2
-                                             WHERE d2.mhregnum = mh.mhregnum
-                                               AND TRIM(d2.olbcfoli) LIKE '%?%')))
-"""
-REG_FILTER_USERNAME = " AND TRIM(d.affirmby) LIKE '%?%'"
-REG_FILTER_USERNAME_COLLAPSE = """
- AND (TRIM(d.affirmby) LIKE '%?%' OR
-      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
-                                              FROM document d2
-                                             WHERE d2.mhregnum = mh.mhregnum
-                                               AND TRIM(d2.affirmby) LIKE '%?%')))
-"""
-REG_FILTER_DATE = ' AND d.regidate BETWEEN :query_start AND :query_end'
-REG_FILTER_DATE_COLLAPSE = """
- AND (d.regidate BETWEEN :query_start AND :query_end OR
-      (d.documtid = mh.regdocid AND EXISTS (SELECT d2.documtid
-                                              FROM document d2
-                                             WHERE d2.mhregnum = mh.mhregnum
-                                               AND d2.regidate BETWEEN :query_start AND :query_end)))
-"""
-SORT_DESCENDING = ' DESC'
-SORT_ASCENDING = ' ASC'
 DEFAULT_REG_TYPE_FILTER = "'101 '"
-DEFAULT_SORT_ORDER = ' ORDER BY d.regidate DESC'
 QUERY_ACCOUNT_FILTER_BY = {
     reg_utils.STATUS_PARAM: REG_FILTER_STATUS,
     reg_utils.REG_TYPE_PARAM: REG_FILTER_REG_TYPE,
@@ -1005,3 +798,22 @@ def get_new_registration_json(registration):
     reg_json = registration.set_description_json(reg_json, False)
     current_app.logger.debug('Built JSON from DB2 and PostgreSQL')
     return registration.set_payment_json(reg_json)
+
+
+def get_next_mhr_number() -> str:
+    """Get next MHR number from the legacy number series."""
+    try:
+        query1 = text(NEXT_MHR_NUM_SELECT_FOR_UPDATE)
+        result = db.get_engine(current_app, 'db2').execute(query1)
+        #                                                   {'query_value1': mhr_number, 'query_value2': query_name})
+        row = result.first()
+        next_mhr: int = int(row[0]) + 1
+        query2 = text(NEXT_MHR_NUM_UPDATE)
+        result = db.get_engine(current_app, 'db2').execute(query2, {'query_val': next_mhr})
+        db.session.commit()
+        mhr_number: str = str(next_mhr)
+        current_app.logger.debug(f'New MHR number={mhr_number}.')
+        return mhr_number
+    except Exception as db_exception:   # noqa: B902; return nicer error
+        current_app.logger.error('DB2 get_next_mhr_number exception: ' + str(db_exception))
+        raise DatabaseException(db_exception)

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -557,7 +557,10 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         reg_vals: MhrRegistration = reg_utils.get_generated_values(MhrRegistration(), draft, user_group)
         registration: MhrRegistration = MhrRegistration()
         registration.id = reg_vals.id  # pylint: disable=invalid-name; allow name of id.
-        registration.mhr_number = reg_vals.mhr_number
+        if model_utils.is_legacy():
+            registration.mhr_number = legacy_utils.get_next_mhr_number()
+        else:
+            registration.mhr_number = reg_vals.mhr_number
         registration.doc_reg_number = reg_vals.doc_reg_number
         registration.doc_pkey = reg_vals.doc_pkey
         registration.registration_ts = model_utils.now_ts()

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -1519,6 +1519,57 @@
 			]
 		},
 		{
+			"name": "unit notes",
+			"item": [
+				{
+					"name": "Create MH NPUB Unit Note",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"clientReferenceId\": \"UT-NPUB-001\",\n  \"attentionReference\": \"JACK BROWN\",\n  \"submittingParty\": {\n    \"businessName\": \"ABC SEARCHING COMPANY\",\n    \"address\": {\n      \"street\": \"222 SUMMER STREET\",\n      \"city\": \"VICTORIA\",\n      \"region\": \"BC\",\n      \"country\": \"CA\",\n      \"postalCode\": \"V8W 2V8\"\n    },\n    \"emailAddress\": \"bsmith@abc-search.com\"\n  },\n  \"note\": {\n    \"documentType\": \"NPUB\",\n    \"documentId\": \"81111158\",\n    \"remarks\": \"NPUB UNIT NOTE TEST\",\n    \"givingNoticeParty\": {\n\t    \"businessName\": \"TEST GIVING NOTICE COMPANY\",\n\t    \"address\": {\n\t      \"street\": \"1222 SUMMER STREET\",\n\t      \"city\": \"VICTORIA\",\n\t      \"region\": \"BC\",\n\t      \"country\": \"CA\",\n\t      \"postalCode\": \"V8W 2V8\"\n\t    },\n      \"phoneNumber\": \"2508289999\"\n    }\n  }\n}\n"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/notes/106768",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"notes",
+								"106768"
+							]
+						},
+						"description": "Search step 1 submit a query example: search by a Financing Statement registration number which returns no results."
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "documents",
 			"item": [
 				{
@@ -1614,11 +1665,11 @@
 	"variable": [
 		{
 			"key": "apikey",
-			"value": "PROVIDE"
+			"value": "Provide"
 		},
 		{
 			"key": "account_id",
-			"value": "PROVIDE"
+			"value": "Provide"
 		},
 		{
 			"key": "base_url_prism",
@@ -1631,7 +1682,7 @@
 		},
 		{
 			"key": "jwt",
-			"value": "PROVIDE",
+			"value": "Provide",
 			"type": "string"
 		},
 		{

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -250,7 +250,11 @@ def test_create(session, client, jwt, desc, has_submitting, roles, status, has_a
     # check
     assert response.status_code == status
     if response.status_code == HTTPStatus.CREATED:
-        registration: MhrRegistration = MhrRegistration.find_by_mhr_number(response.json['mhrNumber'],
+        response_json = response.json
+        assert response_json.get('mhrNumber')
+        if model_utils.is_legacy():
+            assert not str(response_json.get('mhrNumber')).startswith('15')
+        registration: MhrRegistration = MhrRegistration.find_by_mhr_number(response_json.get('mhrNumber'),
                                                                            'PS12345')
         assert registration
 

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -76,7 +76,7 @@ TEST_QUERY_FILTER_DATA_DATE = [
 
 # testdata pattern is ({account_id}, {collapse}, {start_value}, {end_value}, {second_filter_name},
 #                      {second_filter_value}, {mhr_numbers}, {expected_date_clause}, {expected_second_clause})
-TEST_QUERY_FILTER_DATA_MULTIPLE = [
+TEST_QUERY_FILTER_DATA_MULTIPLE= [
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.MHR_NUMBER_PARAM,
      '098487', "'dgfhdgf'", db2_utils.REG_FILTER_DATE, 'mh.mhregnum IN (?)'),
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.REG_TYPE_PARAM,
@@ -90,7 +90,6 @@ TEST_QUERY_FILTER_DATA_MULTIPLE = [
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.USER_NAME_PARAM,
      'BCREG2', "'098487'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_USERNAME),
 ]
-
 
 @pytest.mark.parametrize('account_id, has_results', TEST_ACCOUNT_REG_DATA)
 def test_find_account_registrations(session, account_id, has_results):
@@ -264,6 +263,8 @@ def test_account_reg_filter_multiple(session, account_id, collapse, start_value,
     filter_query: str = db2_utils.build_account_query_filter(base_query, params, mhr_numbers,
                                                              MhrDocumentType.find_all())
 
+    #current_app.logger.info(filter_query)
+    #current_app.logger.info(second_filter_clause)
     assert filter_query.find(date_filter_clause) > 0
     assert filter_query.find(second_filter_clause) > 0
 
@@ -311,7 +312,7 @@ def test_get_pid_list(session):
     pid_list = db2_utils.get_pid_list()
     # assert pid_list
     for pid in pid_list:
-        assert pid.get('pidNumber');
+        assert pid.get('pidNumber')
 
 
 def test_update_pid_list(session):
@@ -319,3 +320,12 @@ def test_update_pid_list(session):
     pid_list = [{'pidNumber': '  1789805'}]
     db2_utils.update_pid_list(pid_list, db2_utils.UPDATE_PID_STATUS_SUCCESS)
     db2_utils.update_pid_list(pid_list, ' ')
+
+
+def test_get_next_mhr_number(session):
+    """Assert that the get next mhr number query works as expected."""
+    mhr1 = db2_utils.get_next_mhr_number()
+    mhr2 = db2_utils.get_next_mhr_number()
+    # assert number generated
+    assert mhr1 and mhr2
+    assert int(mhr1) + 1 == int(mhr2)

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -714,6 +714,8 @@ def test_create_new_from_json(session):
     registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
     assert registration.id > 0
     assert registration.mhr_number
+    if model_utils.is_legacy():
+        assert not str(registration.mhr_number).startswith('15')
     assert registration.registration_ts
     assert registration.status_type in MhrRegistrationStatusTypes
     assert registration.registration_type in MhrRegistrationTypes


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16674

*Description of changes:*
- Change MHR number generation to use the same strategy as the legacy application.
- Refactor large DB2 utils file to move queries to a separate file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
