### PR TITLE
MHR API get registrations add unit notes

### DIFF
--- a/mhr_api/report-templates/exemptionV2.html
+++ b/mhr_api/report-templates/exemptionV2.html
@@ -17,7 +17,7 @@
   <div class="business-details-container mtn-2">
     <table class="registration-details-table-grey mt-0" role="presentation">
       <tr>
-        <td>Registration Status:</td>
+        <td>Home Registration Status:</td>
         <td>{{status|title}}</td>
       </tr>
       <tr>

--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -92,12 +92,7 @@
         {% endif %}
       </div>
       <div class="cover-data"><span class="cover-data-bold">Document Registration Date and Time:</span> {{ createDateTime }}</div>
-      {% if meta_account_id == 'ppr_staff' %}
-        <div class="cover-data mt-4"><span class="cover-data-bold">Examiner:</span> {{ username }}</div>
-        <div class="cover-data"><span class="cover-data-bold">Toll-Free Phone:</span> 1-877-526-1526</div>
-      {% else %}
-        <div class="cover-data mt-4"><span class="cover-data-bold">Toll-Free Phone:</span> 1-877-526-1526</div>
-      {% endif %}
+      <div class="cover-data mt-4"><span class="cover-data-bold">Toll-Free Phone:</span> 1-877-526-1526</div>
     </div>
   </div>
 </body>

--- a/mhr_api/report-templates/registrationV2.html
+++ b/mhr_api/report-templates/registrationV2.html
@@ -26,7 +26,7 @@
       {% endif %}
     <table class="business-details-table-grey mt-0" role="presentation">
       <tr>
-        <td>Registration Status:</td>
+        <td>Home Registration Status:</td>
         <td>{{status|title}}</td>
       </tr>
       <tr>

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -26,7 +26,7 @@
       </td>
     </tr>
       <tr>
-      <td>Registration Status:</td>
+      <td>Home Registration Status:</td>
       <td>
         {% if detail.status in ('C', 'HISTORICAL') %}
           Historical

--- a/mhr_api/report-templates/transferV2.html
+++ b/mhr_api/report-templates/transferV2.html
@@ -21,7 +21,7 @@
         <td>{{documentDescription}}</td>
       </tr>
       <tr>
-        <td>Registration Status:</td>
+        <td>Home Registration Status:</td>
         <td>{{status|title}}</td>
       </tr>
       <tr>

--- a/mhr_api/report-templates/transportPermitV2.html
+++ b/mhr_api/report-templates/transportPermitV2.html
@@ -17,7 +17,7 @@
   <div class="business-details-container mtn-2">
     <table class="registration-details-table-grey mt-0" role="presentation">
       <tr>
-        <td>Registration Status:</td>
+        <td>Home Registration Status:</td>
         <td>{{status|title}}</td>
       </tr>
       <tr>

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -566,7 +566,7 @@ class Db2Manuhome(db.Model):
         for note in self.notes:
             if note.document_type in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE) and \
                     note.status == Db2Mhomnote.StatusTypes.ACTIVE:
-                if (not note.expiry_date or note.expiry_date.isoformat() != '0001-01-01') and \
+                if (not note.expiry_date or note.expiry_date.isoformat() == '0001-01-01') and \
                         note.document_type == MhrDocumentTypes.CAUC:
                     has_caution = True
                 elif note.expiry_date:

--- a/mhr_api/src/mhr_api/models/db2/mhomnote.py
+++ b/mhr_api/src/mhr_api/models/db2/mhomnote.py
@@ -224,7 +224,8 @@ class Db2Mhomnote(db.Model):
                            legacy_address=document.legacy_address,
                            remarks=json_data.get('remarks', ''),
                            can_document_id='')
-
+        if not note.remarks:
+            note.remarks = ''
         if json_data.get('givingNoticeParty'):
             notice = json_data.get('givingNoticeParty')
             if notice.get('phoneNumber'):

--- a/mhr_api/src/mhr_api/models/db2/mhomnote.py
+++ b/mhr_api/src/mhr_api/models/db2/mhomnote.py
@@ -18,7 +18,16 @@ from flask import current_app
 from mhr_api.exceptions import DatabaseException
 from mhr_api.models import db, utils as model_utils, Db2Document
 from mhr_api.models.db2 import address_utils
+from mhr_api.models.type_tables import MhrNoteStatusTypes
 from mhr_api.utils.base import BaseEnum
+
+
+FROM_LEGACY_STATUS = {
+    'A': MhrNoteStatusTypes.ACTIVE.value,
+    'C': MhrNoteStatusTypes.CANCELLED.value,
+    'E': MhrNoteStatusTypes.EXPIRED.value,
+    'F': MhrNoteStatusTypes.CORRECTED.value
+}
 
 
 class Db2Mhomnote(db.Model):
@@ -143,6 +152,7 @@ class Db2Mhomnote(db.Model):
             'documentType': self.document_type.strip(),
             'documentId': self.reg_document_id,
             'remarks': self.remarks,
+            'status': FROM_LEGACY_STATUS.get(self.status),
             'destroyed': False
         }
         if self.expiry_date and self.expiry_date.isoformat() != '0001-01-01':
@@ -161,7 +171,7 @@ class Db2Mhomnote(db.Model):
         note = {
             'documentType': self.document_type.strip(),
             'documentId': self.reg_document_id,
-            'status': self.status,
+            'status': FROM_LEGACY_STATUS.get(self.status),
             'remarks': self.remarks
         }
         if self.name:

--- a/mhr_api/src/mhr_api/models/mhr_note.py
+++ b/mhr_api/src/mhr_api/models/mhr_note.py
@@ -56,7 +56,7 @@ class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
             'documentId': str(self.document_id).rjust(8, '0'),
             'documentType': self.document_type,
             'status': self.status_type,
-            'remarks': self.remarks,
+            'remarks': self.remarks if self.remarks is not None else '',
             'destroyed': False
         }
         if self.registration:

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -188,6 +188,7 @@ def get_registrations(mhr_number: str):  # pylint: disable=too-many-return-state
                                                               account_id,
                                                               is_all_staff_account(account_id))
             registration.current_view = True
+            registration.staff = is_staff(jwt)
         else:
             registration = MhrRegistration.find_original_by_mhr_number(mhr_number,
                                                                        account_id,

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -76,7 +76,7 @@ TEST_QUERY_FILTER_DATA_DATE = [
 
 # testdata pattern is ({account_id}, {collapse}, {start_value}, {end_value}, {second_filter_name},
 #                      {second_filter_value}, {mhr_numbers}, {expected_date_clause}, {expected_second_clause})
-TEST_QUERY_FILTER_DATA_MULTIPLE= [
+TEST_QUERY_FILTER_DATA_MULTIPLE = [
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.MHR_NUMBER_PARAM,
      '098487', "'dgfhdgf'", db2_utils.REG_FILTER_DATE, 'mh.mhregnum IN (?)'),
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.REG_TYPE_PARAM,

--- a/mhr_api/tests/unit/models/db2/test_mhomnote.py
+++ b/mhr_api/tests/unit/models/db2/test_mhomnote.py
@@ -23,6 +23,7 @@ from flask import current_app
 
 from mhr_api.models import Db2Mhomnote
 from mhr_api.models.db2 import address_utils
+from mhr_api.models.type_tables import MhrNoteStatusTypes
 
 
 # testdata pattern is ({exists}, {manuhome_id}, {doc_id}, {doc_type}, {expiry}, {count})
@@ -46,7 +47,7 @@ def test_find_by_manuhome_id(session, exists, manuhome_id, doc_id, doc_type, exp
             assert note.note_id > 0
             assert note.note_number >= 0
             assert note.status
-            if note.status == 'A':
+            if note.status == MhrNoteStatusTypes.ACTIVE:
                 assert note.reg_document_id == doc_id
                 assert note.document_type == doc_type
             assert note.can_document_id is not None
@@ -97,6 +98,9 @@ def test_find_by_manuhome_id_active(session, exists, manuhome_id, doc_id, doc_ty
             assert notice_json['address']['region']
             assert notice_json['address']['country']
             assert notice_json['address']['postalCode'] is not None
+            assert reg_json.get('status') in (MhrNoteStatusTypes.ACTIVE,
+                                              MhrNoteStatusTypes.CANCELLED,
+                                              MhrNoteStatusTypes.EXPIRED)
     else:
         assert not notes
 
@@ -119,6 +123,7 @@ def test_note_json(session):
         'documentType': note.document_type,
         'documentId': note.reg_document_id,
         'remarks': note.remarks,
+        'status': MhrNoteStatusTypes.ACTIVE.value,
         'destroyed': False,
         'givingNoticeParty': {
             'businessName': note.name,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16506
                 /bcgov/entity/#16607
*Description of changes:*
- Current view of a registration include unit notes for registries staff
- Add hasCaution to indicate a caution exists on the home.
- 16607 Minor updates to report cover letter and registration tombstone.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
