### PR TITLE
Account reg summary, reg current view, data validation updates.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -108,7 +108,16 @@ SELECT COUNT(documtid)
  WHERE documtid = :query_value
 """
 QUERY_ACCOUNT_ADD_REGISTRATION = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+SELECT mh.mhregnum,
+       CASE
+        WHEN mh.mhstatus = 'R' AND
+             EXISTS (SELECT n.regdocid
+                       FROM mhomnote n
+                      WHERE n.manhomid = mh.manhomid AND n.status = 'A' and n.docutype in ('TAXN')) THEN
+             'F'
+        ELSE mh.mhstatus
+       END AS mhstatus,
+       d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
        (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
           FROM owner o2, owngroup og2
          WHERE o2.manhomid = mh.manhomid
@@ -131,7 +140,7 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
           FROM mhomnote n
          WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry,
         CASE
-        WHEN d.docutype = 'NCAN' THEN
+        WHEN d.docutype in ('NCAN', 'NRED') THEN
           (SELECT n.docutype
              FROM mhomnote n
             WHERE n.manhomid = mh.manhomid AND n.candocid = d.documtid AND n.docutype NOT IN ('CAUC', 'CAUE')
@@ -143,7 +152,16 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
    AND mh.mhregnum = d.mhregnum
 """
 QUERY_ACCOUNT_ADD_REGISTRATION_DOC = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+SELECT mh.mhregnum,
+       CASE
+        WHEN mh.mhstatus = 'R' AND
+             EXISTS (SELECT n.regdocid
+                       FROM mhomnote n
+                      WHERE n.manhomid = mh.manhomid AND n.status = 'A' and n.docutype in ('TAXN')) THEN
+             'F'
+        ELSE mh.mhstatus
+       END AS mhstatus,
+       d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
        (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
           FROM owner o2, owngroup og2
          WHERE o2.manhomid = mh.manhomid
@@ -166,7 +184,7 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
           FROM mhomnote n
          WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry,
         CASE
-        WHEN d.docutype = 'NCAN' THEN
+        WHEN d.docutype in ('NCAN', 'NRED') THEN
           (SELECT n.docutype
              FROM mhomnote n
             WHERE n.manhomid = mh.manhomid AND n.candocid = d.documtid AND n.docutype NOT IN ('CAUC', 'CAUE')
@@ -179,7 +197,16 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
    AND mh.mhregnum = d.mhregnum
 """
 QUERY_ACCOUNT_REGISTRATIONS = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+SELECT mh.mhregnum,
+       CASE
+        WHEN mh.mhstatus = 'R' AND
+             EXISTS (SELECT n.regdocid
+                       FROM mhomnote n
+                      WHERE n.manhomid = mh.manhomid AND n.status = 'A' and n.docutype in ('TAXN')) THEN
+             'F'
+        ELSE mh.mhstatus
+       END AS mhstatus,
+       d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
        (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
           FROM owner o2, owngroup og2
          WHERE o2.manhomid = mh.manhomid
@@ -202,7 +229,7 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
           FROM mhomnote n
          WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry,
         CASE
-        WHEN d.docutype = 'NCAN' THEN
+        WHEN d.docutype in ('NCAN', 'NRED') THEN
           (SELECT n.docutype
              FROM mhomnote n
             WHERE n.manhomid = mh.manhomid AND n.candocid = d.documtid AND n.docutype NOT IN ('CAUC', 'CAUE')
@@ -215,7 +242,16 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
  ORDER BY d.regidate DESC
 """
 QUERY_ACCOUNT_REGISTRATIONS_SORT = """
-SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
+SELECT mh.mhregnum,
+       CASE
+        WHEN mh.mhstatus = 'R' AND
+             EXISTS (SELECT n.regdocid
+                       FROM mhomnote n
+                      WHERE n.manhomid = mh.manhomid AND n.status = 'A' and n.docutype in ('TAXN')) THEN
+             'F'
+        ELSE mh.mhstatus
+       END AS mhstatus,
+       d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRIM(d.docutype),
        (SELECT XMLSERIALIZE(XMLAGG ( XMLELEMENT ( NAME "owner", o2.ownrtype || TRIM(o2.ownrname))) AS CLOB)
           FROM owner o2, owngroup og2
          WHERE o2.manhomid = mh.manhomid
@@ -238,7 +274,7 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
           FROM mhomnote n
          WHERE mh.manhomid = n.manhomid AND n.regdocid = d.documtid) AS note_expiry,
         CASE
-        WHEN d.docutype = 'NCAN' THEN
+        WHEN d.docutype in ('NCAN', 'NRED') THEN
           (SELECT n.docutype
              FROM mhomnote n
             WHERE n.manhomid = mh.manhomid AND n.candocid = d.documtid AND n.docutype NOT IN ('CAUC', 'CAUE')

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -23,6 +23,7 @@ from mhr_api.models.type_tables import (
     MhrDocumentTypes,
     MhrNoteStatusTypes,
     MhrRegistrationTypes,
+    MhrRegistrationStatusTypes,
     MhrStatusTypes
 )
 from mhr_api.models.db import db
@@ -169,7 +170,8 @@ LEGACY_STATUS_DESCRIPTION = {
     'R': 'ACTIVE',
     'E': 'EXEMPT',
     'D': 'DRAFT',
-    'C': 'CANCELLED'
+    'C': 'CANCELLED',
+    'F': 'FROZEN'  # Account registration summary queries only
 }
 TO_LEGACY_STATUS = {
     'ACTIVE': 'R',
@@ -560,6 +562,8 @@ def __update_summary_info(result, results, reg_summary_list, staff, account_id):
     if not result.get('ownerNames'):
         result['ownerNames'] = __get_owner_names(result, results)
     summary_result = __get_summary_result(result, reg_summary_list)
+    if staff and result.get('statusType') == model_utils.STATUS_FROZEN:
+        result['statusType'] = MhrRegistrationStatusTypes.ACTIVE
     if not summary_result:
         doc_type = result.get('documentType')
         if FROM_LEGACY_DOC_TYPE.get(doc_type):

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -198,11 +198,15 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             elif self.current_view:
                 reg_json['notes'] = reg_utils.get_non_staff_notes_json(self, False)
             reg_json['hasCaution'] = self.set_caution()
+            if self.current_view and not self.staff and model_utils.has_taxn_note(reg_json):
+                reg_json['status'] = model_utils.STATUS_FROZEN
             current_app.logger.debug('Built new registration JSON')
             return self.set_payment_json(reg_json)
-
         if model_utils.is_legacy() and self.manuhome:
-            return legacy_utils.get_new_registration_json(self)
+            reg_json = legacy_utils.get_new_registration_json(self)
+            if self.current_view and not self.staff and model_utils.has_taxn_note(reg_json):
+                reg_json['status'] = model_utils.STATUS_FROZEN
+            return reg_json
         return self.json
 
     def set_payment_json(self, registration):

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -25,6 +25,8 @@ import pytz
 from datedelta import datedelta
 from flask import current_app
 
+from mhr_api.models.type_tables import MhrDocumentTypes, MhrNoteStatusTypes
+
 
 # Local timzone
 LOCAL_TZ = pytz.timezone('America/Los_Angeles')
@@ -784,3 +786,14 @@ def expiry_datetime(expiry_iso: str):
     local_ts = LOCAL_TZ.localize(expiry_ts)
     # Return as UTC
     return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)
+
+
+def has_taxn_note(reg_json: dict) -> bool:
+    """For registries non-staff check if an active TAXN unit note exists."""
+    if not reg_json or not reg_json.get('notes'):
+        return False
+    for note in reg_json.get('notes'):
+        if note.get('documentType') == MhrDocumentTypes.TAXN and \
+                (not note.get('status') or note.get('status') == MhrNoteStatusTypes.ACTIVE):
+            return True
+    return False

--- a/mhr_api/src/mhr_api/utils/note_validator.py
+++ b/mhr_api/src/mhr_api/utils/note_validator.py
@@ -62,7 +62,6 @@ def validate_note(registration: MhrRegistration, json_data, staff: bool = False,
         doc_type: str = None
         if json_data.get('note') and json_data['note'].get('documentType'):
             doc_type = json_data['note'].get('documentType')
-        error_msg += validate_remarks(json_data, doc_type)
         error_msg += validate_giving_notice(json_data, doc_type)
         error_msg += validate_effective_ts(json_data, doc_type)
         error_msg += validate_expiry_ts(registration, json_data, doc_type)

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -321,7 +321,7 @@ def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, nc
         assert 'notes' in reg_json
         assert not reg_json.get('notes')
     else:
-        assert 'notes' not in reg_json
+        assert not reg_json.get('notes')
     # search version
     reg_json = manuhome.registration_json
     if has_notes:

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -509,10 +509,12 @@ TEST_DATA_LTSA_PID = [
     ('001020', '2523', False),
     ('001019', '2523', True)
 ]
-# testdata pattern is ({mhr_num}, {account_id}, {status})
+# testdata pattern is ({mhr_num}, {account_id}, {status}, {staff})
 TEST_DATA_STATUS = [
-    ('003936', '2523', 'FROZEN'),
-    ('003304', '2523', 'ACTIVE')
+    ('003936', '2523', 'FROZEN', True),
+    ('003304', '2523', 'ACTIVE', True),
+    ('022873', 'ppr_staff', 'ACTIVE', True),
+    ('022873', 'ppr_staff', 'FROZEN', False)
 ]
 # testdata pattern is ({mhr_num}, {staff}, {current}, {has_notes}, {account_id}, {has_caution}, {ncan_doc_id})
 TEST_MHR_NUM_DATA_NOTE = [
@@ -774,13 +776,14 @@ def test_find_by_mhr_number_pid(session, mhr_number, account_id, has_pid):
         assert not reg_json['location'].get('legalDescription')
 
 
-@pytest.mark.parametrize('mhr_number, account_id, status', TEST_DATA_STATUS)
-def test_find_by_mhr_number_status(session, mhr_number, account_id, status):
+@pytest.mark.parametrize('mhr_number, account_id, status, staff', TEST_DATA_STATUS)
+def test_find_by_mhr_number_status(session, mhr_number, account_id, status, staff):
     """Assert that finding an MHR registration MHR number returns the expected status."""
     registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_number, account_id)
     assert registration
     assert registration.mhr_number == mhr_number
     registration.current_view = True
+    registration.staff = staff
     reg_json = registration.new_registration_json
     assert reg_json.get('status') == status
 

--- a/mhr_api/tests/unit/utils/test_note_validator.py
+++ b/mhr_api/tests/unit/utils/test_note_validator.py
@@ -119,7 +119,7 @@ TEST_NOTE_DATA_EXPIRY = [
 ]
 # test data pattern is ({description}, {valid}, {doc_type}, {remarks}, {mhr_num}, {account}, {message_content})
 TEST_NOTE_DATA_REMARKS = [
-    ('Invalid required', False, 'CAU', None, '102876', 'ppr_staff', validator.REMARKS_REQUIRED),
+    ('Valid optional CAU new rule', True, 'CAU', None, '102876', 'ppr_staff', None),
     ('Valid NCAN allowed new rule', True, 'NCAN', 'REMARKS', '045718', 'ppr_staff', None),
     ('Valid optional', True, 'NPUB', None, '102876', 'ppr_staff', None)
 ]

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -287,6 +287,8 @@ TEST_PERMIT_DATA = [
     ('Valid no doc id not staff', True, False, None, None, '100413', 'PS12345', REQUEST_TRANSPORT_PERMIT),
     ('Invalid FROZEN', False, False, None, validator_utils.STATE_NOT_ALLOWED, '003936', '2523',
      REQUEST_TRANSPORT_PERMIT),
+    ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_TAXN, '022873', 'ppr_staff',
+     REQUEST_TRANSPORT_PERMIT),
     ('Invalid staff FROZEN', False, True, None, validator_utils.STATE_FROZEN_AFFIDAVIT, '003936', 'ppr_staff',
      REQUEST_TRANSPORT_PERMIT),
     ('Invalid EXEMPT', False, False, None, validator_utils.STATE_NOT_ALLOWED, '077010', 'ppr_staff', STAFF_ROLE),

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -241,7 +241,8 @@ TEST_EXEMPTION_DATA = [
     ('Valid no doc id not staff', True, False, None, None, None),
     ('Invalid EXEMPT', False, False, None, validator_utils.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT),
     ('Invalid CANCELLED', False, False, None, validator_utils.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL),
-    ('Invalid note doc type', False, False, None, validator.NOTE_DOC_TYPE_INVALID, MhrRegistrationStatusTypes.ACTIVE)
+    ('Invalid note doc type', False, False, None, validator.NOTE_DOC_TYPE_INVALID, MhrRegistrationStatusTypes.ACTIVE),
+    ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_TAXN, MhrRegistrationStatusTypes.ACTIVE)
 ]
 # testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {groups}, {message content})
 TEST_REG_DATA_GROUP = [
@@ -415,6 +416,9 @@ def test_validate_exemption(session, desc, valid, staff, doc_id, message_content
         account_id = 'ppr_staff'
     elif desc == 'Invalid CANCELLED':
         mhr_num = '001453'
+        account_id = 'ppr_staff'
+    elif desc == 'Invalid FROZEN TAXN':
+        mhr_num = '022873'
         account_id = 'ppr_staff'
     del json_data['submittingParty']['phoneExtension']
     # current_app.logger.info(json_data)

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -78,6 +78,7 @@ TEST_TRANSFER_DATA = [
     ('Invalid EXEMPT', False, False, None, validator_utils.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.EXEMPT),
     ('Invalid CANCELLED', False, False, None, validator_utils.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.HISTORICAL),
     ('Invalid FROZEN', False, False, None, validator_utils.STATE_NOT_ALLOWED, MhrRegistrationStatusTypes.ACTIVE),
+    ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_TAXN, MhrRegistrationStatusTypes.ACTIVE),
     ('Invalid draft', False, False, None, validator_utils.DRAFT_NOT_ALLOWED, MhrRegistrationStatusTypes.ACTIVE),
     (DESC_INVALID_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_INVALID, MhrRegistrationStatusTypes.ACTIVE),
     (DESC_NONEXISTENT_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_NONEXISTENT,
@@ -267,10 +268,13 @@ def test_validate_transfer(session, desc, valid, staff, doc_id, message_content,
     elif desc == 'Invalid CANCELLED':
         mhr_num = '001453'
         account_id = 'ppr_staff'
+    elif desc == 'Invalid FROZEN TAXN':
+        mhr_num = '022873'
+        account_id = 'ppr_staff'
 
     valid_format, errors = schema_utils.validate(json_data, 'transfer', 'mhr')
     # Additional validation not covered by the schema.
-    registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+    registration: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_num, account_id)
     if status:
         registration.status_type = status
     error_msg = validator.validate_transfer(registration, json_data, staff, STAFF_ROLE)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17148

*Description of changes:*
- API data validation non-staff add TAXN frozen state check.
- Account registration summary conditional FROZEN state when non-staff and active TAXN note exists.
- Registration current view conditional FROZEN state when non-staff and active TAXN note exists. Notes array will include an item with a TAXN documentType.
- Remove remarks requirement with CAU unit note registrations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
