### PR TITLE
Conditionally add expireDays and hasCaution to account reg summary.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -123,7 +123,13 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE d2.mhregnum = d.mhregnum
            AND d2.regidate = (SELECT MAX(d3.regidate)
                                 FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
+       (SELECT n.status
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_status,
+       (SELECT n.expiryda
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry
   FROM manuhome mh, document d
  WHERE mh.mhregnum = :query_mhr_number
    AND mh.mhregnum = d.mhregnum
@@ -144,7 +150,13 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE d4.mhregnum = d.mhregnum
            AND d4.regidate = (SELECT MAX(d3.regidate)
                                 FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
+       (SELECT n.status
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_status,
+       (SELECT n.expiryda
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry
   FROM manuhome mh, document d, document d2
  WHERE d2.docuregi = :query_value
    AND d2.mhregnum = mh.mhregnum
@@ -166,7 +178,13 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE d2.mhregnum = d.mhregnum
            AND d2.regidate = (SELECT MAX(d3.regidate)
                                 FROM document d3
-                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type
+                               WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
+       (SELECT n.status
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_status,
+       (SELECT n.expiryda
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry
   FROM manuhome mh, document d
  WHERE mh.mhregnum IN (?)
    AND mh.mhregnum = d.mhregnum
@@ -189,6 +207,12 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
            AND d2.regidate = (SELECT MAX(d3.regidate)
                                 FROM document d3
                                WHERE d3.mhregnum = d.mhregnum)) AS last_doc_type,
+       (SELECT n.status
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_status,
+       (SELECT n.expiryda
+          FROM mhomnote n
+         WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry,
        (SELECT TRIM(o2.ownrname)
           FROM owner o2, owngroup og2
          WHERE o2.manhomid = mh.manhomid

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -346,14 +346,14 @@ def today_local():
 
 
 def expiry_date_days(expiry_dt: date) -> int:
-    """Create a date representing the date at 23:59:59 local time as UTC from the current expiry date."""
+    """Compute the date difference in days between the expiry date and and the current date."""
     today_ts = today_local()
     date_diff = expiry_dt - today_ts.date()
     return date_diff.days
 
 
 def expiry_ts_days(expiry_ts: _datetime) -> int:
-    """Create a date representing the date at 23:59:59 local time as UTC from the current expiry date."""
+    """Compute the date difference in days between the expiry timstamp and and the current timestamp."""
     today_ts = now_ts()
     date_diff = today_ts - expiry_ts
     return date_diff.days

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -345,6 +345,20 @@ def today_local():
     return now_ts().astimezone(LOCAL_TZ)
 
 
+def expiry_date_days(expiry_dt: date) -> int:
+    """Create a date representing the date at 23:59:59 local time as UTC from the current expiry date."""
+    today_ts = today_local()
+    date_diff = expiry_dt - today_ts.date()
+    return date_diff.days
+
+
+def expiry_ts_days(expiry_ts: _datetime) -> int:
+    """Create a date representing the date at 23:59:59 local time as UTC from the current expiry date."""
+    today_ts = now_ts()
+    date_diff = today_ts - expiry_ts
+    return date_diff.days
+
+
 def expiry_dt_from_years(life_years: int, iso_date: str = None):
     """Create a date representing the date at 23:59:59 local time as UTC.
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.4.0'  # pylint: disable=invalid-name
+__version__ = '1.4.1'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -492,6 +492,8 @@ def test_find_summary_by_mhr_number(session, account_id, mhr_num, exists, reg_de
     if exists:
         current_app.logger.info(registration)
         assert registration['mhrNumber'] == mhr_num
+        assert registration['registrationType']
+        assert 'hasCaution' in registration
         assert registration['registrationDescription'] == reg_desc
         assert registration['statusType'] is not None
         assert registration['createDateTime'] is not None
@@ -513,6 +515,8 @@ def test_find_summary_by_doc_reg_number(session, account_id, doc_reg_num, mhr_nu
     if result_count > 0:
         current_app.logger.info(registration)
         assert registration['mhrNumber'] == mhr_num
+        assert registration['registrationType']
+        assert 'hasCaution' in registration
         assert registration['registrationDescription'] == reg_desc
         assert registration['statusType'] is not None
         assert registration['createDateTime'] is not None
@@ -528,6 +532,10 @@ def test_find_summary_by_doc_reg_number(session, account_id, doc_reg_num, mhr_nu
         else:
             assert registration.get('changes')
             assert len(registration['changes']) >= (result_count - 1)
+            for reg in registration.get('changes'):
+                desc: str = reg['registrationDescription']
+                if reg.get('registrationType') == MhrRegistrationTypes.REG_NOTE and desc.find('CAUTION') > 0:
+                    assert reg.get('expireDays')
     else:
         assert not registration
 
@@ -543,6 +551,8 @@ def test_find_account_registrations(session, account_id, has_results):
     if has_results:
         for registration in reg_list:
             assert registration['mhrNumber']
+            assert registration['registrationType']
+            assert 'hasCaution' in registration
             assert registration['registrationDescription']
             assert registration['statusType'] is not None
             assert registration['createDateTime'] is not None
@@ -555,6 +565,11 @@ def test_find_account_registrations(session, account_id, has_results):
             assert not registration.get('inUserList')
             if registration['registrationDescription'] == REG_DESCRIPTION:
                 assert 'lienRegistrationType' in registration
+            if registration.get('changes'):
+                for reg in registration.get('changes'):
+                    desc: str = reg['registrationDescription']
+                    if reg.get('registrationType') == MhrRegistrationTypes.REG_NOTE and desc.find('CAUTION') > 0:
+                        assert reg.get('expireDays')
     else:
         assert not reg_list
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16510

*Description of changes:*
- For CAU, CAUC, CAUE document types add expireDays to GET account reg summary response.
- For MHREG, MHREG_CONVERSION registration types add hadCaution to  GET account reg summary response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
