### PR TITLE
DB2 save note no contact bug fix.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/mhomnote.py
+++ b/mhr_api/src/mhr_api/models/db2/mhomnote.py
@@ -219,9 +219,9 @@ class Db2Mhomnote(db.Model):
                            reg_document_id=document.id,
                            document_type=document.document_type,
                            destroyed='N',
-                           phone_number=document.phone_number,
-                           name=document.name,
-                           legacy_address=document.legacy_address,
+                           phone_number='',
+                           name='',
+                           legacy_address='',
                            remarks=json_data.get('remarks', ''),
                            can_document_id='')
         if not note.remarks:

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -100,7 +100,7 @@ LOCATION_STRATA_ALLOWED = 'Dealer/manufacturer name, park name, PAD, band name, 
     'with a STRATA location type. '
 LOCATION_OTHER_ALLOWED = 'Dealer/manufacturer name, park name, PAD, band name, and reserve number are not allowed ' \
     'with an OTHER location type. '
-TRAN_QUALIFIED_DELETE = 'Qualified suppliers mut either delete one owner group or all owner groups. '
+TRAN_QUALIFIED_DELETE = 'Qualified suppliers must either delete one owner group or all owner groups. '
 NOTICE_NAME_REQUIRED = 'The giving notice party person or business name is required. '
 NOTICE_ADDRESS_REQUIRED = 'The giving notice address is required. '
 DESTROYED_FUTURE = 'The destroyed date and time cannot be in the future. '


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17252

*Description of changes:*
- Do not use the submitting party as the note contact info when there is no person giving notice party in the unit note registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
