### PR TITLE
Remove secured party dialog modal for registering party

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.30",
+      "version": "2.0.31",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
+++ b/ppr-ui/src/components/dialogs/SecuredPartyDialog.vue
@@ -16,7 +16,7 @@
           </v-row>
           <v-row no-gutters v-if="!isDuplicate" class="pt-5">
             <v-col class="text-md-center ml-8">
-              <h1 class="dialogTitle">{{ totalParties }} Similar {{ partyWord }} Parties Found</h1>
+              <h1 class="dialogTitle">{{ totalParties }} Similar Secured Parties Found</h1>
             </v-col>
           </v-row>
           <v-row v-else no-gutters class="pt-5">
@@ -36,9 +36,9 @@
 
       <div>
         <p v-if="!isDuplicate" class="text-md-center px-6 pt-3 intro">
-          One or more similar {{ partyWord }} Parties were found. Do you want to use an
-          existing {{ partyWord }} Party listed below or use your information to create
-          a new {{ partyWord }} Party?
+          One or more similar Secured Parties were found. Do you want to use an
+          existing Secured Party listed below or use your information to create
+          a new Secured Party?
         </p>
         <p v-else-if="!isReview" class="text-md-center px-6 pt-3 intro">
           Registrations cannot list a Secured Party with the same name and address more than once. This registration
@@ -52,7 +52,7 @@
       </div>
       <div class="partyWindow">
         <div v-if="!isDuplicate" class="text-md-center generic-label" id="create-new-party">
-          Use my information and create a new {{ partyWord }} Party:
+          Use my information and create a new Secured Party:
         </div>
 
         <v-container class="currentParty">
@@ -97,12 +97,12 @@
         </v-container>
 
         <div v-if="!isDuplicate" class="text-md-center generic-label">
-          Use an existing {{ partyWord }} Party:
+          Use an existing Secured Party:
         </div>
         <v-container v-if="!isDuplicate">
           <v-row
             class="searchResponse"
-            :class="isExistingSecuredParty(result.code, isRegisteringParty)
+            :class="isExistingSecuredParty(result.code)
                     ? 'company-row-no-hover' : 'companyRow'"
             v-for="(result, i) in results"
             :key="i"
@@ -121,10 +121,10 @@
                 {{ getCountryName(result.address.country) }}
               </div>
               <div class="addressText">
-                {{ partyWord }} Party Code: {{ result.code }}
+                Secured Party Code: {{ result.code }}
               </div>
             </v-col>
-            <v-col v-if="!isExistingSecuredParty(result.code, isRegisteringParty)" cols="2" class="pt-5">
+            <v-col v-if="!isExistingSecuredParty(result.code)" cols="2" class="pt-5">
               <v-btn
                 class="ml-auto float-right partyButton"
                 color="primary"
@@ -178,7 +178,6 @@ import { useSecuredParty } from '@/composables/parties'
 import {
   useCountriesProvinces
 } from '@/composables/address/factories'
-import { ActionTypes } from '@/enums'
 import ErrorContact from '@/components/common/ErrorContact.vue'
 
 export default defineComponent({
@@ -201,10 +200,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    isRegisteringParty: {
-      type: Boolean,
-      default: false
-    },
     activeIndex: {
       type: Number,
       default: -1
@@ -224,19 +219,12 @@ export default defineComponent({
       }),
       totalParties: computed((): number => {
         return props.defaultResults.length
-      }),
-      partyWord: computed((): string => {
-        if (props.isRegisteringParty) {
-          return 'Registering'
-        }
-        return 'Secured'
       })
     })
 
     const countryProvincesHelpers = useCountriesProvinces()
 
     const {
-      setRegisteringParty,
       isExistingSecuredParty,
       addEditSecuredParty,
       currentSecuredParty
@@ -250,24 +238,14 @@ export default defineComponent({
         emailAddress: selectedResult.emailAddress,
         code: selectedResult.code
       }
-      if (props.isRegisteringParty) {
-        newParty.action = ActionTypes.EDITED
-        setRegisteringParty(newParty)
-      } else {
-        currentSecuredParty.value = newParty
-        addEditSecuredParty(props.activeIndex)
-      }
+      currentSecuredParty.value = newParty
+      addEditSecuredParty(props.activeIndex)
       context.emit('emitResetClose')
     }
 
     const createParty = () => {
-      if (props.isRegisteringParty) {
-        localState.party.action = ActionTypes.EDITED
-        setRegisteringParty(localState.party)
-      } else {
-        currentSecuredParty.value = localState.party
-        addEditSecuredParty(props.activeIndex)
-      }
+      currentSecuredParty.value = localState.party
+      addEditSecuredParty(props.activeIndex)
       context.emit('emitResetClose')
     }
 

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -370,8 +370,7 @@ export default defineComponent({
           currentSecuredParty.value.personName.last = ''
         }
         // check for duplicate
-        if (!props.isRegisteringParty &&
-          hasMatchingSecuredParty(currentSecuredParty.value, props.isEditMode, props.activeIndex)) {
+        if (hasMatchingSecuredParty(currentSecuredParty.value, props.isEditMode, props.activeIndex)) {
           // trigger duplicate secured party dialog
           localState.foundDuplicate = true
           showDialog()

--- a/ppr-ui/src/components/parties/party/EditParty.vue
+++ b/ppr-ui/src/components/parties/party/EditParty.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="edit-party" class="white pa-6" :class="{ 'border-error-left': setShowErrorBar }">
     <secured-party-dialog
+      v-if="!isRegisteringParty"
       attach="#app"
       :isDuplicate="foundDuplicate"
       :defaultDialog="toggleDialog"
       :defaultParty="currentSecuredParty"
       :defaultResults="dialogResults"
-      :isRegisteringParty="isRegisteringParty"
       :activeIndex="activeIndex"
       @emitResetClose="closeAndReset"
       @emitClose="toggleDialog = false"
@@ -369,6 +369,13 @@ export default defineComponent({
           currentSecuredParty.value.personName.middle = ''
           currentSecuredParty.value.personName.last = ''
         }
+
+        if (props.isRegisteringParty) {
+          setRegisteringParty(currentSecuredParty.value)
+          context.emit('resetEvent')
+          return
+        }
+
         // check for duplicate
         if (hasMatchingSecuredParty(currentSecuredParty.value, props.isEditMode, props.activeIndex)) {
           // trigger duplicate secured party dialog
@@ -376,6 +383,7 @@ export default defineComponent({
           showDialog()
           return
         }
+
         if (currentSecuredParty.value.businessName && localState.isPartyTypeBusiness) {
           if (!isEqual(currentSecuredParty, originalSecuredParty)) {
             // go to the service and see if there are similar secured parties
@@ -392,12 +400,7 @@ export default defineComponent({
           }
         }
 
-        if (props.isRegisteringParty) {
-          setRegisteringParty(currentSecuredParty.value)
-          context.emit('resetEvent')
-        } else {
-          addEditSecuredParty(props.activeIndex)
-        }
+        addEditSecuredParty(props.activeIndex)
       } else {
         // trigger show validation
         localState.showAllAddressErrors = !localState.showAllAddressErrors

--- a/ppr-ui/src/composables/parties/useSecuredParty.ts
+++ b/ppr-ui/src/composables/parties/useSecuredParty.ts
@@ -93,7 +93,7 @@ export const useSecuredParty = (context?) => {
     }
   }
 
-  const isExistingSecuredParty = (partyCode: string, isRegisteringParty: boolean): boolean => {
+  const isExistingSecuredParty = (partyCode: string, isRegisteringParty: boolean = false): boolean => {
     if (isRegisteringParty) {
       return getAddSecuredPartiesAndDebtors.value?.registeringParty?.code === partyCode
     }

--- a/ppr-ui/tests/unit/SecuredPartyDialog.spec.ts
+++ b/ppr-ui/tests/unit/SecuredPartyDialog.spec.ts
@@ -46,21 +46,3 @@ describe('Secured Party Dialog SA tests', () => {
     expect(wrapper.find('.currentParty .businessName').text()).toBe(mockedSecuredParties1[0].businessName)
   })
 })
-
-describe('Registering Party Dialog SA tests', () => {
-  let wrapper: Wrapper<any>
-
-  beforeEach(async () => {
-    wrapper = createComponent(SecuredPartyDialog, props)
-  })
-  afterEach(() => {
-    wrapper.destroy()
-  })
-
-  it('renders with default values', async () => {
-    expect(wrapper.findComponent(SecuredPartyDialog).exists()).toBe(true)
-    wrapper.setProps({ isRegisteringParty: true })
-    await nextTick()
-    expect(wrapper.find('#create-new-party').text()).toContain('new Registering Party')
-  })
-})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16097

*Description of changes:*
- No longer shows the secured party dialog modal when adding or changing a registering party.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
