### PR TITLE
Limits panels with cancel button options

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.39",
+      "version": "2.0.40",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
@@ -37,7 +37,7 @@
 
               <!-- Actions other than Cancel Note-->
               <v-list-item
-                v-for="option in getNoteOptions(note)"
+                v-for="option in noteOptions"
                 :key="UnitNotesInfo[option].header"
                 @click="handleOptionSelection(option, note)"
                 :data-test-id="`unit-note-option-${option}`"
@@ -143,7 +143,6 @@ export default defineComponent({
     return {
       handleOptionSelection,
       pacificDate,
-      getNoteOptions,
       UnitNoteDocTypes,
       UnitNotesInfo,
       ...toRefs(localState)

--- a/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs } from 'vue-demi'
+import { defineComponent } from 'vue-demi'
 import { RouteNames, UnitNoteDocTypes } from '@/enums'
 import { useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
@@ -117,9 +117,7 @@ export default defineComponent({
       getNoteOptions
     } = useMhrUnitNote()
 
-    const localState = reactive({
-      noteOptions: getNoteOptions(props.note)
-    })
+    const noteOptions = getNoteOptions(props.note)
 
     const initUnitNote = (noteType: UnitNoteDocTypes): void => {
       setMhrUnitNoteType(noteType)
@@ -145,7 +143,7 @@ export default defineComponent({
       pacificDate,
       UnitNoteDocTypes,
       UnitNotesInfo,
-      ...toRefs(localState)
+      noteOptions
     }
   }
 })

--- a/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
@@ -4,6 +4,7 @@ import { useStore } from '@/store/store'
 import { deleteEmptyProperties, submitMhrUnitNote } from '@/utils'
 import { storeToRefs } from 'pinia'
 import { cloneDeep } from 'lodash'
+import { CancellableUnitNoteTypes, NoticeOfCautionDropDown } from '@/resources'
 
 export const useMhrUnitNote = () => {
   const {
@@ -114,6 +115,24 @@ export const useMhrUnitNote = () => {
     )
   }
 
+  const getNoteOptions = (unitNote: UnitNoteIF): UnitNoteDocTypes[] => {
+    const options = []
+
+    if (unitNote.status === UnitNoteStatusTypes.CANCELLED) {
+      return options
+    }
+
+    if (isNoticeOfCautionOrRelatedDocType(unitNote)) {
+      options.push(...NoticeOfCautionDropDown)
+    }
+
+    if (CancellableUnitNoteTypes.includes(unitNote.documentType)) {
+      options.push(UnitNoteDocTypes.NOTE_CANCELLATION)
+    }
+
+    return options
+  }
+
   const initUnitNote = (): UnitNoteRegistrationIF => {
     return {
       clientReferenceId: '',
@@ -176,6 +195,7 @@ export const useMhrUnitNote = () => {
     isPersonGivingNoticeOptional,
     hasEffectiveDateTime,
     hasExpiryDate,
+    getNoteOptions,
     groupUnitNotes,
     isNoticeOfCautionOrRelatedDocType
   }

--- a/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
@@ -115,6 +115,7 @@ export const useMhrUnitNote = () => {
     )
   }
 
+  // Provides document types based on the given unit note that configure the unit note dropdown options
   const getNoteOptions = (unitNote: UnitNoteIF): UnitNoteDocTypes[] => {
     const options = []
 

--- a/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
+++ b/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
@@ -19,6 +19,7 @@ export interface UnitNoteIF {
 export interface UnitNoteInfoIF {
   header: string,
   dropdownText: string,
+  dropdownIcon?: string,
   fee: FeeSummaryDefaults,
   reviewSectionNumber?: Record<string, number>,
   panelHeader?: string,

--- a/ppr-ui/src/resources/unitNotes.ts
+++ b/ppr-ui/src/resources/unitNotes.ts
@@ -31,6 +31,7 @@ export const UnitNotesInfo: Record<UnitNoteDocTypes, UnitNoteInfoIF> = {
   [UnitNoteDocTypes.CONTINUED_NOTE_OF_CAUTION]: {
     header: 'Continued Notice of Caution',
     dropdownText: 'Add Continued Notice of Caution',
+    dropdownIcon: 'mdi-plus',
     fee: FeeSummaryDefaults.NO_FEE,
     reviewSectionNumber: { // section numbers on Review page
       effectiveDateTime: 2,
@@ -44,6 +45,7 @@ export const UnitNotesInfo: Record<UnitNoteDocTypes, UnitNoteInfoIF> = {
   [UnitNoteDocTypes.EXTENSION_TO_NOTICE_OF_CAUTION]: {
     header: 'Extension to Notice of Caution',
     dropdownText: 'Add Extension to Notice of Caution',
+    dropdownIcon: 'mdi-plus',
     fee: FeeSummaryDefaults.UNIT_NOTE_10,
     reviewSectionNumber: { // section numbers on Review page
       effectiveDateTime: 2,
@@ -57,6 +59,7 @@ export const UnitNotesInfo: Record<UnitNoteDocTypes, UnitNoteInfoIF> = {
   [UnitNoteDocTypes.NOTE_CANCELLATION]: {
     header: 'Cancel Note',
     dropdownText: 'Cancel Note',
+    dropdownIcon: 'mdi-delete',
     fee: FeeSummaryDefaults.NO_FEE
   },
   [UnitNoteDocTypes.CONFIDENTIAL_NOTE]: {
@@ -120,3 +123,16 @@ export const UnitNotesInfo: Record<UnitNoteDocTypes, UnitNoteInfoIF> = {
     fee: FeeSummaryDefaults.NO_FEE
   }
 }
+
+export const CancellableUnitNoteTypes: UnitNoteDocTypes[] = [
+  UnitNoteDocTypes.NOTICE_OF_CAUTION,
+  UnitNoteDocTypes.CONTINUED_NOTE_OF_CAUTION,
+  UnitNoteDocTypes.EXTENSION_TO_NOTICE_OF_CAUTION,
+  UnitNoteDocTypes.CONFIDENTIAL_NOTE,
+  UnitNoteDocTypes.PUBLIC_NOTE,
+  UnitNoteDocTypes.RESTRAINING_ORDER
+  /*
+  Possible Future Filing
+  Exemptions (EXRS) (EXRN)
+  */
+]

--- a/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
+++ b/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
@@ -187,3 +187,78 @@ export const mockUnitNotes: Array<UnitNoteIF> = [
     destroyed: false
   }
 ]
+
+export const mockedUnitNotes2 = [
+  {
+    documentType: UnitNoteDocTypes.PUBLIC_NOTE,
+    documentId: '1',
+    documentRegistrationNumber: '123456',
+    documentDescription: 'Public Note',
+    createDateTime: '2023-07-30T09:00:00Z',
+    effectiveDateTime: '2023-12-01T12:00:00Z',
+    expiryDateTime: '2023-13-30T23:59:59Z',
+    remarks: 'This is a public Note.',
+    givingNoticeParty: {
+      businessName: 'HALSTON MODULAR HOMES LTD.',
+      address: {
+        street: 'PO BOX 266',
+        city: 'KNUTSFORD',
+        region: 'BC',
+        country: 'CA',
+        postalCode: 'V0E 2A0'
+      },
+      phoneNumber: '2508289998',
+      emailAddress: 'testing@email.com'
+    },
+    status: UnitNoteStatusTypes.ACTIVE,
+    destroyed: false
+  },
+  {
+    documentType: UnitNoteDocTypes.PUBLIC_NOTE,
+    documentId: '2',
+    documentRegistrationNumber: '123456',
+    documentDescription: 'Public Note',
+    createDateTime: '2023-06-30T09:00:00Z',
+    effectiveDateTime: '2023-06-01T12:00:00Z',
+    expiryDateTime: '2023-07-30T23:59:59Z',
+    remarks: 'This is a public Note.',
+    givingNoticeParty: {
+      businessName: 'HALSTON MODULAR HOMES LTD.',
+      address: {
+        street: 'PO BOX 266',
+        city: 'KNUTSFORD',
+        region: 'BC',
+        country: 'CA',
+        postalCode: 'V0E 2A0'
+      },
+      phoneNumber: '2508289998',
+      emailAddress: 'testing@email.com'
+    },
+    status: UnitNoteStatusTypes.CANCELLED,
+    destroyed: false
+  },
+  {
+    documentType: UnitNoteDocTypes.DECAL_REPLACEMENT,
+    documentId: '3',
+    documentRegistrationNumber: '123456',
+    documentDescription: 'Decal Replacement Note',
+    createDateTime: '2023-05-30T09:00:00Z',
+    effectiveDateTime: '2023-06-01T12:00:00Z',
+    expiryDateTime: '2023-08-30T23:59:59Z',
+    remarks: 'This is a decal replacment Note.',
+    givingNoticeParty: {
+      businessName: 'HALSTON MODULAR HOMES LTD.',
+      address: {
+        street: 'PO BOX 266',
+        city: 'KNUTSFORD',
+        region: 'BC',
+        country: 'CA',
+        postalCode: 'V0E 2A0'
+      },
+      phoneNumber: '2508289998',
+      emailAddress: 'testing@email.com'
+    },
+    status: UnitNoteStatusTypes.ACTIVE,
+    destroyed: false
+  }
+]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16924

*Description of changes:*
- Limit cancel button to cancellable unit note types
- Made dropdown menu more abstract
- Move `getNoteOptions` to composable
- Added and updated tests

*Screenshots:*

Only shows dropdown menu for cancellable notes:

![Continued notice of caution that was cancelled](https://github.com/bcgov/ppr/assets/77707952/2b4463b1-5650-43c9-b1e7-215b60e86330)

![Only show cancel, on cancellable notes](https://github.com/bcgov/ppr/assets/77707952/5e9c0b38-db51-4544-9b4c-f79a68e5553a)

*Note:*

Drop down requirements: 
Go to:
https://docs.google.com/spreadsheets/d/1Fa7mDrvYfhkAkmn_P0YNUfdP6YlvyFKW/edit?usp=sharing&ouid=101606009220440832808&rtpof=true&sd=true

And click on the `Dropdown Menus` tab at the bottom.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
