### PR TITLE
Adds no certification option for staff

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.27",
+      "version": "2.0.28",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
@@ -99,7 +99,19 @@
           </template>
         </template>
 
-        <!-- Default no Home Certification option is selected -->
+        <!-- Has no home certification is checked -->
+        <template v-else-if="getMhrRegistrationHomeDescription.noCertification">
+          <v-row no-gutters class="pa-6">
+            <v-col cols="3">
+              <h3>Home Certification</h3>
+            </v-col>
+            <v-col cols="9">
+              <p>There is no certification available for this home.</p>
+            </v-col>
+          </v-row>
+        </template>
+
+        <!-- No option selected -->
         <template v-else>
           <v-row no-gutters class="pa-6">
             <v-col cols="3">

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/YourHomeReview.vue
@@ -100,7 +100,7 @@
         </template>
 
         <!-- Has no home certification is checked -->
-        <template v-else-if="getMhrRegistrationHomeDescription.noCertification">
+        <template v-else-if="getMhrRegistrationHomeDescription.hasNoCertification">
           <v-row no-gutters class="pa-6">
             <v-col cols="3">
               <h3>Home Certification</h3>

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card
-  id="mhr-home-certification"
-  class="mt-8 pa-8 pr-6"
-  flat
-  rounded
-  :class="{ 'py-10': isMhrManufacturerRegistration }"
+    id="mhr-home-certification"
+    class="mt-8 pa-8 pr-6"
+    flat
+    rounded
+    :class="{ 'py-10': isMhrManufacturerRegistration }"
   >
     <v-row no-gutters>
       <v-col cols="12" sm="2">
@@ -112,13 +112,12 @@
             label="There is no certification available for this home."
             v-model="hasNoCertification"
             class="mt-9 float-left"
-            data-test-id="no-certification-checkbox"
           />
           <v-tooltip
+            id="no-certification-tooltip"
             top
             content-class="top-tooltip pa-4"
             transition="fade-transition"
-            data-test-id="no-certification-tooltip"
             nudge-right="4"
           >
             <template v-slot:activator="{ on }">
@@ -224,7 +223,7 @@ export default defineComponent({
         const utcDate = createUtcDate(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
         return localTodayDate(utcDate)
       }),
-      hasNoCertification: getMhrRegistrationHomeDescription.value?.noCertification || false
+      hasNoCertification: getMhrRegistrationHomeDescription.value?.hasNoCertification || false
     })
 
     const validateForms = async () => {
@@ -279,7 +278,7 @@ export default defineComponent({
     })
 
     watch(() => localState.hasNoCertification, (val: boolean) => {
-      setMhrHomeDescription({ key: 'noCertification', value: localState.hasNoCertification })
+      setMhrHomeDescription({ key: 'hasNoCertification', value: localState.hasNoCertification })
       localState.certificationOption = null
       engineerForm.value?.resetValidation()
       csaForm.value?.resetValidation()

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
@@ -106,12 +106,12 @@
 
         <!-- Home Certification Checkbox -->
         <template v-if="isRoleStaffReg">
-          <v-divider  v-if="certificationOption" class="mt-7 ml-0 mr-2"/>
+          <v-divider v-if="certificationOption" class="mt-4 ml-0 mr-2"/>
           <v-checkbox
             id="no-certification-checkbox"
             label="There is no certification available for this home."
             v-model="hasNoCertification"
-            class="mt-9 float-left"
+            class="mt-8 pt-0 mb-n4 float-left"
           />
           <v-tooltip
             id="no-certification-tooltip"
@@ -122,7 +122,7 @@
           >
             <template v-slot:activator="{ on }">
               <v-icon
-                class="ml-2 mt-10"
+                class="ml-2 mt-8"
                 color="primary"
                 v-on="on"
               >

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
@@ -1,16 +1,24 @@
 <template>
-  <v-card flat rounded id="mhr-home-certification" class="mt-8 pa-8 pr-6" :class="{'py-10': !showRadio}">
+  <v-card
+  id="mhr-home-certification"
+  class="mt-8 pa-8 pr-6"
+  flat
+  rounded
+  :class="{ 'py-10': isMhrManufacturerRegistration }"
+  >
     <v-row no-gutters>
       <v-col cols="12" sm="2">
-        <label class="generic-label" :class="{'error-text': validate}">Certification</label>
+        <label class="generic-label" :class="{ 'error-text': validate }">Certification</label>
       </v-col>
       <v-col cols="12" sm="10" class="pl-1">
-        <template v-if="showRadio">
+        <template v-if="!isMhrManufacturerRegistration">
           <v-radio-group
             id="certification-option-btns"
             v-model="certificationOption"
             class="mt-0 pr-1" row
             hide-details="true"
+            :disabled="hasNoCertification"
+            :class="{ 'disabled-radio': hasNoCertification }"
           >
             <v-radio
               id="csa-option"
@@ -27,7 +35,7 @@
               :value="HomeCertificationOptions.ENGINEER_INSPECTION"
             />
           </v-radio-group>
-          <v-divider class="my-9 ml-0 mr-2" v-if="!!certificationOption"/>
+          <v-divider v-if="!!certificationOption" class="my-9 ml-0 mr-2"/>
         </template>
 
         <!-- CSA Section -->
@@ -61,7 +69,7 @@
         </div>
 
         <!-- Engineer Section -->
-        <div v-show="isEngineerOption" v-if="showEngineerOption">
+        <div v-if="!isMhrManufacturerRegistration" v-show="isEngineerOption">
           <v-row no-gutters>
             <v-col cols="12">
               <v-form id="engineer-form" ref="engineerForm" v-model="isEngineerValid">
@@ -95,6 +103,39 @@
             </v-col>
           </v-row>
         </div>
+
+        <!-- Home Certification Checkbox -->
+        <template v-if="isRoleStaffReg">
+          <v-divider  v-if="certificationOption" class="mt-7 ml-0 mr-2"/>
+          <v-checkbox
+            id="no-certification-checkbox"
+            label="There is no certification available for this home."
+            v-model="hasNoCertification"
+            class="mt-9 float-left"
+            data-test-id="no-certification-checkbox"
+          />
+          <v-tooltip
+            top
+            content-class="top-tooltip pa-4"
+            transition="fade-transition"
+            data-test-id="no-certification-tooltip"
+            nudge-right="4"
+          >
+            <template v-slot:activator="{ on }">
+              <v-icon
+                class="ml-2 mt-10"
+                color="primary"
+                v-on="on"
+              >
+                mdi-information-outline
+              </v-icon>
+            </template>
+            If a CSA Number or Engineer’s Inspection is not available for this home,
+            select this option and enter a description of the safety evidence in the
+            Other Information section.
+          </v-tooltip>
+        </template>
+
       </v-col>
     </v-row>
   </v-card>
@@ -126,7 +167,7 @@ export default defineComponent({
   setup (props) {
     const { setMhrHomeDescription } = useStore()
     const { getMhrRegistrationHomeDescription, getMhrRegistrationValidationModel,
-      isMhrManufacturerRegistration } = storeToRefs(useStore())
+      isMhrManufacturerRegistration, isRoleStaffReg } = storeToRefs(useStore())
     // Composable(s)
     const {
       customRules,
@@ -144,7 +185,6 @@ export default defineComponent({
     const datePicker = ref(null) as FormIF
 
     const localState = reactive({
-      homeCertificationValid: false,
       certificationOption: getMhrRegistrationHomeDescription.value?.certificationOption || null,
       csaNumber: getMhrRegistrationHomeDescription.value?.csaNumber || '',
       csaStandard: getMhrRegistrationHomeDescription.value?.csaStandard || '',
@@ -175,7 +215,8 @@ export default defineComponent({
       }),
       isHomeCertificationValid: computed((): boolean => {
         return (localState.isCsaOption && localState.isCsaValid) ||
-          (localState.isEngineerOption && localState.isEngineerValid && !!localState.engineerDate)
+          (localState.isEngineerOption && localState.isEngineerValid && !!localState.engineerDate) ||
+          localState.hasNoCertification
       }),
       today: computed(() => localTodayDate()),
       minDate: computed(() => {
@@ -183,8 +224,7 @@ export default defineComponent({
         const utcDate = createUtcDate(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
         return localTodayDate(utcDate)
       }),
-      showRadio: computed(() => !isMhrManufacturerRegistration.value),
-      showEngineerOption: computed(() => !isMhrManufacturerRegistration.value)
+      hasNoCertification: getMhrRegistrationHomeDescription.value?.noCertification || false
     })
 
     const validateForms = async () => {
@@ -215,7 +255,7 @@ export default defineComponent({
     })
     watch(() => localState.isHomeCertificationValid, (val: boolean) => {
       setValidation(MhrSectVal.YOUR_HOME_VALID, MhrCompVal.HOME_CERTIFICATION_VALID, val)
-    })
+    }, { immediate: true })
     watch(() => props.validate, async (val: boolean) => {
       await validateForms()
     })
@@ -237,11 +277,25 @@ export default defineComponent({
         localState.csaStandard = ''
       }
     })
+
+    watch(() => localState.hasNoCertification, (val: boolean) => {
+      setMhrHomeDescription({ key: 'noCertification', value: localState.hasNoCertification })
+      localState.certificationOption = null
+      engineerForm.value?.resetValidation()
+      csaForm.value?.resetValidation()
+      localState.engineerName = ''
+      localState.engineerDate = ''
+      localState.csaNumber = ''
+      localState.csaStandard = ''
+    })
+
     return {
       csaForm,
       engineerForm,
       datePicker,
       HomeCertificationOptions,
+      isMhrManufacturerRegistration,
+      isRoleStaffReg,
       required,
       ...toRefs(localState)
     }
@@ -296,6 +350,10 @@ export default defineComponent({
     .v-list-item__title, .v-list-item .v-list-item__subtitle {
       color: $app-blue !important;
     }
+  }
+
+  .disabled-radio {
+   opacity: 40% !important;
   }
 }
 </style>

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -128,7 +128,7 @@ export const useNewMhrRegistration = () => {
         engineerName: '',
         engineerDate: '',
         certificationOption: null,
-        noCertification: null,
+        hasNoCertification: null,
         rebuiltRemarks: '',
         otherRemarks: ''
       }

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -128,6 +128,7 @@ export const useNewMhrRegistration = () => {
         engineerName: '',
         engineerDate: '',
         certificationOption: null,
+        noCertification: null,
         rebuiltRemarks: '',
         otherRemarks: ''
       }

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationDescriptionIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationDescriptionIF.ts
@@ -16,7 +16,7 @@ export interface MhrRegistrationDescriptionIF {
   engineerName: string,
   engineerDate: string,
   certificationOption?: HomeCertificationOptions, // Optional because it's a local property. Not used for submission
-  noCertification?: boolean, // For staff registration use only. Not submitted with registration
+  hasNoCertification?: boolean, // For staff registration use only. Not submitted with registration
   rebuiltRemarks: string,
   otherRemarks: string
 }

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationDescriptionIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationDescriptionIF.ts
@@ -16,6 +16,7 @@ export interface MhrRegistrationDescriptionIF {
   engineerName: string,
   engineerDate: string,
   certificationOption?: HomeCertificationOptions, // Optional because it's a local property. Not used for submission
+  noCertification?: boolean, // For staff registration use only. Not submitted with registration
   rebuiltRemarks: string,
   otherRemarks: string
 }

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -239,6 +239,7 @@ export const stateModel: StateModelIF = {
       engineerName: '',
       engineerDate: '',
       certificationOption: null,
+      noCertification: null,
       rebuiltRemarks: '',
       otherRemarks: ''
     }

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -239,7 +239,7 @@ export const stateModel: StateModelIF = {
       engineerName: '',
       engineerDate: '',
       certificationOption: null,
-      noCertification: null,
+      hasNoCertification: null,
       rebuiltRemarks: '',
       otherRemarks: ''
     }

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -207,12 +207,12 @@ export default defineComponent({
         localState.submitting = true
         const data = buildApiData()
 
-        // In cases where noCertification is selected:
-        // Need to clear noCertification for submission and replace it with an empty csa number
+        // In cases where hasNoCertification is selected:
+        // Need to clear hasNoCertification for submission and replace it with an empty csa number
         // This is to meet the API Schema requirements.
         // This does not apply to drafts as we want to maintain that property for resuming drafts
-        if (data?.description?.noCertification) {
-          delete data.description.noCertification
+        if (data?.description?.hasNoCertification) {
+          delete data.description.hasNoCertification
           data.description.csaNumber = ''
         }
 

--- a/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrRegistration.vue
@@ -205,7 +205,18 @@ export default defineComponent({
       if (localState.isValidMhrRegistration) {
         // Submit Filing
         localState.submitting = true
-        const mhrSubmission = await submitMhrRegistration(buildApiData(), parseStaffPayment())
+        const data = buildApiData()
+
+        // In cases where noCertification is selected:
+        // Need to clear noCertification for submission and replace it with an empty csa number
+        // This is to meet the API Schema requirements.
+        // This does not apply to drafts as we want to maintain that property for resuming drafts
+        if (data?.description?.noCertification) {
+          delete data.description.noCertification
+          data.description.csaNumber = ''
+        }
+
+        const mhrSubmission = await submitMhrRegistration(data, parseStaffPayment())
         localState.submitting = false
         if (!mhrSubmission.error && mhrSubmission?.mhrNumber) {
           resetAllValidations()

--- a/ppr-ui/tests/unit/HomeCertification.spec.ts
+++ b/ppr-ui/tests/unit/HomeCertification.spec.ts
@@ -12,31 +12,11 @@ import flushPromises from 'flush-promises'
 import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
 import { HomeCertificationOptions, AuthRoles } from '@/enums'
-import { getTestId } from './utils'
+import { getTestId, createComponent } from './utils'
 
 Vue.use(Vuetify)
 
-const vuetify = new Vuetify({})
-setActivePinia(createPinia())
 const store = useStore()
-
-/**
- * Creates and mounts a component, so that it can be tested.
- *
- * @returns a Wrapper<SearchBar> object with the given parameters.
- */
-function createComponent (): Wrapper<any> {
-  const localVue = createLocalVue()
-
-  localVue.use(Vuetify)
-  document.body.setAttribute('data-app', 'true')
-  return mount((HomeCertification as any), {
-    localVue,
-    propsData: {},
-    store,
-    vuetify
-  })
-}
 
 describe('Home Certification - staff', () => {
   let wrapper: Wrapper<any>
@@ -46,7 +26,7 @@ describe('Home Certification - staff', () => {
   })
 
   beforeEach(async () => {
-    wrapper = createComponent()
+    wrapper = createComponent(HomeCertification, {})
     await store.setMhrHomeDescription({ key: 'certificationOption', value: null })
     await store.setMhrHomeDescription({ key: 'noCertification', value: null })
     wrapper.vm.certificationOption = null
@@ -194,7 +174,7 @@ describe('Home Certification - manufacturer', () => {
   })
 
   beforeEach(async () => {
-    wrapper = createComponent()
+    wrapper = createComponent(HomeCertification, {})
     await nextTick()
     await flushPromises()
   })

--- a/ppr-ui/tests/unit/HomeCertification.spec.ts
+++ b/ppr-ui/tests/unit/HomeCertification.spec.ts
@@ -1,9 +1,8 @@
 // Libraries
 import Vue, { nextTick } from 'vue'
 import Vuetify from 'vuetify'
-import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
-import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
+import { Wrapper } from '@vue/test-utils'
 
 // Components
 import { HomeCertification } from '@/components/mhrRegistration'
@@ -12,7 +11,7 @@ import flushPromises from 'flush-promises'
 import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
 import { HomeCertificationOptions, AuthRoles } from '@/enums'
-import { getTestId, createComponent } from './utils'
+import { createComponent } from './utils'
 
 Vue.use(Vuetify)
 
@@ -28,7 +27,7 @@ describe('Home Certification - staff', () => {
   beforeEach(async () => {
     wrapper = createComponent(HomeCertification, {})
     await store.setMhrHomeDescription({ key: 'certificationOption', value: null })
-    await store.setMhrHomeDescription({ key: 'noCertification', value: null })
+    await store.setMhrHomeDescription({ key: 'hasNoCertification', value: null })
     wrapper.vm.certificationOption = null
     wrapper.vm.hasNoCertification = false
     await nextTick()
@@ -55,7 +54,7 @@ describe('Home Certification - staff', () => {
     expect(wrapper.find('#csa-form').isVisible()).toBe(false)
     expect(wrapper.find('#engineer-form').isVisible()).toBe(false)
     expect(wrapper.find('#no-certification-checkbox').isVisible()).toBe(true)
-    expect(wrapper.find(getTestId('no-certification-tooltip')).exists()).toBe(true)
+    expect(wrapper.find('#no-certification-tooltip').exists()).toBe(true)
   })
 
   it('opens the CSA Form when selected', async () => {
@@ -198,6 +197,6 @@ describe('Home Certification - manufacturer', () => {
     expect(wrapper.find('#csa-form').isVisible()).toBe(true)
     expect(wrapper.find('#engineer-form').exists()).toBe(false)
     expect(wrapper.find('#no-certification').exists()).toBe(false)
-    expect(wrapper.find(getTestId('no-certification-tooltip')).exists()).toBe(false)
+    expect(wrapper.find('#no-certification-tooltip').exists()).toBe(false)
   })
 })

--- a/ppr-ui/tests/unit/HomeCertification.spec.ts
+++ b/ppr-ui/tests/unit/HomeCertification.spec.ts
@@ -11,7 +11,8 @@ import { SharedDatePicker } from '@/components/common'
 import flushPromises from 'flush-promises'
 import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
-import { HomeCertificationOptions } from '@/enums'
+import { HomeCertificationOptions, AuthRoles } from '@/enums'
+import { getTestId } from './utils'
 
 Vue.use(Vuetify)
 
@@ -40,15 +41,25 @@ function createComponent (): Wrapper<any> {
 describe('Home Certification - staff', () => {
   let wrapper: Wrapper<any>
 
+  beforeAll(async () => {
+    await store.setAuthRoles([AuthRoles.PPR_STAFF, AuthRoles.STAFF, AuthRoles.MHR, AuthRoles.PPR])
+  })
+
   beforeEach(async () => {
     wrapper = createComponent()
     await store.setMhrHomeDescription({ key: 'certificationOption', value: null })
+    await store.setMhrHomeDescription({ key: 'noCertification', value: null })
     wrapper.vm.certificationOption = null
+    wrapper.vm.hasNoCertification = false
     await nextTick()
     await flushPromises()
   })
   afterEach(() => {
     wrapper.destroy()
+  })
+
+  afterAll(async () => {
+    await store.setAuthRoles([])
   })
 
   it('renders base component with default sub components', async () => {
@@ -63,6 +74,8 @@ describe('Home Certification - staff', () => {
     // Verify Forms hidden before radio btn selection
     expect(wrapper.find('#csa-form').isVisible()).toBe(false)
     expect(wrapper.find('#engineer-form').isVisible()).toBe(false)
+    expect(wrapper.find('#no-certification-checkbox').isVisible()).toBe(true)
+    expect(wrapper.find(getTestId('no-certification-tooltip')).exists()).toBe(true)
   })
 
   it('opens the CSA Form when selected', async () => {
@@ -142,6 +155,32 @@ describe('Home Certification - staff', () => {
     await wrapper.find('#engineer-option').trigger('click')
     expect(wrapper.findComponent(SharedDatePicker).exists()).toBe(true)
   })
+
+  it('collapses form if no certification checkbox is selected', async () => {
+    await wrapper.find('#csa-option').trigger('click')
+    expect(wrapper.find('#csa-form').isVisible()).toBe(true)
+
+    await wrapper.find('#no-certification-checkbox').trigger('click')
+    expect(wrapper.find('#csa-form').isVisible()).toBe(false)
+  })
+
+  it('disables buttons if no certification checkbox is selected', async () => {
+    await wrapper.find('#no-certification-checkbox').trigger('click')
+
+    expect(wrapper.find('#csa-option').attributes('disabled')).toBe('disabled')
+    expect(wrapper.find('#engineer-option').attributes('disabled')).toBe('disabled')
+
+    // Enables button after unselected
+    await wrapper.find('#no-certification-checkbox').trigger('click')
+    expect(wrapper.find('#csa-option').attributes('disabled')).toBe(undefined)
+    expect(wrapper.find('#engineer-option').attributes('disabled')).toBe(undefined)
+  })
+
+  it('sets the home certification section to valid if no certification checkbox is selected', async () => {
+    expect(store.getMhrRegistrationValidationModel.yourHomeValid.homeCertificationValid).toBe(false)
+    await wrapper.find('#no-certification-checkbox').trigger('click')
+    expect(store.getMhrRegistrationValidationModel.yourHomeValid.homeCertificationValid).toBe(true)
+  })
 })
 
 describe('Home Certification - manufacturer', () => {
@@ -178,5 +217,7 @@ describe('Home Certification - manufacturer', () => {
     // Verify only csa-form is shown
     expect(wrapper.find('#csa-form').isVisible()).toBe(true)
     expect(wrapper.find('#engineer-form').exists()).toBe(false)
+    expect(wrapper.find('#no-certification').exists()).toBe(false)
+    expect(wrapper.find(getTestId('no-certification-tooltip')).exists()).toBe(false)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16797

*Description of changes:*
- Update Home Certification component to include no certification checkbox
- Update model and submission to accommodate this change
- Added tests

*Screenshots:* 

Checked:
![Screenshot 2023-07-14 130524](https://github.com/bcgov/ppr/assets/77707952/cadd225a-1c2a-47d0-8402-1de2775063ad)

Review and Confirm
![Screenshot 2023-07-14 130358](https://github.com/bcgov/ppr/assets/77707952/2327216e-b41f-4e36-8178-0e7627ba66cd)

Returning from Review and Confirm and Unchecked
![Screenshot 2023-07-14 130609](https://github.com/bcgov/ppr/assets/77707952/38cca88a-5402-4f42-aa9b-fc2d739619d4)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
