### PR TITLE
API unit note caution updates and bug fixes.

### DIFF
--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -9,22 +9,32 @@
     {% for note in detail.notes %}
         <div class="no-page-break">
             <div class="section-title mt-4">{{note.documentDescription}}</div>      
-            <table class="no-page-break section-data details-table mt-4" role="presentation">
+            <table class="no-page-break section-data notes-table mt-4" role="presentation">
                 <tr>
                     <td class="section-sub-title">MHR Number:</td>
                     <td>{{detail.mhrNumber}}</td>
                 </tr>
                 <tr>
-                    <td class="section-sub-title">Document Number:</td>
-                    <td>{{note.documentId}}</td>
+                    <td class="section-sub-title">Document Registration Number:</td>
+                    <td>{{note.documentRegistrationNumber}}</td>
                 </tr>
                 <tr>
-                    <td class="section-sub-title">Registration Date and Time:</td>
+                    <td class="section-sub-title">Document Registration Date and Time:</td>
                     <td>{{note.createDateTime}}</td>
                 </tr>
                 <tr>
+                    <td class="section-sub-title">Effective Date and Time:</td>
+                    <td>
+                        {% if note.effectiveDateTime is defined and note.effectiveDateTime != '' %}
+                            {{note.effectiveDateTime}}
+                        {% else %}
+                            {{note.createDateTime}}
+                        {% endif %}                        
+                    </td>
+                </tr>
+                <tr>
                     <td class="section-sub-title">
-                        {% if note.documentType == 'EXNR' %}Destroyed Date:{% else %}Expired Date:{% endif %}
+                        {% if note.documentType == 'EXNR' %}Destroyed Date:{% else %}Expiry Date:{% endif %}
                     </td>
                     <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
                             {{note.expiryDate}}
@@ -104,5 +114,8 @@
                 </tr>
         </table>
         </div>
+        {% if not loop.last %}
+            <div class="separator mt-4 mb-1"></div>
+        {% endif %}
     {% endfor %}
 {% endif %}

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -509,6 +509,28 @@
 		width: 67%;
 	}
 
+
+	.notes-table {
+		width: 100%;
+		/* table-layout: fixed; */
+		border-collapse: collapse;
+	}
+
+	.notes-table td {
+		vertical-align: top;
+		overflow-wrap: break-word;
+  		word-wrap: break-word;
+	}
+
+	.notes-table td:nth-child(1) {
+		padding-right: 10px;
+		width: 43%;
+	}
+
+	.notes-table td:nth-child(2) {
+		width: 57%;
+	}
+
 	.statement-table {
 		width: 100%;
 		table-layout: fixed;

--- a/mhr_api/report-templates/unitNoteV2.html
+++ b/mhr_api/report-templates/unitNoteV2.html
@@ -46,7 +46,7 @@
       </tr>
       {% if note is defined and note.documentType is defined and note.documentType in ('CAU', 'CAUC', 'CAUE') %}
         <tr>
-            <td>Expiry Date and Time:</td>
+            <td>Expiry Date:</td>
             <td>
                 {% if note.expiryDateTime is defined and note.expiryDateTime != '' %}
                     {{note.expiryDateTime}}

--- a/mhr_api/src/mhr_api/models/db2/document.py
+++ b/mhr_api/src/mhr_api/models/db2/document.py
@@ -40,6 +40,9 @@ class Db2Document(db.Model):
         PERMIT = '103 '
         PERMIT_TRIM = '103'
         PERMIT_EXTENSION = '103E'
+        CAUTION = 'CAU '
+        CONTINUE_CAUTION = 'CAUC'
+        EXTEND_CAUTION = 'CAUE'
 
     __bind_key__ = 'db2'
     __tablename__ = 'document'

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -856,6 +856,7 @@ class Db2Manuhome(db.Model):
         doc.update_id = current_app.config.get('DB2_RACF_ID', '')
         manuhome.reg_documents.append(doc)
         cancel_remarks: str = None
+        cancel_doc_type: str = None
         if new_doc.document_type == MhrDocumentTypes.NCAN and reg_json.get('cancelDocumentId'):
             cancel_doc_id: str = reg_json.get('cancelDocumentId')
             for note in manuhome.reg_notes:
@@ -863,7 +864,20 @@ class Db2Manuhome(db.Model):
                     note.can_document_id = doc.id
                     note.status = Db2Mhomnote.StatusTypes.CANCELLED
                     cancel_remarks = note.remarks
+                    cancel_doc_type = note.document_type
                     break
+            current_app.logger.info(f'$$$ cancel_doc_type=${cancel_doc_type}$')
+            if cancel_doc_type and cancel_doc_type in ('CAU', Db2Document.DocumentTypes.CAUTION,
+                                                       Db2Document.DocumentTypes.CONTINUE_CAUTION,
+                                                       Db2Document.DocumentTypes.EXTEND_CAUTION):
+                for note in manuhome.reg_notes:
+                    current_app.logger.info(f'$$$ checking {note.status} ${note.document_type}$')
+                    if note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
+                            note.document_type in (Db2Document.DocumentTypes.CAUTION,
+                                                   Db2Document.DocumentTypes.CONTINUE_CAUTION,
+                                                   Db2Document.DocumentTypes.EXTEND_CAUTION):
+                        note.can_document_id = doc.id
+                        note.status = Db2Mhomnote.StatusTypes.CANCELLED
         # Add note.
         if reg_json.get('note'):
             reg_note = registration.notes[0]

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -866,12 +866,10 @@ class Db2Manuhome(db.Model):
                     cancel_remarks = note.remarks
                     cancel_doc_type = note.document_type
                     break
-            current_app.logger.info(f'$$$ cancel_doc_type=${cancel_doc_type}$')
             if cancel_doc_type and cancel_doc_type in ('CAU', Db2Document.DocumentTypes.CAUTION,
                                                        Db2Document.DocumentTypes.CONTINUE_CAUTION,
                                                        Db2Document.DocumentTypes.EXTEND_CAUTION):
                 for note in manuhome.reg_notes:
-                    current_app.logger.info(f'$$$ checking {note.status} ${note.document_type}$')
                     if note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
                             note.document_type in (Db2Document.DocumentTypes.CAUTION,
                                                    Db2Document.DocumentTypes.CONTINUE_CAUTION,

--- a/mhr_api/src/mhr_api/models/mhr_note.py
+++ b/mhr_api/src/mhr_api/models/mhr_note.py
@@ -23,6 +23,9 @@ from .db import db
 from .type_tables import MhrDocumentTypes, MhrNoteStatusTypes, MhrPartyTypes, MhrDocumentType
 
 
+REMARKS_CAUC_NO_EXPIRY = 'Continued until further order of the court.'
+
+
 class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
     """This class manages all of the MHR note information."""
 
@@ -171,4 +174,10 @@ class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
             note.expiry_date = model_utils.compute_caution_expiry(note.effective_ts, True)
         elif reg_json.get('expiryDateTime'):
             note.expiry_date = model_utils.expiry_datetime(reg_json['expiryDateTime'])
+        if note.document_type == MhrDocumentTypes.CAUC and not note.expiry_date:
+            if not note.remarks:
+                note.remarks = REMARKS_CAUC_NO_EXPIRY
+            elif note.remarks.lower().find(REMARKS_CAUC_NO_EXPIRY.lower()) < 0:
+                note.remarks += ' ' + REMARKS_CAUC_NO_EXPIRY
+            reg_json['remarks'] = note.remarks
         return note

--- a/mhr_api/src/mhr_api/models/mhr_note.py
+++ b/mhr_api/src/mhr_api/models/mhr_note.py
@@ -168,7 +168,7 @@ class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
         else:
             note.effective_ts = registration_ts
         if note.document_type == MhrDocumentTypes.CAU:  # Compute expiry date.
-            note.expiry_date = model_utils.compute_caution_expiry(note.effective_ts, False)
+            note.expiry_date = model_utils.compute_caution_expiry(note.effective_ts, True)
         elif reg_json.get('expiryDateTime'):
-            note.expiry_date = model_utils.ts_from_iso_format(reg_json['expiryDateTime'])
+            note.expiry_date = model_utils.expiry_datetime(reg_json['expiryDateTime'])
         return note

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -249,9 +249,9 @@ def get_generated_values(registration, draft, user_group: str = None):
         registration.draft_number = str(row[4])
         registration.draft_id = int(row[5])
     if gen_doc_id and not draft:
-        registration.doc_id = str(row[4])
-    elif gen_doc_id and draft:
         registration.doc_id = str(row[6])
+    elif gen_doc_id and draft:
+        registration.doc_id = str(row[4])
     return registration
 
 

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -772,3 +772,15 @@ def compute_caution_expiry(effective_ts, end_of_day: bool = False):
         # Return as UTC
         return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)
     return effective_ts
+
+
+def expiry_datetime(expiry_iso: str):
+    """Set the expiry time to the end of the day."""
+    base_date = date_from_iso_format(expiry_iso)
+    # Naive time
+    expiry_time = time(23, 59, 59, tzinfo=None)
+    expiry_ts = _datetime.combine(base_date, expiry_time)
+    # Explicitly set to local timezone which will adjust for daylight savings.
+    local_ts = LOCAL_TZ.localize(expiry_ts)
+    # Return as UTC
+    return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -529,7 +529,7 @@ class Report:  # pylint: disable=too-few-public-methods
             if note.get('expiryDateTime') and str(note['expiryDateTime']).startswith('0001-01-01'):
                 note['expiryDateTime'] = ''
             elif note.get('expiryDateTime'):
-                note['expiryDateTime'] = Report._to_report_datetime(note.get('expiryDateTime'))
+                note['expiryDateTime'] = Report._to_report_datetime(note.get('expiryDateTime'), False)
             if note.get('effectiveDateTime'):
                 note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'))
             if note.get('givingNoticeParty') and note['givingNoticeParty'].get('phoneNumber'):

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.4.3'  # pylint: disable=invalid-name
+__version__ = '1.4.4'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_location.py
+++ b/mhr_api/tests/unit/models/db2/test_location.py
@@ -76,6 +76,12 @@ TEST_DATA_LTSA_PID = [
     (True, 7284, 'REG01020', False),
     (True, 7282, 'REG01019', True)
 ]
+# testdata pattern is ({manhomid}, {street}, {city}, {region}, {country})
+TEST_ADDRESS_DATA_FIND = [
+    (107725, '3737 PALM HARBOR DRIVE', 'MILLERSBURG', 'OR', 'US'),
+    (26, '3120 NORTH ISLAND HIGHWAY', 'CAMPBELL RIVER', 'BC', 'CA'),
+    (87950, '13455 FORT ROAD', 'EDMONTON', 'AB', 'CA')
+]
 
 
 @pytest.mark.parametrize('exists,manuhome_id,park_name,pad,street_num,street,city,count', TEST_DATA)
@@ -159,6 +165,19 @@ def test_find_by_manuhome_id_active(session, exists, manuhome_id, park_name, pad
         assert reg_json['address']['postalCode'] is not None
     else:
         assert not location
+
+
+@pytest.mark.parametrize('manuhome_id,street,city,region,country', TEST_ADDRESS_DATA_FIND)
+def test_find_address(session, manuhome_id, street, city, region, country):
+    """Assert that find a location address json contains all expected elements."""
+    location: Db2Location = Db2Location.find_by_manuhome_id_active(manuhome_id)
+    assert location
+    loc_json = location.registration_json
+    assert loc_json.get('address')
+    assert loc_json['address'].get('city') == city
+    assert loc_json['address'].get('street') == street
+    assert loc_json['address'].get('region') == region
+    assert loc_json['address'].get('country') == country
 
 
 @pytest.mark.parametrize('exists,manuhome_id,doc_id', TEST_DATA_DOC_ID)

--- a/mhr_api/tests/unit/utils/test_note_validator.py
+++ b/mhr_api/tests/unit/utils/test_note_validator.py
@@ -114,7 +114,7 @@ TEST_NOTE_DATA_EXPIRY = [
     ('Invalid past', False, 'CAUE', -30, '080104', 'ppr_staff', validator.EXPIRY_PAST),
     ('Invalid required', False, 'CAUE', None, '080104', 'ppr_staff', validator.EXPIRY_REQUIRED),
     ('Invalid before current', False, 'CAUE', +1, '080104', 'ppr_staff', validator.EXPIRY_BEFORE_CURRENT),
-    ('Invalid expiry elapsed', False, 'CAUE', +1, '046315', 'ppr_staff', validator.EXPIRY_CURRENT_EXPIRED)
+    ('Valid expiry elapsed', True, 'CAUE', +1, '046315', 'ppr_staff', None)
 ]
 # test data pattern is ({description}, {valid}, {doc_type}, {remarks}, {mhr_num}, {account}, {message_content})
 TEST_NOTE_DATA_REMARKS = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16831
                  /bcgov/entity/#16832
                 /bcgov/entity/16910

*Description of changes:*
- Minor unit note registration and search unit note section report updates.
- Caution unit note rule updates:
	Expiry end of day
	CAUC and CAUE can be created after a CAU has expired.
	Multiple active CAU registrations are allowed.
	Cancelling a CAU/CAUC/CAUE cancels all active CAU/CAUC/CAUE registrations.
- Bug fix on saving manufacturer MHREG with a draft.
- 16910 bug fix non-Canada location province codes in search showing country of Canada.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
