### PR TITLE
Updates draft parsing and validation reset

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -239,11 +239,6 @@ export const useNewMhrRegistration = () => {
   const parseDescription = (): MhrRegistrationDescriptionIF => {
     let description: MhrRegistrationDescriptionIF = getMhrRegistrationHomeDescription.value
 
-    // Apply default manufacturer
-    if (!description.manufacturer) {
-      description.manufacturer = '*'
-    }
-
     description = cleanEmpty(description)
     description.sections = Object.values(description.sections)
     description.sectionCount = description.sections.length

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, onMounted, reactive, toRefs } from 'vue-demi'
+import { computed, defineComponent, nextTick, onMounted, onUnmounted, reactive, toRefs } from 'vue-demi'
 import { useRoute, useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
@@ -202,6 +202,12 @@ export default defineComponent({
 
       context.emit('emitHaveData', true)
       localState.dataLoaded = true
+    })
+
+    // Ensures validations state does not presist, between different MHR registrations
+    // and for authorization and staff payment
+    onUnmounted(() => {
+      resetAllValidations()
     })
 
     const submit = async () => {

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, onMounted, onUnmounted, reactive, toRefs } from 'vue-demi'
+import { computed, defineComponent, nextTick, onMounted, reactive, toRefs } from 'vue-demi'
 import { useRoute, useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
@@ -191,8 +191,7 @@ export default defineComponent({
 
       // Reset validations
       setMhrTransferType(null)
-      setValidation(MhrSectVal.REVIEW_CONFIRM_VALID, MhrCompVal.VALIDATE_STEPS, false)
-      setValidation(MhrSectVal.REVIEW_CONFIRM_VALID, MhrCompVal.VALIDATE_APP, false)
+      resetAllValidations()
 
       // page is ready to view
       if (getMhrDraftNumber.value) {
@@ -202,12 +201,6 @@ export default defineComponent({
 
       context.emit('emitHaveData', true)
       localState.dataLoaded = true
-    })
-
-    // Ensures validations state does not presist, between different MHR registrations
-    // and for authorization and staff payment
-    onUnmounted(() => {
-      resetAllValidations()
     })
 
     const submit = async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16443

*Description of changes:*
- Resets validation when `MhrRegistration` component mounts to avoid unwanted state maintained between drafts/registrations.
- Removes unnecessary '*' from being set when saving a draft. (Confirmed with designers that this is unwanted)

*screenshots:*
Before: 

* Save a draft with the form fully completed (including authorization) and then resume the draft
* Authorization not selected but I can complete the draft.
![image](https://github.com/bcgov/ppr/assets/77707952/47358d5a-42dc-48f3-b4a2-02583c32244c)
![image](https://github.com/bcgov/ppr/assets/77707952/7cdd8410-e839-4ea9-a1e3-49bb384bf74f)

After:
* Save a draft with the form fully completed and then resume the draft:
* Can not complete draft must select authorization
![image](https://github.com/bcgov/ppr/assets/77707952/d21a8f76-629d-4217-80fb-67a5f3111a4a)
![image](https://github.com/bcgov/ppr/assets/77707952/aec10728-316b-4632-b4a4-866e99056598)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
