### PR TITLE
Hide information when no data entered in review confirm

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/SubmittingPartyReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/SubmittingPartyReview.vue
@@ -6,7 +6,7 @@
     </header>
 
     <div :class="{ 'border-error-left': showStepError }">
-      <section class="mx-6 pt-8" v-if="showStepError">
+      <section  v-if="showStepError" class="mx-6 pt-8" :class="{ 'pb-8': !hasData }">
         <span>
           <v-icon color="error">mdi-information-outline</v-icon>
           <span class="error-text mx-1">This step is unfinished.</span>
@@ -17,7 +17,7 @@
       </section>
 
       <!-- -->
-      <template>
+      <template v-if="hasData">
         <section id="review-submitting-party-section">
           <!-- Insert Review mode of component here -->
           <v-row no-gutters class="px-6 pb-5 pt-6">
@@ -106,7 +106,7 @@ import { RouteNames } from '@/enums'
 import { useStore } from '@/store/store'
 import { BaseAddress } from '@/composables/address'
 import { PartyAddressSchema } from '@/schemas'
-import { toDisplayPhone } from '@/utils'
+import { toDisplayPhone, hasTruthyValue } from '@/utils'
 import { useMhrValidations } from '@/composables'
 import { AttnRefConfigIF } from '@/interfaces'
 import { attentionConfig, folioOrRefConfig } from '@/resources/attnRefConfigs'
@@ -137,11 +137,16 @@ export default defineComponent({
       address: computed(() => getMhrRegistrationSubmittingParty.value.address),
       businessName: computed(() => getMhrRegistrationSubmittingParty.value.businessName),
       personName: computed(() => getMhrRegistrationSubmittingParty.value.personName),
-      hasAddress: computed(() => !Object.values(localState.address).every(val => !val)),
+      hasAddress: computed(() => hasTruthyValue(localState.address)),
       attnOrRefConfig: computed((): AttnRefConfigIF => isRoleStaffReg.value ? attentionConfig : folioOrRefConfig),
       emptyText: computed(() => isMhrManufacturerRegistration.value ? '' : '(Not Entered)'),
       showStepError: computed(() => {
         return !isMhrManufacturerRegistration.value && !getStepValidation(MhrSectVal.SUBMITTING_PARTY_VALID)
+      }),
+      hasData: computed(() : boolean => {
+        return hasTruthyValue(getMhrRegistrationSubmittingParty.value) ||
+        (!isMhrManufacturerRegistration.value &&
+        (!!getMhrRegistrationDocumentId.value || !!getMhrAttentionReference.value))
       })
     })
 

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
@@ -6,7 +6,7 @@
     </header>
 
     <div :class="{'border-error-left': showStepError && !isTransferReview }">
-      <section class="mx-6 pt-8" v-if="showStepError && !isTransferReview">
+      <section v-if="showStepError && !isTransferReview" class="mx-6 pt-8" :class="{ 'pb-8': !hasData}">
         <span>
           <v-icon color="error">mdi-information-outline</v-icon>
           <span class="error-text mx-1">This step is unfinished.</span>
@@ -16,136 +16,137 @@
         </span>
       </section>
 
-      <!-- Manufacturer Make Model -->
-      <section class="py-6">
-        <v-row no-gutters class="px-6">
-          <v-col cols="3">
-            <h3>Manufacturer's Name</h3>
-          </v-col>
-          <v-col cols="9">
-            <p>{{ getMhrRegistrationHomeDescription.manufacturer || '(Not Entered)' }}</p>
-          </v-col>
-        </v-row>
-        <v-row no-gutters class="pt-3 px-6">
-          <v-col cols="3">
-            <h3>Year of Manufacture</h3>
-          </v-col>
-          <v-col cols="9">
-            <p v-if="getMhrRegistrationHomeDescription.baseInformation.year">
-              {{ getMhrRegistrationHomeDescription.baseInformation.circa
-              ? 'Circa ' + getMhrRegistrationHomeDescription.baseInformation.year
-              : getMhrRegistrationHomeDescription.baseInformation.year
-              }}
-            </p>
-            <p v-else>(Not Entered)</p>
-          </v-col>
-        </v-row>
-        <v-row no-gutters class="pt-3 px-6">
-          <v-col cols="3">
-            <h3>Make</h3>
-          </v-col>
-          <v-col cols="9">
-            <p>{{ getMhrRegistrationHomeDescription.baseInformation.make || '(Not Entered)'  }}</p>
-          </v-col>
-        </v-row>
-        <v-row no-gutters class="pt-3 px-6">
-          <v-col cols="3">
-            <h3>Model</h3>
-          </v-col>
-          <v-col cols="9">
-            <p>{{ getMhrRegistrationHomeDescription.baseInformation.model || '(Not Entered)'  }}</p>
-          </v-col>
-        </v-row>
-      </section>
-
-      <v-divider class="mx-4"/>
-
-      <!-- CSA Review -->
-      <template v-if="isCSA || isEngineerInspection">
-        <template v-if="isCSA">
-          <v-row no-gutters class="pa-6">
-            <v-col cols="3" class="pt-1">
-              <h3>CSA Number</h3>
+      <template v-if="hasData">
+        <!-- Manufacturer Make Model -->
+        <section class="py-6">
+          <v-row no-gutters class="px-6">
+            <v-col cols="3">
+              <h3>Manufacturer's Name</h3>
             </v-col>
-            <v-col cols="9" class="pt-1">
-              <p>{{ getMhrRegistrationHomeDescription.csaNumber || '(Not Entered)' }}</p>
-            </v-col>
-            <v-col cols="3" class="pt-1">
-              <h3>CSA Standard</h3>
-            </v-col>
-            <v-col cols="9" class="pt-1">
-              <p>{{ getMhrRegistrationHomeDescription.csaStandard || '(Not Entered)' }}</p>
+            <v-col cols="9">
+              <p>{{ getMhrRegistrationHomeDescription.manufacturer || '(Not Entered)' }}</p>
             </v-col>
           </v-row>
-        </template>
-
-        <!-- Engineer Review -->
-        <template v-if="isEngineerInspection">
-          <v-row no-gutters class="pa-6">
-            <v-col cols="3" class="pt-1">
-              <h3>Engineer's Name</h3>
+          <v-row no-gutters class="pt-3 px-6">
+            <v-col cols="3">
+              <h3>Year of Manufacture</h3>
             </v-col>
-            <v-col cols="9" class="pt-1">
-              <p>{{ getMhrRegistrationHomeDescription.engineerName || '(Not Entered)' }}</p>
-            </v-col>
-            <v-col cols="3" class="pt-1">
-              <h3>Date of Engineer's Report</h3>
-            </v-col>
-            <v-col cols="9" class="pt-1">
-              <p>{{ engineerDisplayDate || '(Not Entered)' }}</p>
+            <v-col cols="9">
+              <p v-if="getMhrRegistrationHomeDescription.baseInformation.year">
+                {{ getMhrRegistrationHomeDescription.baseInformation.circa
+                ? 'Circa ' + getMhrRegistrationHomeDescription.baseInformation.year
+                : getMhrRegistrationHomeDescription.baseInformation.year
+                }}
+              </p>
+              <p v-else>(Not Entered)</p>
             </v-col>
           </v-row>
-        </template>
-      </template>
-
-      <!-- Default no Home Certification option is selected -->
-      <template v-else>
-        <v-row no-gutters class="pa-6">
-          <v-col cols="3">
-            <h3>Home Certification</h3>
-          </v-col>
-          <v-col cols="9">
-            <p>(Not Entered)</p>
-          </v-col>
-        </v-row>
-      </template>
-
-      <v-divider class="mx-4"/>
-
-      <!-- Home Sections Review -->
-      <template>
-        <section class="pt-6" id="review-home-sections">
-          <h3 class="px-6">Home Sections</h3>
-          <HomeSections class="mt-n4 px-6 py-0" :isReviewMode="true" />
+          <v-row no-gutters class="pt-3 px-6">
+            <v-col cols="3">
+              <h3>Make</h3>
+            </v-col>
+            <v-col cols="9">
+              <p>{{ getMhrRegistrationHomeDescription.baseInformation.make || '(Not Entered)'  }}</p>
+            </v-col>
+          </v-row>
+          <v-row no-gutters class="pt-3 px-6">
+            <v-col cols="3">
+              <h3>Model</h3>
+            </v-col>
+            <v-col cols="9">
+              <p>{{ getMhrRegistrationHomeDescription.baseInformation.model || '(Not Entered)'  }}</p>
+            </v-col>
+          </v-row>
         </section>
-      </template>
-
-      <template v-if="!isMhrManufacturerRegistration">
-        <v-divider class="mx-4"/>
-
-        <!-- Rebuilt Status Review -->
-        <v-row no-gutters class="pa-6">
-          <v-col cols="3">
-            <h3>Rebuilt Status</h3>
-          </v-col>
-          <v-col cols="9">
-            <p v-html="formatAsHtml(getMhrRegistrationHomeDescription.rebuiltRemarks) || '(Not Entered)'"></p>
-          </v-col>
-        </v-row>
 
         <v-divider class="mx-4"/>
 
-        <!-- Other Information Review -->
-        <v-row no-gutters class="pa-6">
-          <v-col cols="3">
-            <h3>Other Information</h3>
-          </v-col>
-          <v-col cols="9">
-            <p v-html="formatAsHtml(getMhrRegistrationOtherInfo) || '(Not Entered)'"></p>
-          </v-col>
-        </v-row>
-      </template>
+        <!-- CSA Review -->
+        <template v-if="isCSA || isEngineerInspection">
+          <template v-if="isCSA">
+            <v-row no-gutters class="pa-6">
+              <v-col cols="3" class="pt-1">
+                <h3>CSA Number</h3>
+              </v-col>
+              <v-col cols="9" class="pt-1">
+                <p>{{ getMhrRegistrationHomeDescription.csaNumber || '(Not Entered)' }}</p>
+              </v-col>
+              <v-col cols="3" class="pt-1">
+                <h3>CSA Standard</h3>
+              </v-col>
+              <v-col cols="9" class="pt-1">
+                <p>{{ getMhrRegistrationHomeDescription.csaStandard || '(Not Entered)' }}</p>
+              </v-col>
+            </v-row>
+          </template>
 
+          <!-- Engineer Review -->
+          <template v-if="isEngineerInspection">
+            <v-row no-gutters class="pa-6">
+              <v-col cols="3" class="pt-1">
+                <h3>Engineer's Name</h3>
+              </v-col>
+              <v-col cols="9" class="pt-1">
+                <p>{{ getMhrRegistrationHomeDescription.engineerName || '(Not Entered)' }}</p>
+              </v-col>
+              <v-col cols="3" class="pt-1">
+                <h3>Date of Engineer's Report</h3>
+              </v-col>
+              <v-col cols="9" class="pt-1">
+                <p>{{ engineerDisplayDate || '(Not Entered)' }}</p>
+              </v-col>
+            </v-row>
+          </template>
+        </template>
+
+        <!-- Default no Home Certification option is selected -->
+        <template v-else>
+          <v-row no-gutters class="pa-6">
+            <v-col cols="3">
+              <h3>Home Certification</h3>
+            </v-col>
+            <v-col cols="9">
+              <p>(Not Entered)</p>
+            </v-col>
+          </v-row>
+        </template>
+
+        <v-divider class="mx-4"/>
+
+        <!-- Home Sections Review -->
+        <template>
+          <section class="pt-6" id="review-home-sections">
+            <h3 class="px-6">Home Sections</h3>
+            <HomeSections class="mt-n4 px-6 py-0" :isReviewMode="true" />
+          </section>
+        </template>
+
+        <template v-if="!isMhrManufacturerRegistration">
+          <v-divider class="mx-4"/>
+
+          <!-- Rebuilt Status Review -->
+          <v-row no-gutters class="pa-6">
+            <v-col cols="3">
+              <h3>Rebuilt Status</h3>
+            </v-col>
+            <v-col cols="9">
+              <p v-html="formatAsHtml(getMhrRegistrationHomeDescription.rebuiltRemarks) || '(Not Entered)'"></p>
+            </v-col>
+          </v-row>
+
+          <v-divider class="mx-4"/>
+
+          <!-- Other Information Review -->
+          <v-row no-gutters class="pa-6">
+            <v-col cols="3">
+              <h3>Other Information</h3>
+            </v-col>
+            <v-col cols="9">
+              <p v-html="formatAsHtml(getMhrRegistrationOtherInfo) || '(Not Entered)'"></p>
+            </v-col>
+          </v-row>
+        </template>
+      </template>
     </div>
   </v-card>
 </template>
@@ -154,7 +155,7 @@
 import { computed, defineComponent, reactive, toRefs } from 'vue-demi'
 import { useStore } from '@/store/store'
 import { HomeCertificationOptions, RouteNames } from '@/enums'
-import { yyyyMmDdToPacificDate, formatAsHtml } from '@/utils'
+import { yyyyMmDdToPacificDate, formatAsHtml, hasTruthyValue } from '@/utils'
 import { HomeSections } from '@/components/mhrRegistration'
 import { useMhrValidations } from '@/composables'
 import { storeToRefs } from 'pinia'
@@ -194,7 +195,11 @@ export default defineComponent({
       engineerDisplayDate: computed((): string => {
         return yyyyMmDdToPacificDate(getMhrRegistrationHomeDescription.value?.engineerDate, true)
       }),
-      showStepError: computed(() => !getStepValidation(MhrSectVal.YOUR_HOME_VALID))
+      showStepError: computed(() => !getStepValidation(MhrSectVal.YOUR_HOME_VALID)),
+      hasData: computed(() : boolean => {
+        return hasTruthyValue(getMhrRegistrationHomeDescription.value) ||
+        (!isMhrManufacturerRegistration.value && !!getMhrRegistrationOtherInfo.value)
+      })
     })
 
     return {

--- a/ppr-ui/src/utils/utilities.ts
+++ b/ppr-ui/src/utils/utilities.ts
@@ -36,3 +36,13 @@ export function addTimestampToDate (dateToConvert: string, isEndDate: boolean): 
   }
   return dateToConvert
 }
+
+/**
+ * Checks if an object or its nested objects
+ * have a non-object property with a truthy value
+ */
+export function hasTruthyValue (obj: Object) {
+  return Object.values(obj).some(
+    (value) => !!value && (typeof value === 'object' ? hasTruthyValue(value) : true)
+  )
+}

--- a/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
@@ -24,6 +24,7 @@ import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
 import { defaultFlagSet } from '@/utils'
 import { StaffPayment } from '@bcrs-shared-components/staff-payment'
+import { HomeSections } from '@/components/mhrRegistration'
 
 Vue.use(Vuetify)
 
@@ -57,7 +58,7 @@ function createComponent (): Wrapper<any> {
 }
 
 describe('Mhr Review Confirm registration', () => {
-  let wrapper: any
+  let wrapper: Wrapper<any>
   sessionStorage.setItem('KEYCLOAK_TOKEN', 'token')
   const currentAccount = {
     id: 'test_id'
@@ -175,6 +176,21 @@ describe('Mhr Review Confirm registration', () => {
     expect(homeOwnersTable.text()).toContain(mockedPerson.phoneExtension)
     expect(homeOwnersTable.text()).toContain(mockedPerson.address.city)
     expect(homeOwnersTable.text()).toContain(HomeTenancyTypes.NA)
+  })
+
+  it('does not show portions of yourHomeReview and SubmittingPartyReview if no data was entered', async () => {
+    wrapper = createComponent()
+    const yourHomeReview = wrapper.findComponent(YourHomeReview)
+    expect(yourHomeReview.exists()).toBeTruthy()
+    expect(yourHomeReview.findComponent(HomeSections).exists()).toBe(false)
+    await store.setMhrHomeDescription({ key: 'manufacturer', value: 'test' })
+    expect(yourHomeReview.findComponent(HomeSections).exists()).toBe(true)
+
+    const submittingPartyReview = wrapper.findComponent(SubmittingPartyReview)
+    expect(submittingPartyReview.exists()).toBeTruthy()
+    expect(submittingPartyReview.find('#review-submitting-party-section').exists()).toBe(false)
+    await store.setMhrSubmittingParty({ key: 'phoneNumber', value: '123' })
+    expect(submittingPartyReview.find('#review-submitting-party-section').exists()).toBe(true)
   })
 })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16936

*Description of changes:*
- Added localState `hasData` that maintains if any data was entered for a given section.
- Added tests
- Created utility to check if object has non-object truthy value.

*Screenshots:*

Before: 

No Data entered

![image](https://github.com/bcgov/ppr/assets/77707952/ede09ee7-2ffd-474a-aaae-9d5569b03512)


After:

No Data entered

![image](https://github.com/bcgov/ppr/assets/77707952/ad81e2fc-e152-4199-9453-68f14f8cd3fa)

When some field as a value:

![image](https://github.com/bcgov/ppr/assets/77707952/a725a449-a66c-47fc-93fa-1c89379eebcb)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
