### PR TITLE
Add new qualified supplier info endpoints.

### DIFF
--- a/mhr_api/src/mhr_api/models/__init__.py
+++ b/mhr_api/src/mhr_api/models/__init__.py
@@ -42,6 +42,7 @@ from .mhr_manufacturer import MhrManufacturer
 from .mhr_note import MhrNote
 from .mhr_owner_group import MhrOwnerGroup
 from .mhr_party import MhrParty
+from .mhr_qualified_supplier import MhrQualifiedSupplier
 from .mhr_registration import MhrRegistration
 from .mhr_registration_report import MhrRegistrationReport
 from .mhr_section import MhrSection
@@ -80,7 +81,7 @@ __all__ = ('db',
            'LtsaDescription', 'MhrDraft', 'MhrDocument', 'MhrDescription', 'MhrExtraRegistration',
            'MhrLocation', 'MhrManufacturer', 'MhrNote', 'MhrParty', 'MhrRegistration',
            'MhrRegistrationReport', 'MhrDocumentType', 'MhrLocationType', 'MhrNoteStatusType', 'MhrOwnerGroup',
-           'MhrOwnerStatusType', 'MhrPartyType',
+           'MhrOwnerStatusType', 'MhrPartyType', 'MhrQualifiedSupplier',
            'MhrRegistrationStatusType', 'MhrRegistrationType', 'MhrSection', 'MhrStatusType', 'MhrTenancyType',
            'Party', 'PartyType', 'ProvinceType', 'Registration', 'RegistrationType',
            'RegistrationTypeClass', 'SearchRequest', 'SearchResult', 'SearchType', 'StateType', 'SerialType',

--- a/mhr_api/src/mhr_api/models/mhr_qualified_supplier.py
+++ b/mhr_api/src/mhr_api/models/mhr_qualified_supplier.py
@@ -1,0 +1,115 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds data for qualifid supplier party information."""
+from __future__ import annotations
+
+# from flask import current_app
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+
+from .db import db
+from .address import Address  # noqa: F401 pylint: disable=unused-import
+from .type_tables import MhrPartyTypes
+
+
+class MhrQualifiedSupplier(db.Model):  # pylint: disable=too-many-instance-attributes
+    """This class manages all of the MHR qualiifed supplier parties (people and businesses)."""
+
+    __tablename__ = 'mhr_qualified_suppliers'
+
+    id = db.Column('id', db.Integer, db.Sequence('mhr_supplier_id_seq'), primary_key=True)
+    # party person
+    first_name = db.Column('first_name', db.String(50), nullable=True)
+    middle_name = db.Column('middle_name', db.String(50), nullable=True)
+    last_name = db.Column('last_name', db.String(50), nullable=True)
+    # or party business
+    business_name = db.Column('business_name', db.String(150), nullable=True)
+    account_id = db.Column('account_id', db.String(20), nullable=False)
+    email_id = db.Column('email_address', db.String(250), nullable=True)
+    phone_number = db.Column('phone_number', db.String(20), nullable=True)
+    phone_extension = db.Column('phone_extension', db.String(10), nullable=True)
+
+    # parent keys
+    address_id = db.Column('address_id', db.Integer, db.ForeignKey('addresses.id'), nullable=True, index=True)
+    party_type = db.Column('party_type', PG_ENUM(MhrPartyTypes),
+                           db.ForeignKey('mhr_party_types.party_type'), nullable=False)
+    # Relationships - Addressess
+    address = db.relationship('Address', foreign_keys=[address_id], uselist=False)
+
+    @property
+    def json(self) -> dict:
+        """Return the party as a json object."""
+        party = {
+            'partyType': self.party_type,
+            'address': self.address.json
+        }
+        if self.business_name:
+            party['businessName'] = self.business_name
+        elif self.last_name:
+            person_name = {
+                'first': self.first_name,
+                'last': self.last_name
+            }
+            if self.middle_name:
+                person_name['middle'] = self.middle_name
+            party['personName'] = person_name
+        if self.email_id:
+            party['emailAddress'] = self.email_id
+        if self.phone_number:
+            party['phoneNumber'] = self.phone_number
+        if self.phone_extension:
+            party['phoneExtension'] = self.phone_extension
+        return party
+
+    def save(self):
+        """Render a qualified supplier to the local cache."""
+        db.session.add(self)
+        db.session.commit()
+
+    @classmethod
+    def find_by_id(cls, supplier_id: int = None):
+        """Return a qualified suppier party object by primary key ID."""
+        supplier = None
+        if supplier_id:
+            supplier = cls.query.get(supplier_id)
+        return supplier
+
+    @classmethod
+    def find_by_account_id(cls, account_id: str = None):
+        """Return a list of party objects by registration id."""
+        supplier = None
+        if account_id:
+            supplier = cls.query.filter(MhrQualifiedSupplier.account_id == account_id).one_or_none()
+        return supplier
+
+    @staticmethod
+    def create_from_json(json_data, account_id: str, party_type: str):
+        """Create a qualified supplier object from a json schema object: map json to db."""
+        # current_app.logger.info(json_data)
+        supplier: MhrQualifiedSupplier = MhrQualifiedSupplier(account_id=account_id,
+                                                              party_type=party_type)
+        if json_data.get('businessName'):
+            supplier.business_name = json_data['businessName'].strip().upper()
+        else:
+            supplier.last_name = json_data['personName']['last'].strip().upper()
+            supplier.first_name = json_data['personName']['first'].strip().upper()
+            if json_data['personName'].get('middle'):
+                supplier.middle_name = json_data['personName']['middle'].strip().upper()
+        if json_data.get('emailAddress'):
+            supplier.email_id = json_data['emailAddress'].strip()
+        if json_data.get('phoneNumber'):
+            supplier.phone_number = json_data['phoneNumber'].strip()
+        if json_data.get('phoneExtension'):
+            supplier.phone_extension = json_data['phoneExtension'].strip()
+        supplier.address = Address.create_from_json(json_data['address'])
+        return supplier

--- a/mhr_api/src/mhr_api/resources/v1/__init__.py
+++ b/mhr_api/src/mhr_api/resources/v1/__init__.py
@@ -28,6 +28,7 @@ from .notes import bp as notes_bp
 from .ops import bp as ops_bp
 from .other_registrations import bp as other_registrations_bp
 from .permits import bp as permits_bp
+from .qualified_supplier import bp as qualified_supplier_bp
 from .registration_report_callback import bp as registration_report_callback_bp
 from .registrations import bp as registrations_bp
 from .search_history import bp as search_history_bp
@@ -62,6 +63,7 @@ class V1Endpoint:
         self.app.register_blueprint(ops_bp)
         self.app.register_blueprint(other_registrations_bp)
         self.app.register_blueprint(permits_bp)
+        self.app.register_blueprint(qualified_supplier_bp)
         self.app.register_blueprint(registrations_bp)
         self.app.register_blueprint(searches_bp)
         self.app.register_blueprint(search_history_bp)

--- a/mhr_api/src/mhr_api/resources/v1/qualified_supplier.py
+++ b/mhr_api/src/mhr_api/resources/v1/qualified_supplier.py
@@ -1,0 +1,94 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for executing MHR qualified supplier contact information requests."""
+
+# pylint: disable=too-many-return-statements
+
+from http import HTTPStatus
+
+from flask import Blueprint
+from flask import request, jsonify, current_app
+from flask_cors import cross_origin
+from registry_schemas import utils as schema_utils
+
+from mhr_api.utils.auth import jwt
+from mhr_api.exceptions import BusinessException, DatabaseException
+from mhr_api.services.authz import authorized
+from mhr_api.models import MhrQualifiedSupplier
+from mhr_api.models.type_tables import MhrPartyTypes
+from mhr_api.resources import utils as resource_utils, registration_utils as reg_utils
+from mhr_api.utils import validator_utils
+
+
+bp = Blueprint('SUPPLIER1', __name__, url_prefix='/api/v1/qualified-suppliers')  # pylint: disable=invalid-name
+
+
+@bp.route('', methods=['GET', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def get_account_qualified_supplier():
+    """Get account qualified supplier information."""
+    try:
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        current_app.logger.info(f'Getting qualified supplier information for account {account_id}.')
+        supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_account_id(account_id)
+        if supplier:
+            return jsonify(supplier.json), HTTPStatus.OK
+        current_app.logger.info(f'No qualified supplier info found for account {account_id}.')
+        return resource_utils.not_found_error_response('qualified supplier information', account_id)
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id, 'GET manufacturer info')
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('', methods=['POST', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def post_account_qualified_supplier():
+    """Create qualified supplier information for an account."""
+    try:
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        current_app.logger.info(f'Creating qualified supplier  information for account {account_id}.')
+        supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_account_id(account_id)
+        if supplier:
+            msg: str = f'Qualified supplier information already exists for account {account_id}.'
+            current_app.logger.error(msg)
+            return resource_utils.bad_request_response(msg)
+        request_json = request.get_json(silent=True)
+        valid_format, errors = schema_utils.validate(request_json, 'party', 'common')
+        # Additional validation not covered by the schema.
+        extra_validation_msg = validator_utils.validate_party(request_json, 'qualified supplier')
+        if not valid_format or extra_validation_msg != '':
+            return resource_utils.validation_error_response(errors, reg_utils.VAL_ERROR, extra_validation_msg)
+        supplier = MhrQualifiedSupplier.create_from_json(request_json, account_id, MhrPartyTypes.CONTACT)
+        supplier.save()
+        return jsonify(supplier.json), HTTPStatus.OK
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id, 'GET manufacturer info')
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)

--- a/mhr_api/src/mhr_api/utils/validator_utils.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils.py
@@ -170,6 +170,16 @@ def validate_submitting_party(json_data):
     return error_msg
 
 
+def validate_party(party: dict, desc: str):
+    """Verify party names are valid."""
+    error_msg = ''
+    if party.get('businessName'):
+        error_msg += validate_text(party.get('businessName'), desc + ' business name')
+    elif party.get('personName'):
+        error_msg += validate_individual_name(party.get('personName'), desc + ' person name')
+    return error_msg
+
+
 def validate_individual_name(name_json, desc: str = ''):
     """Verify individual name is valid."""
     error_msg = validate_text(name_json.get('first'), desc + ' first')

--- a/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
+++ b/mhr_api/tests/postman/mhr-api-unit.postman_collection.json
@@ -932,6 +932,113 @@
 					"response": []
 				},
 				{
+					"name": "Create account qualified supplier information",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"businessName\": \"UNIT TEST NOTARY PUBLIC\",\n  \"address\": {\n    \"street\": \"1088 FORT STREET\",\n    \"city\": \"VICTORIA\",\n    \"region\": \"BC\",\n    \"country\": \"CA\",\n    \"postalCode\": \"V8S 7J4\"\n  },\n  \"phoneNumber\": \"2503862484\"\n}\n"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/qualified-suppliers",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"qualified-suppliers"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "qualified suppliers",
+			"item": [
+				{
+					"name": "Get account qualified supplier information",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Account-Id",
+								"type": "text",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"description": "Prism only local mock server header.",
+								"key": "Prefer",
+								"type": "text",
+								"value": "example=/api/v1/searches/1294376/put"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/qualified-suppliers",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"qualified-suppliers"
+							]
+						},
+						"description": "Retrieve the recent history of search requests for the account."
+					},
+					"response": []
+				},
+				{
 					"name": "Create account manufacturer information",
 					"protocolProfileBehavior": {
 						"disabledSystemHeaders": {
@@ -1850,7 +1957,7 @@
 		},
 		{
 			"key": "staff_account_id",
-			"value": "PROVIDE",
+			"value": "3040",
 			"type": "string"
 		}
 	]

--- a/mhr_api/tests/unit/api/test_qualified_suppliers.py
+++ b/mhr_api/tests/unit/api/test_qualified_suppliers.py
@@ -1,0 +1,108 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the qualified supplier endpoints.
+
+Test-Suite to ensure that the /qualified-suppliers/* endpoints are working as expected.
+"""
+import copy
+from http import HTTPStatus
+
+import pytest
+from flask import current_app
+
+from mhr_api.models import MhrQualifiedSupplier
+from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
+from tests.unit.services.utils import create_header_account, create_header
+from tests.unit.utils.test_registration_data import MANUFACTURER_VALID
+
+INVALID_BUS_NAME = 'TEST \U0001d5c4\U0001d5c6/\U0001d5c1 INVALID'
+VALID_BUS_NAME = 'TEST NOTARY PUBLIC'
+SUPPLIER_JSON = {
+    'businessName': 'TEST NOTARY PUBLIC',
+    'address': {
+        'street': '1704 GOVERNMENT ST.',
+        'city': 'PENTICTON',
+        'region': 'BC',
+        'postalCode': 'V2A 7A1',
+        'country': 'CA'
+    },
+    'emailAddress': 'test@gmail.com',
+    'phoneNumber': '2507701067'
+}
+# testdata pattern is ({desc}, {roles}, {account_id}, {status})
+TEST_ACCOUNT_DATA = [
+    ('Valid', [MHR_ROLE], 'test', HTTPStatus.OK),
+    ('Valid no results', [MHR_ROLE], '1234', HTTPStatus.NOT_FOUND),
+    ('Non-staff no account', [MHR_ROLE], None, HTTPStatus.BAD_REQUEST),
+    ('Staff no account', [MHR_ROLE, STAFF_ROLE], None, HTTPStatus.BAD_REQUEST),
+    ('Unauthorized', [COLIN_ROLE], 'test', HTTPStatus.UNAUTHORIZED)
+]
+# testdata pattern is ({desc}, {roles}, {account_id}, {status}, {bus_name})
+TEST_CREATE_DATA = [
+    ('Valid', [MHR_ROLE], 'new-test', HTTPStatus.OK, VALID_BUS_NAME),
+    ('Invalid exists', [MHR_ROLE], 'test', HTTPStatus.BAD_REQUEST, VALID_BUS_NAME),
+    ('Invalid validation error', [MHR_ROLE], 'new-test', HTTPStatus.BAD_REQUEST, INVALID_BUS_NAME)
+]
+
+
+@pytest.mark.parametrize('desc,roles,account_id,status', TEST_ACCOUNT_DATA)
+def test_get_account_supplier(session, client, jwt, desc, roles, account_id, status):
+    """Assert that the GET account qualified supplier info endpoint behaves as expected."""
+    # setup
+    headers = create_header_account(jwt, roles, 'test-user', account_id) if account_id else create_header(jwt, roles)
+
+    # test
+    response = client.get('/api/v1/qualified-suppliers', headers=headers)
+
+    # check
+    assert response.status_code == status
+    if status == HTTPStatus.OK:
+        json_data = response.json
+        assert json_data
+        assert json_data.get('businessName')
+        assert json_data.get('partyType')
+        assert json_data.get('address')
+        assert json_data.get('phoneNumber')
+
+
+@pytest.mark.parametrize('desc,roles,account,status,bus_name', TEST_CREATE_DATA)
+def test_create_account_supplier(session, client, jwt, desc, roles, account, status, bus_name):
+    """Assert that a post MH qualified supplier information works as expected."""
+    # setup
+    headers = None
+    json_data = copy.deepcopy(SUPPLIER_JSON)
+    json_data['businessName'] = bus_name
+    if account:
+        headers = create_header_account(jwt, roles, 'UT-TEST', account)
+    else:
+        headers = create_header(jwt, roles)
+    # test
+    response = client.post('/api/v1/qualified-suppliers',
+                           json=json_data,
+                           headers=headers,
+                           content_type='application/json')
+
+    # check
+    current_app.logger.debug(response.json)
+    assert response.status_code == status
+    if response.status_code == HTTPStatus.CREATED:
+        json_data = response.json
+        assert json_data
+        assert json_data.get('businessName')
+        assert json_data.get('partyType')
+        assert json_data.get('address')
+        assert json_data.get('phoneNumber')
+        supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_account_id(account)
+        assert supplier

--- a/mhr_api/tests/unit/models/test_mhr_qualified_supplier.py
+++ b/mhr_api/tests/unit/models/test_mhr_qualified_supplier.py
@@ -1,0 +1,128 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the MHR qualified supplier Model.
+
+Test-Suite to ensure that the MHR qualified supplier Model is working as expected.
+"""
+from flask import current_app
+
+import pytest
+
+from mhr_api.models import Address, MhrQualifiedSupplier, MhrParty
+from  mhr_api.models.type_tables import MhrPartyTypes
+
+
+# testdata pattern is ({id}, {has_results})
+TEST_ID_DATA = [
+    (200000000, True),
+    (300000000, False)
+]
+# testdata pattern is ({account_id}, {has_results})
+TEST_ACCOUNT_ID_DATA = [
+    ('test', True),
+    ('JUNK', False)
+]
+SUPPLIER_JSON = {
+    'businessName': 'TEST NOTARY PUBLIC',
+    'partyType': 'CONTACT',
+    'address': {
+        'street': '1704 GOVERNMENT ST.',
+        'city': 'PENTICTON',
+        'region': 'BC',
+        'postalCode': 'V2A 7A1',
+        'country': 'CA'
+    },
+    'emailAddress': 'test@gmail.com',
+    'phoneNumber': '2507701067'
+}
+
+
+@pytest.mark.parametrize('id, has_results', TEST_ID_DATA)
+def test_find_by_id(session, id, has_results):
+    """Assert that find qualified supplier by primary key contains all expected elements."""
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_id(id)
+    if has_results:
+        assert supplier
+        assert supplier.id == id
+        assert supplier.account_id
+        assert supplier.business_name
+        assert supplier.address
+        assert supplier.phone_number
+    else:
+        assert not supplier
+
+
+@pytest.mark.parametrize('account_id, has_results', TEST_ACCOUNT_ID_DATA)
+def test_find_by_account_id(session, account_id, has_results):
+    """Assert that find qualified supplier by account id contains all expected elements."""
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_account_id(account_id)
+    if has_results:
+        assert supplier
+        assert supplier.id
+        assert supplier.account_id == account_id
+        assert supplier.business_name
+        assert supplier.address
+        assert supplier.phone_number
+        json_data = supplier.json
+        assert json_data
+        assert json_data.get('businessName')
+        assert json_data.get('partyType')
+        assert json_data.get('address')
+        assert json_data.get('phoneNumber')
+    else:
+        assert not supplier
+
+
+def test_supplier_json(session):
+    """Assert that the qualifed supplier model renders to a json format correctly."""
+    address: Address = Address.create_from_json(SUPPLIER_JSON.get('address'))
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier(id=1, 
+                                                          party_type=MhrPartyTypes.CONTACT,
+                                                          business_name=SUPPLIER_JSON.get('businessName'),
+                                                          address=address,
+                                                          email_id=SUPPLIER_JSON.get('emailAddress'),
+                                                          phone_number=SUPPLIER_JSON.get('phoneNumber'))
+    current_app.logger.debug(supplier.json)
+    assert SUPPLIER_JSON == supplier.json
+
+
+def test_create_from_json(session):
+    """Assert that creating a valid manufacturer from JSON is as expected."""
+    account_id: str = '1234'
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.create_from_json(SUPPLIER_JSON,
+                                                                           account_id,
+                                                                           MhrPartyTypes.CONTACT)
+    assert supplier
+    assert supplier.party_type == MhrPartyTypes.CONTACT
+    assert supplier.account_id == account_id
+    assert supplier.business_name
+    assert supplier.address
+    assert supplier.phone_number
+
+
+def test_save_new_from_json(session):
+    """Assert that saving a valid manufacturer from JSON is as expected."""
+    account_id: str = '1234'
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.create_from_json(SUPPLIER_JSON,
+                                                                           account_id,
+                                                                           MhrPartyTypes.CONTACT)
+    assert supplier
+    supplier.save()
+    assert supplier.id > 0
+    assert supplier.party_type == MhrPartyTypes.CONTACT
+    assert supplier.account_id == account_id
+    assert supplier.business_name
+    assert supplier.address
+    assert supplier.phone_number


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17200

*Description of changes:*
- Add GET and POST /mhr/api/v1/qualified-suppliers endpoints to support auth QS account onboarding.
- Update postman with examples.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
