### PR TITLE
Minor fix to home sections form validations

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.28",
+      "version": "2.0.29",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
@@ -119,7 +119,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, ref, toRefs } from 'vue-demi'
+import { computed, defineComponent, reactive, ref, toRefs, nextTick } from 'vue-demi'
 /* eslint-disable no-unused-vars */
 import { FormIF, HomeSectionIF } from '@/interfaces'
 import { useInputRules } from '@/composables/useInputRules'
@@ -172,8 +172,10 @@ export default defineComponent({
 
     const close = (): void => { context.emit('close') }
     const remove = (): void => { context.emit('remove') }
-    const submit = (): void => {
+    const submit = async (): Promise<void> => {
       localState.hasSubmit = true
+      await nextTick()
+
       addEditHomeSectionsForm.value?.validate()
 
       if (localState.addEditValid) {

--- a/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-card flat rounded id="add-edit-home-sections-form" class="mt-2 mb-5 pa-7">
+  <v-card
+    id="add-edit-home-sections-form"
+    flat
+    rounded
+    class="mt-2 mb-5 pa-7"
+    :class="{'border-error-left': validate && isNewHomeSection }">
     <v-form ref="addEditHomeSectionsForm" v-model="addEditValid">
       <v-row no-gutters>
         <v-col cols="12" sm="2">
@@ -130,7 +135,8 @@ export default defineComponent({
   emits: ['close', 'remove', 'submit'],
   props: {
     isNewHomeSection: { type: Boolean, default: true },
-    editHomeSection: { type: Object as () => HomeSectionIF, default: () => {} }
+    editHomeSection: { type: Object as () => HomeSectionIF, default: () => {} },
+    validate: { type: Boolean, default: false }
   },
   setup (props, context) {
     const {

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeSections.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeSections.vue
@@ -28,6 +28,7 @@
       <AddEditHomeSections
         v-if="showAddEditHomeSections"
         :isNewHomeSection="isNewHomeSection"
+        :validate="validate"
         @close="showAddEditHomeSections = false"
         @submit="addHomeSection($event)"
       />


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16936

*Description of changes:*
- Awaited `nextTick()` so that component updates before form validation takes place.
- Added a left border error if returned from review and confirm to add section form (detached from home section)

*Screenshots:*

Form Validates when pressing done:
![image](https://github.com/bcgov/ppr/assets/77707952/2f9e226a-3596-483e-ab5b-e5a19063984a)

Left border error when returning from review and confirm:

![image](https://github.com/bcgov/ppr/assets/77707952/72571d67-093e-40db-9659-10dbc497dd35)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
