### PR TITLE
Fix Additional Name in Transfers

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -242,7 +242,7 @@
                   <v-text-field
                     v-on="on"
                     id="suffix"
-                    v-model="owner.suffix"
+                    v-model="owner[getSuffixOrDesc(owner)]"
                     filled
                     :label="nameConfig.label"
                     data-test-id="suffix"
@@ -705,6 +705,14 @@ export default defineComponent({
       localState.autoCompleteIsActive = false
     }
 
+    // For Individual and Business Owners, bind suffix to additional name field model
+    // For all other owners, bind description field
+    const getSuffixOrDesc = (owner: MhrRegistrationHomeOwnerIF): string => {
+      return [HomeOwnerPartyTypes.OWNER_IND, HomeOwnerPartyTypes.OWNER_BUS].includes(owner.partyType)
+        ? 'suffix'
+        : 'description'
+    }
+
     watch(
       () => localState.searchValue,
       (val: string) => {
@@ -730,6 +738,7 @@ export default defineComponent({
       addressSchema,
       setSearchValue,
       setCloseAutoComplete,
+      getSuffixOrDesc,
       getStepValidation,
       MhrSectVal,
       isCurrentOwner,

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
@@ -82,7 +82,7 @@ export default defineComponent({
         case HomeOwnerPartyTypes.OWNER_IND:
         case HomeOwnerPartyTypes.OWNER_BUS:
           return isTransferToExecutorProbateWill.value || isTransferToExecutorUnder25Will.value ||
-            isTransferToAdminNoWill.value
+            isTransferToAdminNoWill.value || isTransferToSurvivingJointTenant.value
         case HomeOwnerPartyTypes.EXECUTOR:
           return disableNameFields.value || isTransferToAdminNoWill.value || isFrozenMhr.value
         case HomeOwnerPartyTypes.ADMINISTRATOR:

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -143,10 +143,14 @@
                           {{ item.organizationName }}
                         </div>
                       </div>
-                      <div v-if="item.suffix" class="font-light suffix">
+
+                      <div v-if="item.partyType === HomeOwnerPartyTypes.OWNER_IND ||
+                        item.partyType === HomeOwnerPartyTypes.OWNER_BUS"
+                        class="font-light suffix"
+                      >
                         {{ item.suffix }}
                       </div>
-                      <div v-else-if="item.description" class="font-light description">
+                      <div v-else class="font-light description">
                         {{ item.description }}
                       </div>
                     </div>

--- a/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
@@ -101,8 +101,8 @@ export default defineComponent({
     const { customRules, required, maxLength } = useInputRules()
     const { editHomeOwner } = useHomeOwners(true)
     const { setUnsavedChanges } = useStore()
-    const deathCertificateForm = ref(null)
-    const deathCertificateNumberRef = ref(null)
+    const deathCertificateForm: FormIF = ref(null)
+    const deathCertificateNumberRef: FormIF = ref(null)
     const deathCertificateNumberRules = computed(
       (): Array<Function> => customRules(
         maxLength(20),
@@ -142,7 +142,7 @@ export default defineComponent({
     // Validate form when prompted
     watch(() => props.validate, async (validate: boolean) => {
       await nextTick()
-      validate && (deathCertificateForm as FormIF).validate()
+      validate && deathCertificateForm.value.validate()
     }, { immediate: true })
 
     // Update deceased owner deathCertificateNumber when value changes

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -463,24 +463,25 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
         deletedOwner = find(deletedOwnerGroup.owners, { action: ActionTypes.REMOVED })
       }
 
-      let suffix = ''
+      // prefill Description field Execs, Admin, Trustees have description as Additional Name
+      let desc = ''
       if ([HomeOwnerPartyTypes.OWNER_IND, HomeOwnerPartyTypes.OWNER_BUS].includes(deletedOwner.partyType)) {
         // if reg or business owner is deleted, prefill the additional name (suffix) with the name of the deleted owner
         const { first, middle, last } = deletedOwner.individualName || {}
 
-        suffix = deletedOwner.organizationName?.length > 0
+        desc = deletedOwner.organizationName?.length > 0
           ? transferOwnerPrefillAdditionalName[transferType] + deletedOwner.organizationName
           : transferOwnerPrefillAdditionalName[transferType] +
             [first, middle, last].filter(Boolean).join(' ') +
             ', deceased'
       } else {
         // if executor, admin or trustee, copy the additional name (suffix) from the suffix of deleted owner
-        suffix = deletedOwner.description
+        desc = deletedOwner.description
       }
 
       Object.assign(owner, {
         ownerId: allOwners.length + 1,
-        suffix: suffix,
+        description: desc,
         partyType: transferOwnerPartyTypes[transferType],
         groupId: deletedOwnerGroup.groupId // new Owner will be added to the same group as deleted Owner
       } as MhrRegistrationHomeOwnerIF)

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -203,7 +203,7 @@ describe('Home Owners', () => {
   })
 
   it('displays badge for ADDED owners (Persons and Orgs)', async () => {
-    const homeOwnerGroup = [{ groupId: 1, owners: [mockedAddedPerson, mockedAddedOrganization] }]
+    const homeOwnerGroup = [{ groupId: 1, owners: [mockedAddedPerson, mockedAddedOrganization], type: '' }]
 
     // add a person
     await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
@@ -252,7 +252,7 @@ describe('Home Owners', () => {
   })
 
   it('displays badge for REMOVED owners (Persons and Orgs)', async () => {
-    const homeOwnerGroup = [{ groupId: 1, owners: [mockedRemovedPerson, mockedRemovedOrganization] }]
+    const homeOwnerGroup = [{ groupId: 1, owners: [mockedRemovedPerson, mockedRemovedOrganization], type: '' }]
 
     // add a person
     await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
@@ -301,21 +301,23 @@ describe('Home Owners', () => {
   })
 
   it('should display a DELETED home owner group', async () => {
-    const homeOwnerGroups = [
+    const homeOwnerGroups: MhrRegistrationHomeOwnerGroupIF[] = [
       {
         groupId: 1,
         interest: 'Undivided',
         interestNumerator: 2,
         interestDenominator: 4,
-        owners: [mockedPerson]
+        owners: [mockedPerson],
+        type: ''
       },
       {
         groupId: 2,
         interest: 'Undivided',
-        action: 'REMOVED',
+        action: ActionTypes.REMOVED,
         interestNumerator: 2,
         interestDenominator: 4,
-        owners: [mockedOrganization]
+        owners: [mockedOrganization],
+        type: ''
       }
     ]
 
@@ -346,31 +348,34 @@ describe('Home Owners', () => {
     // Verify Headers
     expect(ownersTable.findAllComponents(TableGroupHeader).length).toBe(2)
     expect(ownersTable.text()).toContain('Group 1')
-    expect(ownersTable.text()).toContain('Group 2')
+    expect(ownersTable.text()).not.toContain('Group 2')
+    expect(ownersTable.text()).toContain('Previous Owner Group')
 
     // there should be 'DELETED' badges shown for the Deleted Group
     expect(ownersTable.findAllComponents(TableGroupHeader).at(1)
-      .findComponent(InfoChip).text()).toContain('REMOVED')
+      .findComponent(InfoChip).text()).toContain(ActionTypes.REMOVED)
 
     wrapper.vm.setShowGroups(false)
   })
 
   it('should display a CHANGED a home owner group', async () => {
-    const homeOwnerGroups = [
+    const homeOwnerGroups: MhrRegistrationHomeOwnerGroupIF[] = [
       {
         groupId: 1,
         interest: 'Undivided',
         interestNumerator: 2,
         interestDenominator: 4,
-        owners: [mockedPerson]
+        owners: [mockedPerson],
+        type: ''
       },
       {
         groupId: 2,
         interest: 'Undivided',
-        action: 'CHANGED',
+        action: ActionTypes.CHANGED,
         interestNumerator: 3,
         interestDenominator: 4,
-        owners: [mockedOrganization]
+        owners: [mockedOrganization],
+        type: ''
       }
     ]
 
@@ -514,7 +519,7 @@ describe('Home Owners', () => {
     // setup transfer type to test
     const TRANSFER_TYPE = ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL
 
-    let homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson] }]
+    let homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson], type: '' }]
     await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
 
     const homeOwnersTable = wrapper.findComponent(HomeOwnersTable)
@@ -544,7 +549,7 @@ describe('Home Owners', () => {
     ).toBe(HomeTenancyTypes.NA)
 
     // reset owners
-    homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson] }]
+    homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson], type: '' }]
     await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
 
     // delete original owner

--- a/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
@@ -173,6 +173,7 @@ export const mockedAddedPerson: MhrRegistrationHomeOwnerIF = {
   suffix: 'Sr.',
   phoneNumber: '(545) 333-2211',
   phoneExtension: '1234',
+  partyType: HomeOwnerPartyTypes.OWNER_IND,
   address: mockedAddress,
   action: ActionTypes.ADDED
 }
@@ -188,6 +189,7 @@ export const mockedRemovedPerson: MhrRegistrationHomeOwnerIF = {
   phoneNumber: '(545) 333-2211',
   phoneExtension: '1234',
   address: mockedAddress,
+  partyType: HomeOwnerPartyTypes.OWNER_IND,
   action: ActionTypes.REMOVED
 }
 
@@ -197,6 +199,7 @@ export const mockedOrganization: MhrRegistrationHomeOwnerIF = {
   suffix: 'Inc.',
   phoneNumber: '(999) 888-7766',
   phoneExtension: '4321',
+  partyType: HomeOwnerPartyTypes.OWNER_BUS,
   address: mockedAddressAlt
 }
 
@@ -206,6 +209,7 @@ export const mockedAddedOrganization: MhrRegistrationHomeOwnerIF = {
   suffix: 'Inc.',
   phoneNumber: '(999) 888-7766',
   phoneExtension: '4321',
+  partyType: HomeOwnerPartyTypes.OWNER_BUS,
   address: mockedAddressAlt,
   action: ActionTypes.ADDED
 }
@@ -216,6 +220,7 @@ export const mockedRemovedOrganization: MhrRegistrationHomeOwnerIF = {
   suffix: 'Inc.',
   phoneNumber: '(999) 888-7766',
   phoneExtension: '4321',
+  partyType: HomeOwnerPartyTypes.OWNER_BUS,
   address: mockedAddressAlt,
   action: ActionTypes.REMOVED
 }


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16795

*Description of changes:*
- Fix Additional Name when working with Transfers
- Fix not to allow Home Owners Role changes for Surviving Owner Transfer 
- Other fixes
- Unit test updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
