### PR TITLE
PPR API 2 bug fixes.

### DIFF
--- a/ppr-api/src/database/patch/16470-ppr-account_registration_vw-update.sql
+++ b/ppr-api/src/database/patch/16470-ppr-account_registration_vw-update.sql
@@ -1,5 +1,4 @@
--- 10903 2022-02-04 Run this manually for now
---DROP VIEW public.account_registration_vw;
+-- 16470 DEV 2023-06-15 TEST/SANDBOX 2023-06- PROD 2023-06-
 CREATE OR REPLACE VIEW public.account_registration_vw AS
 WITH q AS (
   SELECT (now() at time zone 'utc')
@@ -121,3 +120,4 @@ SELECT r.registration_number, r.registration_ts, r.registration_type, r.registra
   AND r2.registration_type_cl IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')
 )
 ;
+

--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -53,9 +53,9 @@ QUERY_ACCOUNT_REG_NUM_CLAUSE = """
                  AND arv2.registration_type_cl NOT IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')
                  AND arv2.registration_number LIKE :reg_num || '%'))
 """
-QUERY_ACCOUNT_CLIENT_REF_CLAUSE = " AND arv.client_reference_id LIKE :client_reference_id || '%'"
+QUERY_ACCOUNT_CLIENT_REF_CLAUSE = " AND arv.client_reference_id LIKE '%' || :client_reference_id || '%'"
 QUERY_ACCOUNT_CLIENT_REF_CLAUSE_NEW = """
- AND (arv.client_reference_id ILIKE :client_reference_id || '%' OR
+ AND (arv.client_reference_id ILIKE '%' || :client_reference_id || '%' OR
     EXISTS (SELECT arv2.financing_id
             FROM account_registration_vw arv2
             WHERE arv2.financing_id = arv.financing_id

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -261,12 +261,15 @@ SELECT r.registration_number, r.registration_ts, r.registration_type, r.registra
          WHERE r2.financing_id = r.financing_id) AS last_update_ts,
        (SELECT CASE WHEN p.business_name IS NOT NULL THEN p.business_name
                     WHEN p.branch_id IS NOT NULL THEN (SELECT name FROM client_codes WHERE id = p.branch_id)
+                    WHEN p.middle_initial IS NOT NULL THEN p.first_name || ' ' || p.middle_initial || ' ' || p.last_name
                     ELSE p.first_name || ' ' || p.last_name END
           FROM parties p
          WHERE p.registration_id = r.id
            AND p.party_type = 'RG') AS registering_party,
        (SELECT string_agg((CASE WHEN p.business_name IS NOT NULL THEN p.business_name
                                 WHEN p.branch_id IS NOT NULL THEN (SELECT name FROM client_codes WHERE id = p.branch_id)
+                                WHEN p.middle_initial IS NOT NULL THEN p.first_name || ' ' || p.middle_initial ||
+                                     ' ' || p.last_name
                                 ELSE p.first_name || ' ' || p.last_name END), ', ')
           FROM parties p
          WHERE p.financing_id = fs.id
@@ -313,12 +316,15 @@ SELECT r.registration_number, r.registration_ts, r.registration_type, r.registra
          WHERE r2.financing_id = r.financing_id) AS last_update_ts,
        (SELECT CASE WHEN p.business_name IS NOT NULL THEN p.business_name
                     WHEN p.branch_id IS NOT NULL THEN (SELECT name FROM client_codes WHERE id = p.branch_id)
+                    WHEN p.middle_initial IS NOT NULL THEN p.first_name || ' ' || p.middle_initial || ' ' || p.last_name
                     ELSE p.first_name || ' ' || p.last_name END
           FROM parties p
          WHERE p.registration_id = r.id
            AND p.party_type = 'RG') AS registering_party,
        (SELECT string_agg((CASE WHEN p.business_name IS NOT NULL THEN p.business_name
                                 WHEN p.branch_id IS NOT NULL THEN (SELECT name FROM client_codes WHERE id = p.branch_id)
+                                WHEN p.middle_initial IS NOT NULL THEN p.first_name || ' ' || p.middle_initial ||
+                                     ' ' || p.last_name
                                 ELSE p.first_name || ' ' || p.last_name END), ', ')
           FROM parties p
          WHERE p.financing_id = fs.id
@@ -410,8 +416,8 @@ ORDER BY r.registration_ts DESC
 QUERY_ACCOUNT_DRAFTS_LIMIT = " FETCH FIRST :max_results_size ROWS ONLY"
 QUERY_ACCOUNT_DRAFTS_DEFAULT_ORDER = " ORDER BY create_ts DESC"
 QUERY_ACCOUNT_DRAFTS_DOC_NUM_CLAUSE = " AND document_number LIKE :doc_num || '%'"
-QUERY_ACCOUNT_DRAFTS_CLIENT_REF_CLAUSE = " AND client_reference_id LIKE :client_reference_id || '%'"
-QUERY_ACCOUNT_DRAFTS_CLIENT_REF_CLAUSE_NEW = " AND client_reference_id ILIKE :client_reference_id || '%'"
+QUERY_ACCOUNT_DRAFTS_CLIENT_REF_CLAUSE = " AND client_reference_id LIKE '%' || :client_reference_id || '%'"
+QUERY_ACCOUNT_DRAFTS_CLIENT_REF_CLAUSE_NEW = " AND client_reference_id ILIKE '%' || :client_reference_id || '%'"
 QUERY_ACCOUNT_DRAFTS_REG_NAME_CLAUSE = " AND registering_name LIKE '%' || :registering_name || '%'"
 QUERY_ACCOUNT_DRAFTS_REG_NAME_CLAUSE_NEW = " AND registering_name ILIKE '%' || :registering_name || '%'"
 QUERY_ACCOUNT_DRAFTS_REG_TYPE_CLAUSE = ' AND registration_type = :registration_type'

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.4'  # pylint: disable=invalid-name
+__version__ = '1.1.5'  # pylint: disable=invalid-name

--- a/ppr-api/tests/unit/models/test_drafts.py
+++ b/ppr-api/tests/unit/models/test_drafts.py
@@ -57,6 +57,21 @@ TEST_QUERY_BASE_DATA = [
     ('D-T-', None, None, None, '2022-01-22T16:00:00+00:00', '2022-01-28T16:00:00+00:00'),
     (None, 'SA', None, None, '2022-01-22T16:00:00+00:00', '2022-01-28T16:00:00+00:00')
 ]
+# testdata pattern is ({doc_num}, {reg_type}, {client_ref}, {registering_name}, {start_ts}, {end_ts})
+TEST_QUERY_FILTER_DATA = [
+    (None, None, None, None, None, None),
+    ('D-T', None, None, None, None, None),
+    ('d-t', None, None, None, None, None),
+    (None, 'SA', None, None, None, None),
+    (None, 'AM', None, None, None, None),
+    (None, None, 'A-00000', None, None, None),
+    (None, None, '00000', None, None, None),
+    (None, None, None, 'TEST U', None, None),
+    (None, None, None, None, '2022-01-22T16:00:00+00:00', '2022-01-28T16:00:00+00:00'),
+    ('D-T-', None, 'A-00000', None, None, None),
+    ('D-T-', None, None, None, '2022-01-22T16:00:00+00:00', '2022-01-28T16:00:00+00:00'),
+    (None, 'SA', None, None, '2022-01-22T16:00:00+00:00', '2022-01-28T16:00:00+00:00')
+]
 
 
 def test_find_all_by_account_id(session):
@@ -262,7 +277,7 @@ def test_account_draft_query(session, doc_num, reg_type, client_ref, registering
     params.registering_name = registering
     params.start_date_time = start_ts
     params.end_date_time = end_ts
-    query = Draft.build_account_draft_query(params)
+    query = Draft.build_account_draft_query(params, False)
     # current_app.logger.info('\n' + query)
     if params.registration_number:
         assert query.find(model_utils.QUERY_ACCOUNT_DRAFTS_DOC_NUM_CLAUSE) != -1
@@ -321,7 +336,7 @@ def test_account_draft_query_params(session, doc_num, reg_type, client_ref, regi
         assert 'end_date_time' not in query_params
 
 
-@pytest.mark.parametrize('doc_num,reg_type,client_ref,registering,start_ts,end_ts', TEST_QUERY_BASE_DATA)
+@pytest.mark.parametrize('doc_num,reg_type,client_ref,registering,start_ts,end_ts', TEST_QUERY_FILTER_DATA)
 def test_find_all_by_account_id_filter(session, doc_num, reg_type, client_ref, registering, start_ts, end_ts):
     """Assert that account change registration query is as expected."""
     params: AccountRegistrationParams = AccountRegistrationParams(account_id='PS12345',

--- a/ppr-api/tests/unit/models/test_registration_utils.py
+++ b/ppr-api/tests/unit/models/test_registration_utils.py
@@ -66,11 +66,11 @@ TEST_FILTER_API_DATA = [
     ('TEST0018A', None, None, None),
     ('test', None, None, None),
     (None, 'TEST-SA-00', None, None),
+    (None, 'SA', None, None),
     (None, None, '2021-09-02T16:00:00+00:00', '2022-01-28T16:00:00+00:00'),
     ('TEST0', 'TEST-SA-00', None, None),
     ('TEST0', None, '2021-09-02T16:00:00+00:00', '2022-01-28T16:00:00+00:00')
 ]
- 
 
 @pytest.mark.parametrize('desc,account_id,result_count,valid', TEST_REG_COUNT_DATA)
 def test_get_account_reg_count(session, desc, account_id, result_count, valid):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16470
                 /bcgov/entity#1663

*Description of changes:*
- 16470 include middle name in registration summary for secured parties, registering parties.
- 16663 allow filtering by partial match on client reference id (folio).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
