### PR TITLE
Makes Add/Edit  home section label red

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/AddEditHomeSections.vue
@@ -8,7 +8,12 @@
     <v-form ref="addEditHomeSectionsForm" v-model="addEditValid">
       <v-row no-gutters>
         <v-col cols="12" sm="2">
-          <label class="generic-label">{{ isNewHomeSection ? 'Add' : 'Edit' }} Section</label>
+          <label
+            class="generic-label"
+            :class="{ 'error-text': validate }"
+          >
+            {{ isNewHomeSection ? 'Add' : 'Edit' }} Section
+          </label>
         </v-col>
         <v-col cols="12" sm="10" class="pl-2">
           <!-- Add Edit Form -->

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeSections.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeSections.vue
@@ -37,6 +37,7 @@
     <!-- Home Sections Table -->
     <HomeSectionsTable
       :class="{ 'border-error-left': validate }"
+      :validate="validate"
       :isAdding="showAddEditHomeSections"
       :homeSections="getMhrHomeSections"
       :isReviewMode="isReviewMode"

--- a/ppr-ui/src/components/tables/mhr/HomeSectionsTable.vue
+++ b/ppr-ui/src/components/tables/mhr/HomeSectionsTable.vue
@@ -24,6 +24,7 @@
                 <AddEditHomeSections
                     :editHomeSection="item"
                     :isNewHomeSection="false"
+                    :validate="validate"
                     @close="activeIndex = -1"
                     @remove="remove(item)"
                     @submit="edit($event)"
@@ -105,7 +106,8 @@ export default defineComponent({
   props: {
     isAdding: { default: false },
     isReviewMode: { default: false },
-    homeSections: { type: Array as () => HomeSectionIF[], default: () => [] }
+    homeSections: { type: Array as () => HomeSectionIF[], default: () => [] },
+    validate: { type: Boolean, default: false }
   },
   setup (props, context) {
     const localState = reactive({


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16936

*Description of changes:*
- Highlights label when returning from review and confirm screen and panel is open

![Screenshot 2023-07-18 161311](https://github.com/bcgov/ppr/assets/77707952/11226a18-573c-40fb-b7ab-8145f785bfe9)
![Screenshot 2023-07-18 161335](https://github.com/bcgov/ppr/assets/77707952/b32c7f88-e81a-4625-bc14-a77b643460c0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
