### PR TITLE
Updates-Scroll-To-Invalid-For-Mhr-Registration

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.21",
+      "version": "2.0.22",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
@@ -51,7 +51,7 @@ export const useMhrValidations = (validationState: any) => {
 
     // Find the _first_ corresponding Section that is invalid in the specified view
     const view = document.getElementById(viewId)
-    const invalidComponent = view.getElementsByTagName('section')[flagBlockArr.indexOf(false)]
+    const invalidComponent = view?.getElementsByTagName('section')[flagBlockArr.indexOf(false)]
 
     // If there is an invalid component, scroll to it
     if (invalidComponent) {
@@ -70,7 +70,7 @@ export const useMhrValidations = (validationState: any) => {
   const scrollToInvalidReviewConfirm = (stepsValidation: Array<boolean>): boolean => {
     // Find the _first_ corresponding step that is invalid in the specified view
     const view = document.getElementById('mhr-review-confirm')
-    const invalidStep = view.getElementsByTagName('header')[stepsValidation.indexOf(false)]
+    const invalidStep = view?.getElementsByTagName('header')[stepsValidation.indexOf(false)]
 
     // If there is an invalid step, scroll to its header
     if (invalidStep) {

--- a/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrValidations.ts
@@ -44,28 +44,44 @@ export const useMhrValidations = (validationState: any) => {
   }
 
   /** Scroll to first SECTION tag that is invalid in specified flag block. */
-  const scrollToInvalid =
-    async (flagSection: MhrSectVal, viewId: string, optionalFlags: Array<boolean> = null): Promise<boolean> => {
-      // Create an array of the _ordered_ validation flags
-      const flagBlockArr = Object.keys(validationState[flagSection].value)
-        .map(key => validationState[flagSection].value[key])
+  const scrollToInvalid = (flagSection: MhrSectVal, viewId: string): boolean => {
+    // Create an array of the _ordered_ validation flags
+    const flagBlockArr = Object.keys(validationState[flagSection].value)
+      .map(key => validationState[flagSection].value[key])
 
-      // Prepend optional flags to array (ie for review pages)
-      if (optionalFlags) flagBlockArr.unshift(...optionalFlags)
+    // Find the _first_ corresponding Section that is invalid in the specified view
+    const view = document.getElementById(viewId)
+    const invalidComponent = view.getElementsByTagName('section')[flagBlockArr.indexOf(false)]
 
-      // Find the _first_ corresponding Section that is invalid in the specified view
-      const view = document.getElementById(viewId)
-      const invalidComponent = view.getElementsByTagName('section')[flagBlockArr.indexOf(false)]
-
-      // If there is an invalid component, scroll to it
-      if (invalidComponent) {
-        setTimeout(() => {
-          invalidComponent.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
-        }, 500)
-        return false
-      }
-      return true
+    // If there is an invalid component, scroll to it
+    if (invalidComponent) {
+      setTimeout(() => {
+        invalidComponent.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
+      }, 500)
+      return false
     }
+    return true
+  }
+
+  /** Scroll to first HEADER of invalid step in the view.
+   *  If all steps are valid scroll to first Section that is invalid
+   *  in the specified section area.
+   */
+  const scrollToInvalidReviewConfirm = (stepsValidation: Array<boolean>): boolean => {
+    // Find the _first_ corresponding step that is invalid in the specified view
+    const view = document.getElementById('mhr-review-confirm')
+    const invalidStep = view.getElementsByTagName('header')[stepsValidation.indexOf(false)]
+
+    // If there is an invalid step, scroll to its header
+    if (invalidStep) {
+      setTimeout(() => {
+        invalidStep.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
+      }, 500)
+      return false
+    }
+
+    return scrollToInvalid(MhrSectVal.REVIEW_CONFIRM_VALID, 'mhr-review-confirm-components')
+  }
 
   return {
     MhrCompVal,
@@ -76,6 +92,7 @@ export const useMhrValidations = (validationState: any) => {
     getSectionValidation,
     getStepValidation,
     resetAllValidations,
-    scrollToInvalid
+    scrollToInvalid,
+    scrollToInvalidReviewConfirm
   }
 }

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -46,7 +46,6 @@
           :currentStepName="$route.name"
           :router="$router"
           :forceSave="saveDraftExit"
-          @registration-incomplete="registrationIncomplete()"
           @error="emitError($event)"
           @submit="submit()"
           @cancelProceed="resetAllValidations()"
@@ -120,7 +119,7 @@ export default defineComponent({
       setValidation,
       getValidation,
       resetAllValidations,
-      scrollToInvalid
+      scrollToInvalidReviewConfirm
     } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
 
     const {
@@ -158,11 +157,6 @@ export default defineComponent({
     /** Helper to check is the current route matches */
     const isRouteName = (routeName: RouteNames): boolean => {
       return (route.name === routeName)
-    }
-
-    const registrationIncomplete = (): void => {
-      scrollToInvalid(MhrSectVal.REVIEW_CONFIRM_VALID, 'mhr-review-confirm')
-      setValidation(MhrSectVal.REVIEW_CONFIRM_VALID, MhrCompVal.VALIDATE_APP, true)
     }
 
     const emitError = (error: ErrorIF): void => {
@@ -231,7 +225,7 @@ export default defineComponent({
       } else {
         let stepsValidation = getSteps.value.map((step : StepIF) => step.valid)
         stepsValidation.pop() // Removes review confirm step from stepsValidation
-        await scrollToInvalid(MhrSectVal.REVIEW_CONFIRM_VALID, 'mhr-review-confirm', stepsValidation)
+        scrollToInvalidReviewConfirm(stepsValidation)
       }
     }
 
@@ -239,7 +233,6 @@ export default defineComponent({
       getSteps,
       emitError,
       isRouteName,
-      registrationIncomplete,
       submit,
       resetAllValidations,
       ...toRefs(localState)

--- a/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
@@ -1,94 +1,94 @@
 <template>
-  <div id="mhr-review-confirm">
+  <div id="mhr-review-confirm" class="mt-10">
     <!-- Review and Confirm -->
-    <div class="mt-10">
-      <h2>Review and Confirm</h2>
-      <p class="mt-4">
-        Review the information in your registration and complete the additional information below. If you need to
-        change anything, return to the previous step to make the necessary change.
+    <h2>Review and Confirm</h2>
+    <p class="mt-4">
+      Review the information in your registration and complete the additional information below. If you need to
+      change anything, return to the previous step to make the necessary change.
+    </p>
+
+    <!-- Information for manufacturers registration only -->
+    <template v-if="isMhrManufacturerRegistration">
+
+      <p class="mt-3 mb-6">
+        <b>Note: </b>
+        Submitting Party, Home Owner and Location of Home information is based on your manufacturer information
+        and cannot be changed here. If you wish to update this information please contact BC Registries.
       </p>
 
-      <!-- Information for manufacturers registration only -->
-      <template v-if="isMhrManufacturerRegistration">
+      <ContactUsToggle
+        helpText="If you require assistance with changes to your manufacturer information please contact us."
+      />
 
-        <p class="mt-3 mb-6">
-          <b>Note: </b>
-          Submitting Party, Home Owner and Location of Home information is based on your manufacturer information
-          and cannot be changed here. If you wish to update this information please contact BC Registries.
-        </p>
+      <CautionBox
+        setMsg="After registering, the verification statement and decals will be sent to the Submitting Party."
+      />
 
-        <ContactUsToggle
-          helpText="If you require assistance with changes to your manufacturer information please contact us."
-        />
-
-        <CautionBox
-          setMsg="After registering, the verification statement and decals will be sent to the Submitting Party."
-        />
-
-      </template>
-
-      <!-- Your Home Summary -->
-      <YourHomeReview />
-
-      <!-- Submitting Party Review -->
-      <SubmittingPartyReview />
-
-      <!-- Home Owners Review -->
-      <HomeOwnersReview />
-
-      <!-- Home Location Review -->
-      <HomeLocationReview />
-    </div>
-
-    <template  v-if="isMhrManufacturerRegistration">
-      <!-- Attention -->
-      <section id="mhr-attention" class="mt-15">
-        <Attention
-          sectionId="mhr-attention"
-          :sectionNumber="1"
-          :validate="isValidatingApp"
-          @isAttentionValid="setAttentionValidation"
-        />
-      </section>
-
-      <!-- Folio or Reference Number -->
-      <section id="mhr-folio-or-reference-number" class="mt-15">
-        <FolioOrReferenceNumber
-          sectionId="mhr-folio-or-reference-number"
-          :sectionNumber="2"
-          :validate="isValidatingApp"
-          @isFolioOrRefNumValid="setFolioOrReferenceNumberValidation"
-        />
-      </section>
     </template>
 
-    <!-- Authorization -->
-    <section id="mhr-certify-section" class="mt-15">
-      <CertifyInformation
-        :sectionNumber="isMhrManufacturerRegistration ? 3 : 1"
-        :setShowErrors="validateAuthorization"
-        @certifyValid="authorizationValid = $event"
-      />
-    </section>
+    <!-- Your Home Summary -->
+    <YourHomeReview />
 
-    <!-- Staff Payment -->
-    <section id="mhr-staff-payment-section" class="mt-15" v-if="isRoleStaffReg">
-      <h2>
-        2. Staff Payment
-      </h2>
-      <v-card flat class="mt-6 pa-6" :class="{ 'border-error-left': validateStaffPayment }">
-        <StaffPayment
-          id="staff-payment"
-          :displaySideLabel="true"
-          :displayPriorityCheckbox="true"
-          :staffPaymentData="staffPayment"
-          :invalidSection="validateStaffPayment"
-          :validate="hasStaffPaymentValues || isValidatingApp"
-          @update:staffPaymentData="onStaffPaymentDataUpdate($event)"
-          @valid="staffPaymentValid = $event"
+    <!-- Submitting Party Review -->
+    <SubmittingPartyReview />
+
+    <!-- Home Owners Review -->
+    <HomeOwnersReview />
+
+    <!-- Home Location Review -->
+    <HomeLocationReview />
+
+    <div id="mhr-review-confirm-components">
+      <template  v-if="isMhrManufacturerRegistration">
+        <!-- Attention -->
+        <section id="mhr-attention" class="mt-15">
+          <Attention
+            sectionId="mhr-attention"
+            :sectionNumber="1"
+            :validate="isValidatingApp"
+            @isAttentionValid="setAttentionValidation"
+          />
+        </section>
+
+        <!-- Folio or Reference Number -->
+        <section id="mhr-folio-or-reference-number" class="mt-15">
+          <FolioOrReferenceNumber
+            sectionId="mhr-folio-or-reference-number"
+            :sectionNumber="2"
+            :validate="isValidatingApp"
+            @isFolioOrRefNumValid="setFolioOrReferenceNumberValidation"
+          />
+        </section>
+      </template>
+
+      <!-- Authorization -->
+      <section id="mhr-certify-section" class="mt-15">
+        <CertifyInformation
+          :sectionNumber="isMhrManufacturerRegistration ? 3 : 1"
+          :setShowErrors="validateAuthorization"
+          @certifyValid="authorizationValid = $event"
         />
-      </v-card>
-    </section>
+      </section>
+
+      <!-- Staff Payment -->
+      <section id="mhr-staff-payment-section" class="mt-15" v-if="isRoleStaffReg">
+        <h2>
+          2. Staff Payment
+        </h2>
+        <v-card flat class="mt-6 pa-6" :class="{ 'border-error-left': validateStaffPayment }">
+          <StaffPayment
+            id="staff-payment"
+            :displaySideLabel="true"
+            :displayPriorityCheckbox="true"
+            :staffPaymentData="staffPayment"
+            :invalidSection="validateStaffPayment"
+            :validate="hasStaffPaymentValues || isValidatingApp"
+            @update:staffPaymentData="onStaffPaymentDataUpdate($event)"
+            @valid="staffPaymentValid = $event"
+          />
+        </v-card>
+      </section>
+    </div>
   </div>
 </template>
 
@@ -145,6 +145,7 @@ export default defineComponent({
       MhrSectVal,
       setValidation,
       scrollToInvalid,
+      scrollToInvalidReviewConfirm,
       getValidation,
     } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
 
@@ -275,7 +276,7 @@ export default defineComponent({
           let stepsValidation = getSteps.value.map((step : StepIF) => step.valid)
           stepsValidation.pop() // Removes review confirm step from stepsValidation
           localState.isValidatingApp &&
-          scrollToInvalid(MhrSectVal.REVIEW_CONFIRM_VALID, 'mhr-review-confirm', stepsValidation)
+          scrollToInvalidReviewConfirm(stepsValidation)
           // Only set reviewed if add/edit form was open when review reached
           if (isGlobalEditingMode.value) {
             setValidation(MhrSectVal.ADD_EDIT_OWNERS_VALID, MhrCompVal.OWNERS_VALID, false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16877

*Description of changes:*
- Made a separate scroll to invalid function to account for the uniqueness of the review and confirm page.

*Note for reviewers:*
A lot of the spacing changes are from removing an unnecessary div.

To make it easier to review you can hide whitespaces:
![image](https://github.com/bcgov/ppr/assets/77707952/40110f2c-a11a-483d-8d8c-85514b52d6d0)

I don't believe that `@registration-incomplete="registrationIncomplete()"`  is needed since we are intercepting the section that could ultimately lead to that value being emitted. If you need further details please reach out via rocketChat, as it will take me awhile to explain. 

I think, we should clean up the `ButtonFooter` component a bit to remove some unnecessary logic, and make things easier to think through, but ill leave that to future discussions.

*screenshots:*

---
Before PR:

View after scroll to review and confirm components:

Authorization:
![Before-Authorization](https://github.com/bcgov/ppr/assets/77707952/02889243-bf7c-4d07-a60b-904c683366f5)

Staff payments:
![before-staff-payment](https://github.com/bcgov/ppr/assets/77707952/d7fa0df1-b2d5-4e0f-b1d6-eba34e6e392a)

---

After PR:

View after scroll to review and confirm components:

Authorization:
![Authorization](https://github.com/bcgov/ppr/assets/77707952/fae1249a-9d93-46e5-943f-40fcf6b3b026)

Staff-payment:
![StaffPayment](https://github.com/bcgov/ppr/assets/77707952/a7b6a355-38fb-4aa8-b6ac-04c7f790f887)


View after scroll to steps:
Your Home:
![YourHome](https://github.com/bcgov/ppr/assets/77707952/54a12261-0d2f-4303-afb1-198de2cf623f)

Submitting Party:
![SubmittingParty](https://github.com/bcgov/ppr/assets/77707952/a6039d2c-5623-4106-8b78-67142ec644be)

HomeOwners:
![HomeOwners](https://github.com/bcgov/ppr/assets/77707952/65f7ac74-5565-4fbb-895d-7a3fb2819cde)

Location of Home:
![Location of Home](https://github.com/bcgov/ppr/assets/77707952/0d1315f6-0391-4553-ba50-07304a97b7c6)
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
