### PR TITLE
Small Fix for year to display after resuming draft

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/YourHome/ManufacturedYearSelect.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/ManufacturedYearSelect.vue
@@ -78,7 +78,7 @@ export default defineComponent({
       yearOfManufacture: getMhrRegistrationYearOfManufacture?.value
     })
 
-    watch(() => localState.yearOfManufacture, (val: string) => {
+    watch(() => localState.yearOfManufacture, (val: number) => {
       setMhrHomeBaseInformation({ key: 'year', value: val })
     })
 

--- a/ppr-ui/src/components/mhrRegistration/YourHome/ManufacturedYearSelect.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/ManufacturedYearSelect.vue
@@ -75,13 +75,11 @@ export default defineComponent({
 
     const localState = reactive({
       currentYear: new Date().getFullYear(),
-      yearOfManufacture: getMhrRegistrationYearOfManufacture.value?.toString()
+      yearOfManufacture: getMhrRegistrationYearOfManufacture?.value
     })
 
     watch(() => localState.yearOfManufacture, (val: string) => {
-      if (parseInt(val)) {
-        setMhrHomeBaseInformation({ key: 'year', value: parseInt(val) })
-      }
+      setMhrHomeBaseInformation({ key: 'year', value: val })
     })
 
     return {

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, onMounted, reactive, toRefs } from 'vue-demi'
+import { computed, defineComponent, nextTick, onMounted, onUnmounted, reactive, toRefs } from 'vue-demi'
 import { useRoute, useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
@@ -195,6 +195,12 @@ export default defineComponent({
 
       context.emit('emitHaveData', true)
       localState.dataLoaded = true
+    })
+
+    // Ensures validations state does not presist, between different MHR registrations
+    // and for authorization and staff payment
+    onUnmounted(() => {
+      resetAllValidations()
     })
 
     const submit = async () => {

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, onMounted, onUnmounted, reactive, toRefs } from 'vue-demi'
+import { computed, defineComponent, nextTick, onMounted, reactive, toRefs } from 'vue-demi'
 import { useRoute, useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
@@ -195,12 +195,6 @@ export default defineComponent({
 
       context.emit('emitHaveData', true)
       localState.dataLoaded = true
-    })
-
-    // Ensures validations state does not presist, between different MHR registrations
-    // and for authorization and staff payment
-    onUnmounted(() => {
-      resetAllValidations()
     })
 
     const submit = async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16443

*Description of changes:*
* Removed parsing to string, and converting to number when setting as it is not needed for the select.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
