### PR TITLE
NCAN update DB2 saving and JSON.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -20,6 +20,7 @@ from flask import current_app
 from mhr_api.exceptions import BusinessException, DatabaseException, ResourceErrorCodes
 from mhr_api.models import utils as model_utils
 from mhr_api.models.type_tables import MhrTenancyTypes, MhrPartyTypes, MhrRegistrationTypes, MhrDocumentTypes
+from mhr_api.models.type_tables import MhrNoteStatusTypes
 from mhr_api.models import db
 
 from .descript import Db2Descript
@@ -545,7 +546,7 @@ class Db2Manuhome(db.Model):
             notes.append(note_json)
         # Add any NCAN registration using the cancelled note as a base.
         for doc in self.reg_documents:
-            if doc.document_type == MhrDocumentTypes.NCAN:
+            if doc.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED):
                 for note in self.reg_notes:
                     if doc.id == note.can_document_id:
                         cancel_json = note.registration_json
@@ -555,7 +556,7 @@ class Db2Manuhome(db.Model):
                             'documentType': doc.document_type.strip(),
                             'documentId': doc.id,
                             'documentRegistrationNumber': doc.document_reg_id,
-                            'status': Db2Mhomnote.StatusTypes.ACTIVE,
+                            'status': MhrNoteStatusTypes.ACTIVE.value,
                             'createDateTime':  model_utils.format_local_ts(doc.registration_ts),
                             'remarks': cancel_json.get('remarks'),
                             'givingNoticeParty': cancel_json.get('givingNoticeParty')

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -790,7 +790,7 @@ def get_search_json(registration):
                     note['remarks'] != 'MANUFACTURED HOME REGISTRATION CANCELLED':
                 # Only staff can see remarks if not default.
                 note['remarks'] = 'MANUFACTURED HOME REGISTRATION CANCELLED'
-            elif doc_type in ('TAXN', 'EXNR', 'NPUB', 'REST', 'CAU', 'CAUC', 'CAUE') and \
+            elif doc_type in ('TAXN', 'EXNR', 'EXRS', 'NPUB', 'REST', 'CAU', 'CAUC', 'CAUE') and \
                     note.get('status') != MhrNoteStatusTypes.ACTIVE:  # Exclude if not active.
                 include = False
             elif doc_type in ('CAU', 'CAUC', 'CAUE') and note.get('expiryDateTime') and \

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -881,6 +881,6 @@ def update_note_json(registration, note_json: dict) -> dict:
                     note_json['expiryDateTime'] = model_utils.format_ts(note.expiry_date)
                 if note.effective_ts:
                     note_json['effectiveDateTime'] = model_utils.format_ts(note.effective_ts)
-                if note.document_type == MhrDocumentTypes.NCAN:
+                if note.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED):
                     note_json['remarks'] = note.remarks
     return note_json

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -790,7 +790,7 @@ def get_search_json(registration):
                     note['remarks'] != 'MANUFACTURED HOME REGISTRATION CANCELLED':
                 # Only staff can see remarks if not default.
                 note['remarks'] = 'MANUFACTURED HOME REGISTRATION CANCELLED'
-            elif doc_type in ('TAXN', 'EXNR', 'NPUB', 'REST') and \
+            elif doc_type in ('TAXN', 'EXNR', 'NPUB', 'REST', 'CAU', 'CAUC', 'CAUE') and \
                     note.get('status') != MhrNoteStatusTypes.ACTIVE:  # Exclude if not active.
                 include = False
             elif doc_type in ('CAU', 'CAUC', 'CAUE') and note.get('expiryDateTime') and \
@@ -843,6 +843,7 @@ def get_new_registration_json(registration):
             note['documentDescription'] = get_doc_desc(note_doc_type)
             if note.get('cancelledDocumentType'):
                 note['cancelledDocumentDescription'] = get_doc_desc(note.get('cancelledDocumentType'))
+            note = update_note_json(registration, note)
     current_app.logger.debug('Built JSON from DB2 and PostgreSQL')
     return registration.set_payment_json(reg_json)
 
@@ -880,4 +881,6 @@ def update_note_json(registration, note_json: dict) -> dict:
                     note_json['expiryDateTime'] = model_utils.format_ts(note.expiry_date)
                 if note.effective_ts:
                     note_json['effectiveDateTime'] = model_utils.format_ts(note.effective_ts)
+                if note.document_type == MhrDocumentTypes.NCAN:
+                    note_json['remarks'] = note.remarks
     return note_json

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -187,9 +187,9 @@ def get_registrations(mhr_number: str):  # pylint: disable=too-many-return-state
         # Try to fetch MH registration by MHR number
         # Not found or not in the account list throw exceptions.
         if current_param:
-            registration = MhrRegistration.find_by_mhr_number(mhr_number,
-                                                              account_id,
-                                                              is_all_staff_account(account_id))
+            registration = MhrRegistration.find_all_by_mhr_number(mhr_number,
+                                                                  account_id,
+                                                                  is_all_staff_account(account_id))
             registration.current_view = True
             registration.staff = is_staff(jwt)
         else:

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -94,7 +94,8 @@ TEST_QUERY_FILTER_DATA_MULTIPLE = [
 TEST_MHR_NUM_DATA_NOTE = [
     ('080282', True, True, True, None, False),
     ('003936', True, True, False, None, False),
-    ('092238', True, True, True, '63116143', True)
+    ('092238', True, True, True, '63116143', True),
+    ('022873', True, True, True, '43599221', True)
 ]
 
 
@@ -357,7 +358,8 @@ def test_get_new_reg_json_note(session, mhr_num, staff, current, has_notes, ncan
     if has_notes:
         assert reg_json.get('notes')
         has_ncan: bool = False
-        for note in reg_json.get('notes'):
+        for note in reg_json['notes']:
+            current_app.logger.info(note)
             assert note.get('documentRegistrationNumber')
             assert note.get('documentId')
             assert note.get('documentDescription')
@@ -370,8 +372,8 @@ def test_get_new_reg_json_note(session, mhr_num, staff, current, has_notes, ncan
             assert note.get('status')
             assert 'remarks' in note
             assert note.get('givingNoticeParty')
-            if ncan_doc_id:
-                assert has_ncan
+        if ncan_doc_id:
+            assert has_ncan
     elif staff and current:
         assert 'notes' in reg_json
         assert not reg_json.get('notes')
@@ -401,7 +403,7 @@ def test_get_search_json_note(session, mhr_num, staff, current, has_notes, ncan_
             assert note.get('status')
             assert 'remarks' in note
             assert note.get('givingNoticeParty')
-            if ncan_doc_id:
-                assert has_ncan
+        if ncan_doc_id:
+            assert has_ncan
     else:
         assert not reg_json.get('notes')

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -147,6 +147,7 @@ TEST_DATA_NOTE = [
 TEST_MHR_NUM_DATA_NOTE = [
     ('080282', True, True, True, None),
     ('092238', True, True, True, '63116143'),
+    ('022873', True, True, True, '43599221'),
     ('003936', True, True, False, None),
     ('003936', True, False, False, None),
     ('003936', False, True, False, None)

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -482,7 +482,8 @@ TEST_MHR_NUM_DATA_NOTE = [
     ('035159', True, True, True, 'ppr_staff', True, None),
     ('080104', True, True, True, 'ppr_staff', True, None),
     ('046315', True, True, True, 'ppr_staff', False, None),
-    ('092238', True, True, True, 'ppr_staff', False, '63116143')
+    ('092238', True, True, True, 'ppr_staff', False, '63116143'),
+    ('022873', True, True, True, 'ppr_staff', False, '43599221')
 ]
 
 

--- a/mhr_api/tests/unit/models/test_search_result.py
+++ b/mhr_api/tests/unit/models/test_search_result.py
@@ -211,7 +211,7 @@ TEST_SELECT_SORT_DATA_IND = [
 TEST_MHR_NUM_DATA_NOTE = [
     ('080282', False, None),
     ('092238', True, '63116143'),
-    ('022873', True, None)
+    ('022873', True, '43599221')
 ]
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16958

*Description of changes:*
- Do not save DB2 unit note records with NCAN, NRED registrations.
- Update search unit notes to include NCAN, NRED registrations.
- Update search unit notes to use modernized notes if available.
- Update MH registration current view to include NCAN, NRED registrations and use PostgreSQL note if available.
- Exclude cancelled EXRS regitrations from the search report unit notes and do not display an exemption message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
