### PR TITLE
Fix Home Owners styling on Safari

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -990,6 +990,9 @@ export default defineComponent({
     }
 
     .owner-info {
+      width: 100%;
+      display: block;
+
       td {
         white-space: normal;
         vertical-align: top;


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16795

*Description of changes:*
- Home Owners table was not showing up properly on Safari, so this fixes the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
