### PR TITLE
Update Additional Name for Individuals

### DIFF
--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -470,7 +470,9 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
 
         suffix = deletedOwner.organizationName?.length > 0
           ? transferOwnerPrefillAdditionalName[transferType] + deletedOwner.organizationName
-          : transferOwnerPrefillAdditionalName[transferType] + [first, middle, last].filter(Boolean).join(' ')
+          : transferOwnerPrefillAdditionalName[transferType] +
+            [first, middle, last].filter(Boolean).join(' ') +
+            ', deceased'
       } else {
         // if executor, admin or trustee, copy the additional name (suffix) from the suffix of deleted owner
         suffix = deletedOwner.description

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -507,7 +507,7 @@ describe('Home Owners', () => {
     // check that suffix field value is pre-populated with the name of deleted person
     const suffix = <HTMLInputElement>(addEditHomeOwner.find(getTestId('suffix'))).element
     const { first, middle, last } = mockedPerson.individualName
-    expect(suffix.value).toBe(`Executor of the will of ${first} ${middle} ${last}`)
+    expect(suffix.value).toBe(`Executor of the will of ${first} ${middle} ${last}, deceased`)
   })
 
   it('TRANS WILL: displays correct tenancy type in Executor scenarios', async () => {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16065

*Description of changes:*
- Add 'deceased' word when pre-filling Additional Name
- For now, just for the Individuals - Business Owners is pending

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
