### PR TITLE
User Access Select + Nav/Footer CleanUp

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -396,6 +396,12 @@ span.invalid-color {
   text-decoration: underline;
 }
 
+.dotted-underline {
+  cursor: default;
+  border-bottom: 1px dotted $gray7;
+  text-decoration: none;
+}
+
 .disabled-text {
   opacity: 0.4;
 }

--- a/ppr-ui/src/components/common/SubProductSelector.vue
+++ b/ppr-ui/src/components/common/SubProductSelector.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-card flat class="px-8 py-8">
+  <v-card flat class="px-8 pt-9 pb-5">
     <v-row no-gutters>
       <v-col cols="2">
         <label
           class="generic-label"
           for="sub-product-selector"
-          :class="{ 'error-text': false }"
+          :class="{ 'error-text': showErrors }"
         >
           Select Access Type
         </label>
@@ -23,8 +23,8 @@
           >
             <div
               v-for="(subProduct, index) in subProductConfig"
-              :key="subProduct.type"
               class="sub-product-radio-wrapper"
+              :key="subProduct.type"
             >
               <v-radio
                 class="sub-product-radio-btn"
@@ -35,9 +35,9 @@
                     <v-col cols="12">
                       <label class="sub-product-label">{{ subProduct.label }}</label>
                     </v-col>
-                    <v-col class="mt-1">
+                    <v-col class="mt-2">
                       <p>
-                        <ul class="ml-n1">
+                        <ul class="ml-n2">
                           <li v-for="(bullet, index) in subProduct.productBullets" :key="index" class="bullet mt-2">
                             <span :class="{ 'font-weight-bold': isImportantBullet(subProduct, index) }">
                               {{ bullet }}
@@ -45,13 +45,14 @@
                           </li>
                         </ul>
                       </p>
-                      <p v-if="subProduct.note" class="sub-product-note pr-3">
-                        <strong>Note:</strong> <span v-html="subProduct.note"></span>
-                      </p>
                     </v-col>
                   </v-row>
                 </template>
               </v-radio>
+              <!-- Attached Selection Notes -->
+              <p v-if="subProduct.note" class="sub-product-note mt-n2 ml-8 mb-6">
+                <strong>Note:</strong> <span v-html="subProduct.note"></span>
+              </p>
               <v-divider v-if="index !== subProductConfig.length - 1" class="ml-n1 mb-6" />
             </div>
           </v-radio-group>
@@ -64,6 +65,7 @@
 <script lang="ts">
 import { defineComponent, reactive, ref, toRefs, watch } from 'vue-demi'
 import { SubProductConfigIF } from '@/interfaces'
+import { MhrSubTypes } from '@/enums'
 
 export default defineComponent({
   name: 'SubProductSelector',
@@ -72,12 +74,20 @@ export default defineComponent({
     subProductConfig: {
       type: Array as () => Array<SubProductConfigIF>,
       default: () => []
+    },
+    showErrors: {
+      type: Boolean,
+      default: false
+    },
+    defaultProduct: {
+      type: String,
+      default: null
     }
   },
   setup (props, { emit }) {
     const productSelectorFormRef = ref(null)
     const localState = reactive({
-      selectedProduct: ''
+      selectedProduct: props.defaultProduct || ''
     })
 
     const isImportantBullet = (subProduct: SubProductConfigIF, index: string|number) => {
@@ -86,7 +96,7 @@ export default defineComponent({
 
     /** Emit the sub-product as it updates **/
     watch(() => localState.selectedProduct, (subProduct: string) => {
-      emit('updateSubProduct', subProduct)
+      emit('updateSubProduct', subProduct as MhrSubTypes)
     })
 
     return {

--- a/ppr-ui/src/components/common/SubProductSelector.vue
+++ b/ppr-ui/src/components/common/SubProductSelector.vue
@@ -33,7 +33,7 @@
                 <template v-slot:label>
                   <v-row no-gutters>
                     <v-col cols="12">
-                      <label class="sub-product-label">{{ subProduct.label }}</label>
+                      <label class="sub-product-label generic-label">{{ subProduct.label }}</label>
                     </v-col>
                     <v-col class="mt-2">
                       <p>
@@ -113,10 +113,14 @@ export default defineComponent({
 .sub-product-label {
   cursor: pointer;
 }
+#sub-product-selector {
+  margin-top: 2px;
+}
 .sub-product-note {
   font-size: 14px;
   line-height: 22px;
   cursor: default;
+  color: $gray7;
 }
 
 ::v-deep {

--- a/ppr-ui/src/composables/common/useNavigation.ts
+++ b/ppr-ui/src/composables/common/useNavigation.ts
@@ -6,16 +6,27 @@ export const useNavigation = () => {
   const route: Route = useRoute()
   const router: Router = useRouter()
 
+  /**
+   * Simple Navigation helper
+   * @routeName The specified route name to navigate too.
+   */
+  const goToRoute = async (routeName: RouteNames): Promise<void> => {
+    await router.push({ name: routeName })
+  }
+
+  /** Navigate to home Dashboard **/
+  const goToDash = async (): Promise<void> => {
+    await router.push({ name: RouteNames.DASHBOARD })
+  }
+
   /** Helper to check is the current route matches */
   const isRouteName = (routeName: RouteNames): boolean => {
     return route.name === routeName
   }
 
-  /** Navigate to home Dashboard **/
-  const goToDash = (): void => {
-    router.push({
-      name: RouteNames.DASHBOARD
-    })
+  /** Helper to check if the specified routes contain the current route */
+  const containsCurrentRoute = (routeNames: Array<RouteNames>): boolean => {
+    return routeNames.includes(route.name as RouteNames)
   }
 
   /**
@@ -45,8 +56,10 @@ export const useNavigation = () => {
   }
 
   return {
+    goToRoute,
     goToDash,
+    navigateTo,
     isRouteName,
-    navigateTo
+    containsCurrentRoute
   }
 }

--- a/ppr-ui/src/enums/mhrSubProductActions.ts
+++ b/ppr-ui/src/enums/mhrSubProductActions.ts
@@ -11,7 +11,7 @@ export enum MhrActions {
     TRANSPORT_PERMITS = 'Transport permits',
     TRANSPORT_PERMITS_NO_CERT = 'Transport permits (where no tax certificate is required)',
     TRANSFER_TRANSACTIONS = 'Transfer transactions',
-    HOME_TRANSFER_TRANSACTIONS = 'Transfer transactions (related to homes manufacturers currently own',
+    HOME_TRANSFER_TRANSACTIONS = 'Transfer transactions (related to homes manufacturers currently own)',
     RESIDENTIAL_EXEMPTIONS = 'Residential exemptions',
     REGISTRATIONS = 'Registrations',
     APPLICATION_REQUIRED = 'Application process required'

--- a/ppr-ui/src/interfaces/store-interfaces/state-interfaces/user-access-interface.ts
+++ b/ppr-ui/src/interfaces/store-interfaces/state-interfaces/user-access-interface.ts
@@ -1,0 +1,6 @@
+import { MhrSubTypes } from '@/enums'
+
+export interface UserAccessIF {
+  mrhSubProduct: MhrSubTypes
+  qsInformation: {} // To be determined
+}

--- a/ppr-ui/src/interfaces/store-interfaces/state-model-interface.ts
+++ b/ppr-ui/src/interfaces/store-interfaces/state-model-interface.ts
@@ -30,6 +30,7 @@ import {
 } from '@/interfaces'
 import { StaffPaymentIF } from '@bcrs-shared-components/interfaces'
 import { UnitNoteIF } from '@/interfaces/unit-note-interfaces/unit-note-interface'
+import { UserAccessIF } from '@/interfaces/store-interfaces/state-interfaces/user-access-interface'
 
 // State model example
 export interface StateModelIF {
@@ -85,6 +86,7 @@ export interface StateModelIF {
   mhrUnitNotes?: Array<UnitNoteIF>
   mhrUnitNote: UnitNoteRegistrationIF // used for Unit Note filing/registration
   mhrUnitNoteValidationState: MhrUnitNoteValidationStateIF
+  mhrUserAccess: UserAccessIF
   mhrSearchResultSelectAllLien: boolean
   mhrValidationState?: MhrValidationStateIF
   mhrValidationManufacturerState?: MhrValidationManufacturerStateIF

--- a/ppr-ui/src/resources/mhrSubProductConfig.ts
+++ b/ppr-ui/src/resources/mhrSubProductConfig.ts
@@ -29,7 +29,7 @@ export const MhrSubProductConfig: Array<SubProductConfigIF> = [
     type: MhrSubTypes.DEALERS,
     label: `${MhrSubTypes.QUALIFIED_SUPPLIER} - ${MhrSubTypes.DEALERS}`,
     productBullets: [
-      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT, MhrActions.TRANSPORT_PERMITS_NO_CERT
+      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT
     ],
     hasImportantBullet: false
   }

--- a/ppr-ui/src/resources/mhrSubProductConfig.ts
+++ b/ppr-ui/src/resources/mhrSubProductConfig.ts
@@ -7,9 +7,9 @@ export const MhrSubProductConfig: Array<SubProductConfigIF> = [
     label: `${MhrSubTypes.QUALIFIED_SUPPLIER} - ${MhrSubTypes.LAWYERS_NOTARIES}`,
     productBullets: [
       MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS, MhrActions.TRANSFER_TRANSACTIONS,
-      MhrActions.RESIDENTIAL_EXEMPTIONS, MhrActions.APPLICATION_REQUIRED
+      MhrActions.RESIDENTIAL_EXEMPTIONS
     ],
-    hasImportantBullet: true,
+    hasImportantBullet: false,
     note: `General Service Providers who are not lawyers or notaries cannot request Qualified Supplier access online 
      and <a href="https://www2.gov.bc.ca/gov/content/housing-tenancy/owning-a-home/manufactured-home-registry" 
      target="_blank">must submit a paper application <span class="mdi mdi-open-in-new"></span></a> to BC Registries.`
@@ -19,17 +19,16 @@ export const MhrSubProductConfig: Array<SubProductConfigIF> = [
     label: `${MhrSubTypes.QUALIFIED_SUPPLIER} - ${MhrSubTypes.MANUFACTURER}`,
     productBullets: [
       MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS, MhrActions.HOME_TRANSFER_TRANSACTIONS,
-      MhrActions.REGISTRATIONS, MhrActions.APPLICATION_REQUIRED
+      MhrActions.REGISTRATIONS
     ],
-    hasImportantBullet: true
+    hasImportantBullet: false
   },
   {
     type: MhrSubTypes.DEALERS,
     label: `${MhrSubTypes.QUALIFIED_SUPPLIER} - ${MhrSubTypes.DEALERS}`,
     productBullets: [
-      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT,
-      MhrActions.APPLICATION_REQUIRED
+      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT
     ],
-    hasImportantBullet: true
+    hasImportantBullet: false
   }
 ]

--- a/ppr-ui/src/resources/mhrSubProductConfig.ts
+++ b/ppr-ui/src/resources/mhrSubProductConfig.ts
@@ -10,9 +10,11 @@ export const MhrSubProductConfig: Array<SubProductConfigIF> = [
       MhrActions.RESIDENTIAL_EXEMPTIONS
     ],
     hasImportantBullet: false,
+    /* eslint-disable max-len */
     note: `General Service Providers who are not lawyers or notaries cannot request Qualified Supplier access online 
-     and <a href="https://www2.gov.bc.ca/gov/content/housing-tenancy/owning-a-home/manufactured-home-registry" 
+     and <a href="https://www2.gov.bc.ca/gov/content/housing-tenancy/owning-a-home/manufactured-home-registry#qualified-supplier" 
      target="_blank">must submit a paper application <span class="mdi mdi-open-in-new"></span></a> to BC Registries.`
+    /* eslint-enable max-len */
   },
   {
     type: MhrSubTypes.MANUFACTURER,
@@ -27,7 +29,7 @@ export const MhrSubProductConfig: Array<SubProductConfigIF> = [
     type: MhrSubTypes.DEALERS,
     label: `${MhrSubTypes.QUALIFIED_SUPPLIER} - ${MhrSubTypes.DEALERS}`,
     productBullets: [
-      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT
+      MhrActions.MHR_SEARCH, MhrActions.TRANSPORT_PERMITS_NO_CERT, MhrActions.TRANSPORT_PERMITS_NO_CERT
     ],
     hasImportantBullet: false
   }

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -1,4 +1,4 @@
-import { RegistrationFlowType, UnitNoteStatusTypes } from '@/enums'
+import { MhrSubTypes, RegistrationFlowType, UnitNoteStatusTypes } from '@/enums'
 import { PartyIF, RegistrationTypeIF, StateModelIF } from '@/interfaces'
 
 export const stateModel: StateModelIF = {
@@ -363,6 +363,10 @@ export const stateModel: StateModelIF = {
       } as PartyIF,
       destroyed: false
     }
+  },
+  mhrUserAccess: {
+    mrhSubProduct: null,
+    qsInformation: {}
   },
   mhrUnitNoteValidationState: {
     unitNoteAddValid: {

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -48,7 +48,7 @@ import {
   AccountTypes,
   APIRegistrationTypes,
   AuthRoles,
-  MhApiStatusTypes,
+  MhApiStatusTypes, MhrSubTypes,
   ProductCode,
   RegistrationFlowType,
   RouteNames,
@@ -694,6 +694,10 @@ export const useStore = defineStore('assetsStore', () => {
   const getMhrTransferAffidavitCompleted = computed(() => {
     return state.value.mhrTransfer.isAffidavitTransferCompleted
   })
+  // User Access Flow
+  const getMhrSubProduct = computed((): MhrSubTypes => {
+    return state.value.mhrUserAccess.mrhSubProduct
+  })
 
   /** Actions **/
   function resetNewRegistration () {
@@ -1098,6 +1102,11 @@ export const useStore = defineStore('assetsStore', () => {
     set(state.value.mhrUnitNote.note, storeAction.key, storeAction.value)
   }
 
+  // User Access Flow
+  function setMhrSubProduct (subProduct: MhrSubTypes) {
+    state.value.mhrUserAccess.mrhSubProduct = subProduct
+  }
+
   return {
     // Temp feature flag getters
     isTiptapEnabled,
@@ -1265,6 +1274,9 @@ export const useStore = defineStore('assetsStore', () => {
     getMhrUnitNoteType, // doc type of the Unit Note to register
     getMhrUnitNoteValidation,
 
+    // MHR User Access
+    getMhrSubProduct,
+
     // ACTIONS
 
     // Registration
@@ -1366,7 +1378,10 @@ export const useStore = defineStore('assetsStore', () => {
     setMhrUnitNoteType,
     setEmptyUnitNoteRegistration,
     setMhrUnitNoteRegistration,
-    setMhrUnitNote
+    setMhrUnitNote,
+
+    // MHR User Access
+    setMhrSubProduct
 
   }
 })

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -15,7 +15,7 @@ export const defaultFlagSet: LDFlagSet = {
   'assets-tiptap-enabled': false, // Enables new TipTap wysiwyg editor
   'mhr-exemption-enabled': false,
   'mhr-transport-permit-enabled': '',
-  'mhr-user-access-enabled': false,
+  'mhr-user-access-enabled': true,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -15,7 +15,7 @@ export const defaultFlagSet: LDFlagSet = {
   'assets-tiptap-enabled': false, // Enables new TipTap wysiwyg editor
   'mhr-exemption-enabled': false,
   'mhr-transport-permit-enabled': '',
-  'mhr-user-access-enabled': true,
+  'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/views/newRegistration/AddCollateral.vue
+++ b/ppr-ui/src/views/newRegistration/AddCollateral.vue
@@ -52,7 +52,6 @@
       <v-col cols="12">
         <ButtonFooter
           :navConfig="getFooterButtonConfig"
-          :currentStatementType="statementType"
           :currentStepName="stepName"
           @error="emitError($event)"
         />
@@ -64,7 +63,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, reactive, toRefs, watch } from 'vue-demi'
 import { useStore } from '@/store/store'
-import { APIRegistrationTypes, RegistrationFlowType, RouteNames, StatementTypes } from '@/enums'
+import { APIRegistrationTypes, RegistrationFlowType, RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { Stepper, StickyContainer } from '@/components/common'
 import ButtonFooter from '@/components/common/ButtonFooter.vue'
@@ -109,7 +108,6 @@ export default defineComponent({
     const localState = reactive({
       dataLoaded: false,
       feeType: FeeSummaryTypes.NEW,
-      statementType: StatementTypes.FINANCING_STATEMENT,
       stepName: RouteNames.ADD_COLLATERAL,
       registrationLength: computed((): RegistrationLengthI => {
         return {

--- a/ppr-ui/src/views/newRegistration/AddParties.vue
+++ b/ppr-ui/src/views/newRegistration/AddParties.vue
@@ -54,7 +54,6 @@
       <v-col cols="12">
         <ButtonFooter
           :navConfig="getFooterButtonConfig"
-          :currentStatementType="statementType"
           :currentStepName="stepName"
           @error="emitError($event)"
         />
@@ -66,7 +65,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, reactive, toRefs, watch } from 'vue-demi'
 import { useStore } from '@/store/store'
-import { APIRegistrationTypes, RegistrationFlowType, RouteNames, StatementTypes } from '@/enums'
+import { APIRegistrationTypes, RegistrationFlowType, RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { Stepper, StickyContainer } from '@/components/common'
 import ButtonFooter from '@/components/common/ButtonFooter.vue'
@@ -112,7 +111,6 @@ export default defineComponent({
     const localState = reactive({
       dataLoaded: false,
       feeType: FeeSummaryTypes.NEW,
-      statementType: StatementTypes.FINANCING_STATEMENT,
       stepName: RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS,
       registrationLength: computed((): RegistrationLengthI => {
         return {

--- a/ppr-ui/src/views/newRegistration/LengthTrust.vue
+++ b/ppr-ui/src/views/newRegistration/LengthTrust.vue
@@ -55,7 +55,6 @@
       <v-col cols="12">
         <ButtonFooter
           :navConfig="getFooterButtonConfig"
-          :currentStatementType="statementType"
           :currentStepName="stepName"
           @error="emitError($event)"
         />
@@ -71,12 +70,7 @@ import { getFeatureFlag } from '@/utils'
 import { Stepper, StickyContainer } from '@/components/common'
 import ButtonFooter from '@/components/common/ButtonFooter.vue'
 import { RegistrationLengthTrust, RegistrationRepairersLien } from '@/components/registration'
-import {
-  APIRegistrationTypes,
-  RegistrationFlowType,
-  RouteNames,
-  StatementTypes
-} from '@/enums'
+import { APIRegistrationTypes, RegistrationFlowType, RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { ErrorIF } from '@/interfaces' // eslint-disable-line no-unused-vars
 import { RegistrationLengthI } from '@/composables/fees/interfaces'
@@ -119,7 +113,6 @@ export default defineComponent({
     const localState = reactive({
       dataLoaded: false,
       feeType: FeeSummaryTypes.NEW,
-      statementType: StatementTypes.FINANCING_STATEMENT,
       stepName: RouteNames.LENGTH_TRUST,
       registrationLength: computed((): RegistrationLengthI => {
         return {

--- a/ppr-ui/src/views/newRegistration/ReviewConfirm.vue
+++ b/ppr-ui/src/views/newRegistration/ReviewConfirm.vue
@@ -97,7 +97,6 @@
       <v-col cols="12">
         <ButtonFooter
           :navConfig="getFooterButtonConfig"
-          :currentStatementType="statementType"
           :currentStepName="stepName"
           :certifyValid="validCertify && validFolio"
           :forceSave="saveDraftExit"
@@ -112,7 +111,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, reactive, toRefs, watch } from 'vue-demi'
 import { useStore } from '@/store/store'
-import { APIRegistrationTypes, RegistrationFlowType, RouteNames, StatementTypes } from '@/enums'
+import { APIRegistrationTypes, RegistrationFlowType, RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { Stepper, StickyContainer, CertifyInformation } from '@/components/common'
 import ButtonFooter from '@/components/common/ButtonFooter.vue'
@@ -182,7 +181,6 @@ export default defineComponent({
       dataLoaded: false,
       feeType: FeeSummaryTypes.NEW,
       showStepErrors: false,
-      statementType: StatementTypes.FINANCING_STATEMENT,
       stepName: RouteNames.REVIEW_CONFIRM,
       validCertify: false,
       validFolio: true,

--- a/ppr-ui/src/views/userAccess/QsSelectAccess.vue
+++ b/ppr-ui/src/views/userAccess/QsSelectAccess.vue
@@ -3,12 +3,32 @@
     <section id="qs-access-type" class="mt-10">
       <h2>Qualified Supplier Access Type</h2>
       <p class="mt-4">
-        If you are an active B.C. lawyer or notary, a home manufacturer or a home dealer, and would like to have access
+        If you are an
+        <v-tooltip
+          top content-class="top-tooltip"
+          transition="fade-transition"
+        >
+          <template v-slot:activator="{ on }">
+            <span v-on="on" class="dotted-underline" tabindex="0">active B.C. lawyer or notary</span>
+          </template>
+          <div class="pt-2 pb-2">
+            A practising member in good standing of the Law Society of British Columbia, or a practising member in good
+            standing of the Society of Notaries Public of British Columbia.
+          </div>
+        </v-tooltip>
+        , a home manufacturer or a home dealer, and would like to have access
         to perform additional transactions in the Manufactured Home Registry, you must apply to be a Qualified Supplier.
         Indicate the type of Qualified Supplier access you would like to request.
       </p>
 
-        <SubProductSelector class="mt-6" :subProductConfig="MhrSubProductConfig" />
+        <SubProductSelector
+          class="mt-6"
+          :class="{'border-error-left': showErrors}"
+          :showErrors="showErrors"
+          :subProductConfig="MhrSubProductConfig"
+          :defaultProduct="getMhrSubProduct"
+          @updateSubProduct="setMhrSubProduct"
+        />
     </section>
   </div>
 </template>
@@ -17,17 +37,28 @@
 import { defineComponent, reactive, toRefs } from 'vue-demi'
 import { SubProductSelector } from '@/components/common'
 import { MhrSubProductConfig } from '@/resources'
+import { useStore } from '@/store/store'
+import { storeToRefs } from 'pinia'
 
 export default defineComponent({
   name: 'QsSelectAccess',
   components: {
     SubProductSelector
   },
-  props: {},
-  setup (props, context) {
+  props: {
+    showErrors: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup () {
+    const { setMhrSubProduct } = useStore()
+    const { getMhrSubProduct } = storeToRefs(useStore())
     const localState = reactive({})
 
     return {
+      setMhrSubProduct,
+      getMhrSubProduct,
       MhrSubProductConfig,
       ...toRefs(localState)
     }

--- a/ppr-ui/src/views/userAccess/QsSelectAccess.vue
+++ b/ppr-ui/src/views/userAccess/QsSelectAccess.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="qs-select-access">
-    <section id="qs-access-type" class="mt-10">
+    <section id="qs-access-type" class="mt-9">
       <h2>Qualified Supplier Access Type</h2>
       <p class="mt-4">
         If you are an

--- a/ppr-ui/src/views/userAccess/UserAccess.vue
+++ b/ppr-ui/src/views/userAccess/UserAccess.vue
@@ -15,7 +15,7 @@
                 <h1>Request MHR Qualified Supplier Access</h1>
               </v-col>
             </v-row>
-            <QsSelectAccess />
+            <QsSelectAccess :showErrors="!getMhrSubProduct && promptAccessSelect" />
           </v-col>
         </v-row>
       </div>
@@ -54,6 +54,8 @@
         <ButtonFooter
           :navConfig="MhrUserAccessButtonFooterConfig"
           :currentStepName="$route.name"
+          :disableNav="!getMhrSubProduct"
+          @navigationDisabled="promptAccessSelect = $event"
           @error="emitError($event)"
           @submit="submit()"
         />
@@ -95,13 +97,14 @@ export default defineComponent({
     }
   },
   setup (props, { emit }) {
-    const { getUserAccessSteps } = storeToRefs(useStore())
+    const { getMhrSubProduct, getUserAccessSteps } = storeToRefs(useStore())
     const { isRouteName, goToDash } = useNavigation()
     const { isAuthenticated } = useAuth()
 
     const localState = reactive({
       dataLoaded: false,
-      submitting: false
+      submitting: false,
+      promptAccessSelect: false
     })
 
     onMounted(async (): Promise<void> => {
@@ -109,7 +112,7 @@ export default defineComponent({
       // redirect if not authenticated (safety check - should never happen) or if app is not open to user (ff)
       if (!props.appReady || !isAuthenticated.value ||
           (!props.isJestRunning && !getFeatureFlag('mhr-user-access-enabled'))) {
-        goToDash()
+        await goToDash()
         return
       }
 
@@ -130,6 +133,7 @@ export default defineComponent({
       emitError,
       isRouteName,
       RouteNames,
+      getMhrSubProduct,
       getUserAccessSteps,
       MhrUserAccessButtonFooterConfig,
       ...toRefs(localState)

--- a/ppr-ui/src/views/userAccess/UserAccess.vue
+++ b/ppr-ui/src/views/userAccess/UserAccess.vue
@@ -6,11 +6,11 @@
     </v-overlay>
 
     <!-- Request Access Type Pre-Step -->
-    <div v-if="isRouteName(RouteNames.QS_ACCESS_TYPE)" class="view-container px-15 py-0">
+    <div v-if="isRouteName(RouteNames.QS_ACCESS_TYPE)" class="view-container px-15 py-0 mt-4">
       <div class="container pa-0 pt-4">
         <v-row no-gutters>
           <v-col cols="9">
-            <v-row no-gutters id="registration-header" class="pt-3 pb-3 soft-corners-top">
+            <v-row no-gutters id="registration-header" class="pt-3 soft-corners-top">
               <v-col cols="auto">
                 <h1>Request MHR Qualified Supplier Access</h1>
               </v-col>

--- a/ppr-ui/tests/unit/AddCollateral.spec.ts
+++ b/ppr-ui/tests/unit/AddCollateral.spec.ts
@@ -105,7 +105,6 @@ describe('Add Collateral new registration component', () => {
     )
     expect(wrapper.findComponent(StickyContainer).vm.$props.setShowButtons).toBe(false)
     expect(wrapper.findComponent(ButtonFooter).exists()).toBe(true)
-    expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStepName).toBe(RouteNames.ADD_COLLATERAL)
     expect(wrapper.findComponent(Collateral).exists()).toBe(true)
     expect(wrapper.find(header).exists()).toBe(true)

--- a/ppr-ui/tests/unit/AddParties.spec.ts
+++ b/ppr-ui/tests/unit/AddParties.spec.ts
@@ -103,7 +103,6 @@ describe('Add Parties new registration component', () => {
     )
     expect(wrapper.findComponent(StickyContainer).vm.$props.setShowButtons).toBe(false)
     expect(wrapper.findComponent(ButtonFooter).exists()).toBe(true)
-    expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStepName).toBe(
       RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS
     )

--- a/ppr-ui/tests/unit/ButtonFooter.spec.ts
+++ b/ppr-ui/tests/unit/ButtonFooter.spec.ts
@@ -22,7 +22,7 @@ import { useStore } from '../../src/store/store'
 import { ButtonConfigIF } from '@/interfaces'
 import { MhrRegistrationType } from '@/resources'
 import {
-  MHRManufacturerButtonFooterConfig,
+  MHRManufacturerButtonFooterConfig, MhrUserAccessButtonFooterConfig,
   RegistrationButtonFooterConfig
 } from '@/resources/buttonFooterConfig'
 import { createRouter } from 'vue2-helpers/vue-router'
@@ -46,7 +46,6 @@ const nextBtn: string = '#reg-next-btn'
  * @returns a Wrapper<SearchBar> object with the given parameters.
  */
 function createComponent (
-  currentStatementType: String,
   currentStepName: String,
   navConfig: Array<ButtonConfigIF>,
   routeName: RouteNames
@@ -63,7 +62,7 @@ function createComponent (
   document.body.setAttribute('data-app', 'true')
   return mount((ButtonFooter as any), {
     localVue,
-    propsData: { currentStatementType, currentStepName, navConfig },
+    propsData: { currentStepName, navConfig },
     store,
     router,
     vuetify
@@ -73,15 +72,12 @@ function createComponent (
 describe('New Financing Statement Registration Buttons Step 1', () => {
   let wrapper: Wrapper<any>
   let wrapper2: any // eslint-disable-line no-unused-vars
-  const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
   const currentStepName: String = String(RouteNames.LENGTH_TRUST)
 
   beforeEach(async () => {
     const localVue = createLocalVue()
     wrapper2 = shallowMount((LengthTrust as any), { localVue, store, vuetify })
-    wrapper = createComponent(
-      currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.LENGTH_TRUST
-    )
+    wrapper = createComponent(currentStepName, RegistrationButtonFooterConfig, RouteNames.LENGTH_TRUST)
   })
   afterEach(() => {
     wrapper.destroy()
@@ -94,7 +90,6 @@ describe('New Financing Statement Registration Buttons Step 1', () => {
     expect(wrapper.find(saveResumeBtn).exists()).toBe(true)
     expect(wrapper.find(backBtn).exists()).toBe(false)
     expect(wrapper.find(nextBtn).exists()).toBe(true)
-    expect(wrapper.vm.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.props().currentStepName).toBe(RouteNames.LENGTH_TRUST)
     expect(wrapper.vm.buttonConfig.showCancel).toBe(true)
     expect(wrapper.vm.buttonConfig.showSave).toBe(true)
@@ -126,7 +121,6 @@ describe('New Financing Statement Registration Buttons Step 1', () => {
 describe('New Financing Statement Registration Buttons Step 2', () => {
   let wrapper: Wrapper<any>
   let wrapper2: any // eslint-disable-line no-unused-vars
-  const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
   const currentStepName: String = String(RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS)
 
   beforeEach(async () => {
@@ -134,7 +128,7 @@ describe('New Financing Statement Registration Buttons Step 2', () => {
     localVue.use(VueRouter)
     wrapper2 = shallowMount((AddSecuredPartiesAndDebtors as any), { localVue, store, vuetify })
     wrapper = createComponent(
-      currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS
+      currentStepName, RegistrationButtonFooterConfig, RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS
     )
   })
   afterEach(() => {
@@ -148,7 +142,6 @@ describe('New Financing Statement Registration Buttons Step 2', () => {
     expect(wrapper.find(saveResumeBtn).exists()).toBe(true)
     expect(wrapper.find(backBtn).exists()).toBe(true)
     expect(wrapper.find(nextBtn).exists()).toBe(true)
-    expect(wrapper.vm.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.props().currentStepName).toBe(RouteNames.ADD_SECUREDPARTIES_AND_DEBTORS)
     expect(wrapper.vm.buttonConfig.showCancel).toBe(true)
     expect(wrapper.vm.buttonConfig.showSave).toBe(true)
@@ -191,7 +184,6 @@ describe('New Financing Statement Registration Buttons Step 2', () => {
 describe('New Financing Statement Registration Buttons Step 3', () => {
   let wrapper: Wrapper<any>
   let wrapper2: any // eslint-disable-line no-unused-vars
-  const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
   const currentStepName: String = String(RouteNames.ADD_COLLATERAL)
 
   beforeEach(async () => {
@@ -199,7 +191,7 @@ describe('New Financing Statement Registration Buttons Step 3', () => {
     localVue.use(VueRouter)
     wrapper2 = shallowMount((AddCollateral as any), { localVue, store, vuetify })
     wrapper = createComponent(
-      currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.ADD_COLLATERAL
+      currentStepName, RegistrationButtonFooterConfig, RouteNames.ADD_COLLATERAL
     )
   })
   afterEach(() => {
@@ -213,7 +205,6 @@ describe('New Financing Statement Registration Buttons Step 3', () => {
     expect(wrapper.find(saveResumeBtn).exists()).toBe(true)
     expect(wrapper.find(backBtn).exists()).toBe(true)
     expect(wrapper.find(nextBtn).exists()).toBe(true)
-    expect(wrapper.vm.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.props().currentStepName).toBe(RouteNames.ADD_COLLATERAL)
     expect(wrapper.vm.buttonConfig.showCancel).toBe(true)
     expect(wrapper.vm.buttonConfig.showSave).toBe(true)
@@ -255,14 +246,13 @@ describe('New Financing Statement Registration Buttons Step 3', () => {
 describe('New Financing Statement Registration Buttons Step 4', () => {
   let wrapper: Wrapper<any>
   let wrapper2: any // eslint-disable-line no-unused-vars
-  const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
   const currentStepName: String = String(RouteNames.REVIEW_CONFIRM)
 
   beforeEach(async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     wrapper2 = shallowMount((ReviewConfirm as any), { localVue, store, vuetify })
-    wrapper = createComponent(currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM)
+    wrapper = createComponent(currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM)
   })
   afterEach(() => {
     wrapper.destroy()
@@ -275,7 +265,6 @@ describe('New Financing Statement Registration Buttons Step 4', () => {
     expect(wrapper.find(saveResumeBtn).exists()).toBe(true)
     expect(wrapper.find(backBtn).exists()).toBe(true)
     expect(wrapper.find(nextBtn).exists()).toBe(true)
-    expect(wrapper.vm.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.props().currentStepName).toBe(RouteNames.REVIEW_CONFIRM)
     expect(wrapper.vm.buttonConfig.showCancel).toBe(true)
     expect(wrapper.vm.buttonConfig.showSave).toBe(true)
@@ -317,7 +306,6 @@ describe('New Financing Statement Registration Buttons Step 4', () => {
 describe('Step 4 for SBC staff', () => {
   let wrapper: Wrapper<any>
   let wrapper2: any // eslint-disable-line no-unused-vars
-  const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
   const currentStepName: String = String(RouteNames.REVIEW_CONFIRM)
 
   beforeEach(async () => {
@@ -325,7 +313,7 @@ describe('Step 4 for SBC staff', () => {
     localVue.use(VueRouter)
     await store.setAuthRoles(['staff', 'ppr_staff'])
     wrapper2 = shallowMount((ReviewConfirm as any), { localVue, store, vuetify })
-    wrapper = createComponent(currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM)
+    wrapper = createComponent(currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM)
   })
   afterEach(() => {
     wrapper.destroy()
@@ -374,11 +362,8 @@ describe('Button events', () => {
     post.returns(new Promise(resolve => resolve({ data: null })))
     const localVue = createLocalVue()
     localVue.use(VueRouter)
-    const currentStatementType: String = String(StatementTypes.FINANCING_STATEMENT)
     const currentStepName: String = String(RouteNames.REVIEW_CONFIRM)
-    wrapper = createComponent(
-      currentStatementType, currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM
-    )
+    wrapper = createComponent(currentStepName, RegistrationButtonFooterConfig, RouteNames.REVIEW_CONFIRM)
     await flushPromises()
   })
   afterEach(() => {
@@ -401,7 +386,6 @@ describe('Button events', () => {
 
 describe('Mhr Manufacturer Registration step 1 - Your Home', () => {
   let wrapper: Wrapper<any>
-  const currentStatementType = StatementTypes.FINANCING_STATEMENT
   const currentStepName = RouteNames.YOUR_HOME
 
   beforeAll(async () => {
@@ -417,9 +401,7 @@ describe('Mhr Manufacturer Registration step 1 - Your Home', () => {
   beforeEach(async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
-    wrapper = createComponent(
-      currentStatementType, currentStepName, MHRManufacturerButtonFooterConfig, RouteNames.YOUR_HOME
-    )
+    wrapper = createComponent(currentStepName, MHRManufacturerButtonFooterConfig, RouteNames.YOUR_HOME)
   })
   afterEach(() => {
     wrapper.destroy()
@@ -462,7 +444,6 @@ describe('Mhr Manufacturer Registration step 1 - Your Home', () => {
 
 describe('Mhr Manufacturer Registration step 2 - Review and Confirm', () => {
   let wrapper: Wrapper<any>
-  const currentStatementType = StatementTypes.FINANCING_STATEMENT
   const currentStepName = RouteNames.MHR_REVIEW_CONFIRM
 
   beforeAll(async () => {
@@ -477,9 +458,7 @@ describe('Mhr Manufacturer Registration step 2 - Review and Confirm', () => {
   beforeEach(async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
-    wrapper = createComponent(
-      currentStatementType, currentStepName, MHRManufacturerButtonFooterConfig, RouteNames.MHR_REVIEW_CONFIRM
-    )
+    wrapper = createComponent(currentStepName, MHRManufacturerButtonFooterConfig, RouteNames.MHR_REVIEW_CONFIRM)
   })
   afterEach(() => {
     wrapper.destroy()
@@ -513,5 +492,37 @@ describe('Mhr Manufacturer Registration step 2 - Review and Confirm', () => {
     await wrapper.find(saveResumeBtn).trigger('click')
     await nextTick()
     expect(wrapper.vm.$router.currentRoute.name).toBe(RouteNames.DASHBOARD)
+  })
+})
+
+describe('Mhr User Access', () => {
+  let wrapper: Wrapper<any>
+  const currentStepName = RouteNames.QS_ACCESS_TYPE
+
+  beforeEach(async () => {
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    wrapper = createComponent(currentStepName, MhrUserAccessButtonFooterConfig, RouteNames.QS_ACCESS_TYPE)
+    await store.setMhrSubProduct(null)
+  })
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders with correct footer configs', async () => {
+    expect(wrapper.vm.currentStepName).toBe(RouteNames.QS_ACCESS_TYPE)
+    expect(wrapper.findComponent(ButtonFooter).exists()).toBe(true)
+    expect(wrapper.find(backBtn).exists()).toBe(false)
+    expect(wrapper.find(nextBtn).exists()).toBe(true)
+    expect(wrapper.find(saveBtn).exists()).toBe(false)
+    expect(wrapper.find(saveResumeBtn).exists()).toBe(false)
+    expect(wrapper.find(cancelBtn).exists()).toBe(true)
+
+    const buttonConfig = wrapper.vm.buttonConfig as ButtonConfigIF
+    expect(buttonConfig.nextRouteName).toBe(RouteNames.QS_ACCESS_INFORMATION)
+    expect(buttonConfig.nextText).toBe('Complete Qualified Supplier Application')
+
+    // Verify nav enabled by default
+    expect(wrapper.vm.$props.disableNav).toBe(false)
   })
 })

--- a/ppr-ui/tests/unit/LengthTrust.spec.ts
+++ b/ppr-ui/tests/unit/LengthTrust.spec.ts
@@ -97,7 +97,6 @@ describe('Length and Trust Indenture new registration component', () => {
     )
     expect(wrapper.findComponent(StickyContainer).vm.$props.setShowButtons).toBe(false)
     expect(wrapper.findComponent(ButtonFooter).exists()).toBe(true)
-    expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStepName).toBe(RouteNames.LENGTH_TRUST)
     expect(wrapper.findComponent(RegistrationLengthTrust).exists()).toBe(true)
     expect(wrapper.find(header).exists()).toBe(true)

--- a/ppr-ui/tests/unit/ReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/ReviewConfirm.spec.ts
@@ -112,7 +112,6 @@ describe('Review Confirm new registration component', () => {
     )
     expect(wrapper.findComponent(StickyContainer).vm.$props.setShowButtons).toBe(false)
     expect(wrapper.findComponent(ButtonFooter).exists()).toBe(true)
-    expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStatementType).toBe(StatementTypes.FINANCING_STATEMENT)
     expect(wrapper.findComponent(ButtonFooter).vm.$props.currentStepName).toBe(RouteNames.REVIEW_CONFIRM)
     expect(wrapper.findComponent(RegistrationLengthTrustSummary).exists()).toBe(true)
     expect(wrapper.findComponent(Parties).exists()).toBe(true)

--- a/ppr-ui/tests/unit/SubProductSelector.spec.ts
+++ b/ppr-ui/tests/unit/SubProductSelector.spec.ts
@@ -3,6 +3,7 @@ import { SubProductConfigIF } from '@/interfaces'
 import { SubProductSelector } from '@/components/common'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import { nextTick } from 'vue-demi'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
@@ -93,5 +94,42 @@ describe('SubProductSelector', () => {
     expect(note.exists()).toBe(true)
     expect(note.text()).toContain('Note:')
     expect(note.html()).toContain('<strong>Note:</strong> This is a note')
+  })
+
+  it('emits the selected-product-change event when selectedProduct changes', async () => {
+    const subProductConfig: Array<SubProductConfigIF> = [
+      {
+        type: 'subProduct1',
+        label: 'Sub Product 1',
+        productBullets: ['Bullet 1', 'Bullet 2'],
+        note: 'This is a note'
+      },
+      {
+        type: 'subProduct2',
+        label: 'Sub Product 2',
+        productBullets: ['Bullet 1', 'Bullet 2'],
+        note: ''
+      }
+    ]
+
+    const wrapper: Wrapper<any> = mount((SubProductSelector as any), {
+      vuetify,
+      propsData: {
+        subProductConfig,
+        defaultProduct: 'subProduct1'
+      }
+    })
+    await nextTick()
+
+    // Change the selectedProduct prop
+    const radioBtns = wrapper.findAll('.sub-product-radio-btn')
+    radioBtns.at(1).trigger('click')
+
+    // Wait for the next tick to let Vue update the DOM
+    await nextTick()
+
+    // Check that the emitted event was triggered with the correct payload
+    expect(wrapper.emitted('updateSubProduct')).toBeTruthy()
+    expect(wrapper.emitted('updateSubProduct')[0]).toEqual(['subProduct2'])
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17179

*Description of changes:*
- Access Select Validations.
- Save and Set selected type to store.
- Basic User Access Store Setup.
- Tab-able ToolTip content for accessibility .
- Basic nav helper.
- Clean up of redundant footer prop  statement type and it's implementations.

*TESTING NOTES:*
- Use BCREG0018/MyMhrTestBusiness for accessible account. 
- If having issues setting the specific account via the preview url, append the url with: `?accountid=3144`
- To verify footer and nav configurations for refactored code, see PPR Registrations Footers/Steppers.
- Figma designs for reference: https://www.figma.com/file/0sD17BVTK7OwTqPRsAoreu/MHR-Account-User-Flow?type=design&node-id=461-39243&mode=design&t=IeGd9oPcNb2kuOM2-0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
