### PR TITLE
Uses deep watcher to fix table scrolling issue

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
+++ b/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
@@ -47,7 +47,7 @@
         </template>
         <template v-else>
           <v-list-item-content class="py-3 registration-list">
-            <span class="registration-list-item" v-html="`${parent.genFilteredText(item.text)}`"></span>
+            <span class="registration-list-item" v-html="item.text"></span>
           </v-list-item-content>
         </template>
       </template>

--- a/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
+++ b/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
@@ -25,7 +25,7 @@
       :clearable="isClearable"
       @keypress="showAllGroups()"
     >
-      <template v-slot:item="{ parent, item }">
+      <template v-slot:item="{ item }">
         <template v-if="item.class === 'registration-list-header'">
           <v-list-item-content>
             <v-row

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -693,19 +693,24 @@ export default defineComponent({
       if (!localState.firstColRef || val < 350) localState.overrideWidth = false
     })
 
+    // Triggers scrolling on changes to the registration history
+    watch(() => props.setRegistrationHistory,
+      () => {
+        if (localState.newReg?.addedReg) {
+          // need both (only one ref will scroll)
+          scrollToRef(newRegItem)
+          scrollToRef(newAndFirstItem)
+        }
+      },
+      { deep: true }
+    )
+
     onUpdated(() => {
       // needed to set overrideWidth to true
       if (localState.firstColRef?.value?.length > 0) {
         if (localState.firstColRef.value[0].clientWidth > 350) {
           localState.overrideWidth = true
         }
-      }
-
-      // if new reg -> scroll to new reg
-      if (localState.newReg?.addedReg) {
-        // need both (only one ref will scroll)
-        scrollToRef(newRegItem)
-        scrollToRef(newAndFirstItem)
       }
     })
 


### PR DESCRIPTION
*Issue #:
* bcgov/entity#16887
* bcgov/entity#16961

*Description of changes:*
* Changed to deep watcher as onUpdate does not trigger reliably
* Fixed bag in type bar ahead list

*Side note:*
* Cameron stated we might revisit this during the upcoming vue 3 upgrade, because of changes in life cycle hooks.

*Screenshots:*
![image](https://github.com/bcgov/ppr/assets/77707952/7c7beb23-622f-45bb-aef8-24dde530c45a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
