### PR TITLE
Mixed Home Owners error for all Transfers

### DIFF
--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -140,6 +140,10 @@ p {
   text-align: right !important;
 }
 
+.d-block {
+  display: block;
+}
+
 // dialog styles
 .dialog-btn {
   box-shadow: none;

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersMixedRolesError.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersMixedRolesError.vue
@@ -1,18 +1,11 @@
 <template>
       <td
-        class="py-1"
+        class="py-6 error-text text-center d-block"
         :class="{ 'border-error-left': showBorderError }"
         :colspan="4"
-        data-test-id="invalid-group-mixed-owners"
+        :data-test-id="`mixed-owners-msg-group-${groupId}`"
         >
-          <div
-          class="error-text my-6 text-center"
-          :data-test-id="`mixed-owners-msg-group-${groupId}`"
-          >
-            <span>
-            {{ mixedRoleErrorMsg }}
-            </span>
-          </div>
+          {{ mixedRoleErrorMsg }}
       </td>
 </template>
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -80,7 +80,10 @@
                 </div>
               </div>
 
-              <tr v-else-if="!isMhrTransfer && index === 0 && hasMixedOwnersInGroup(item.groupId) && !isReadonlyTable">
+              <tr v-else-if="!isMhrTransfer && index === 0 && hasMixedOwnersInGroup(item.groupId) && !isReadonlyTable"
+                class="d-block"
+              >
+                <!-- Mixed owners error for Registrations -->
                 <HomeOwnersMixedRolesError
                   :groupId="item.groupId"
                   :showBorderError="isInvalidOwnerGroup(item.groupId)"
@@ -394,10 +397,12 @@
               <tr v-else-if="isRemovedHomeOwner(item) &&
                 showSupportingDocuments() &&
                 !isReadonlyTable &&
-                isPartyTypeNotEAT(item)">
+                isPartyTypeNotEAT(item)"
+                class="d-block"
+              >
                 <td
                   :colspan="homeOwnersTableHeaders.length"
-                  class="pl-14"
+                  class="pl-14 d-block"
                   :class="{ 'border-error-left': isInvalidOwnerGroup(group.groupId) }"
                 >
                   <v-expand-transition>
@@ -619,7 +624,8 @@ export default defineComponent({
     const isInvalidOwnerGroup = (groupId: number): boolean => {
       if (!props.isMhrTransfer) return isInvalidRegistrationOwnerGroup(groupId)
       if (!props.validateTransfer) return false
-      if (isTransferDueToSaleOrGift.value) return TransSaleOrGift.hasMixedOwnersInGroup(groupId)
+      // check mixed owners in for all transfer types
+      if (TransSaleOrGift.hasMixedOwnersInGroup(groupId)) return true
 
       if ((isTransferToExecutorProbateWill.value ||
         isTransferToExecutorUnder25Will.value ||
@@ -750,6 +756,7 @@ export default defineComponent({
         return (
           (TransToExec.hasSomeOwnersRemoved(groupId) || hasAddedRoleInGroup) &&
           !(hasAddedRoleInGroup &&
+            !TransSaleOrGift.hasMixedOwnersInGroup(groupId) &&
             TransToExec.hasAllCurrentOwnersRemoved(groupId) &&
           !TransToExec.isAllGroupOwnersWithDeathCerts(groupId))
         )

--- a/ppr-ui/src/components/mhrTransfers/HomeOwnersGroupError.vue
+++ b/ppr-ui/src/components/mhrTransfers/HomeOwnersGroupError.vue
@@ -17,6 +17,11 @@
       TransToExec.hasAllCurrentOwnersRemoved(groupId)">
       {{ transfersErrors.mustContainOneExecutorInGroup }}
     </span>
+    <span v-else-if="TransSaleOrGift.hasMixedOwnersInGroup(groupId)">
+    {{ hasOneHomeOwnerGroup ?
+      MixedRolesErrors.hasMixedOwnerTypes :
+      MixedRolesErrors.hasMixedOwnerTypesInGroup }}
+    </span>
     <span v-else-if="!TransToExec.hasAllCurrentOwnersRemoved(groupId) &&
       TransToExec.hasAddedExecutorsInGroup(groupId)">
       {{ transfersErrors.ownersMustBeDeceased }}

--- a/ppr-ui/src/components/mhrTransfers/HomeOwnersGroupError.vue
+++ b/ppr-ui/src/components/mhrTransfers/HomeOwnersGroupError.vue
@@ -18,9 +18,9 @@
       {{ transfersErrors.mustContainOneExecutorInGroup }}
     </span>
     <span v-else-if="TransSaleOrGift.hasMixedOwnersInGroup(groupId)">
-    {{ hasOneHomeOwnerGroup ?
-      MixedRolesErrors.hasMixedOwnerTypes :
-      MixedRolesErrors.hasMixedOwnerTypesInGroup }}
+      {{ hasOneHomeOwnerGroup ?
+        MixedRolesErrors.hasMixedOwnerTypes :
+        MixedRolesErrors.hasMixedOwnerTypesInGroup }}
     </span>
     <span v-else-if="!TransToExec.hasAllCurrentOwnersRemoved(groupId) &&
       TransToExec.hasAddedExecutorsInGroup(groupId)">
@@ -53,6 +53,11 @@
     <span v-else-if="!TransToAdmin.hasAddedAdministratorsInGroup(groupId) &&
       TransToExec.hasAllCurrentOwnersRemoved(groupId)">
       {{ transfersErrors.mustContainOneAdminInGroup }}
+    </span>
+    <span v-else-if="TransSaleOrGift.hasMixedOwnersInGroup(groupId)">
+      {{ hasOneHomeOwnerGroup ?
+        MixedRolesErrors.hasMixedOwnerTypes :
+        MixedRolesErrors.hasMixedOwnerTypesInGroup }}
     </span>
     <span v-else-if="!TransToExec.hasAllCurrentOwnersRemoved(groupId) &&
       TransToAdmin.hasAddedAdministratorsInGroup(groupId)">

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -481,7 +481,7 @@ describe('Home Owners', () => {
     await nextTick()
 
     const homeOwners = wrapper
-    const MixedRolesError = homeOwners.find(getTestId('invalid-group-mixed-owners'))
+    const MixedRolesError = homeOwners.find(getTestId('mixed-owners-msg-group-1'))
     expect(MixedRolesError.exists()).toBeTruthy()
     expect(MixedRolesError.text()).toContain(MixedRolesErrors.hasMixedOwnerTypes)
 
@@ -514,7 +514,7 @@ describe('Home Owners', () => {
     await nextTick()
 
     const homeOwners = wrapper
-    const MixedRolesError = homeOwners.find(getTestId('invalid-group-mixed-owners'))
+    const MixedRolesError = homeOwners.find(getTestId('mixed-owners-msg-group-1'))
     expect(MixedRolesError.exists()).toBeTruthy()
 
     // remove the executor from the group

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -1062,7 +1062,7 @@ describe('Home Owners', () => {
       { groupId: 2, owners: [mockedPerson], type: '' }
     ])
 
-    expect(groupError.text()).toContain(transfersErrors.ownersMustBeDeceased)
+    expect(groupError.text()).toContain(MixedRolesErrors.hasMixedOwnerTypesInGroup)
   })
 
   it('TRANS ADMIN No Will: remove existing Administrator and add a new one', async () => {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16683

*Description of changes:*
- Added mixed owners validation for all Transfer types (beyond Gift/Sale type)
- Fixed styling for the error
- Updated unit tests (fixed TS errors as well)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
