### PR TITLE
Fix date and time being wrong based on time zone

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.47",
+      "version": "2.0.48",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
@@ -146,7 +146,7 @@ import { SharedDatePicker } from '@/components/common'
 import { HomeCertificationOptions } from '@/enums'
 import { useInputRules, useMhrValidations } from '@/composables'
 import { useStore } from '@/store/store'
-import { createUtcDate, localTodayDate } from '@/utils/date-helper'
+import { createDateFromPacificTime, localTodayDate } from '@/utils/date-helper'
 import { storeToRefs } from 'pinia'
 /* eslint-disable no-unused-vars */
 import { FormIF } from '@/interfaces'
@@ -220,7 +220,7 @@ export default defineComponent({
       today: computed(() => localTodayDate()),
       minDate: computed(() => {
         // Determined by YEAR value in Manufacturers, Make, Model Section
-        const utcDate = createUtcDate(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
+        const utcDate = createDateFromPacificTime(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
         return localTodayDate(utcDate)
       }),
       hasNoCertification: getMhrRegistrationHomeDescription.value?.hasNoCertification || false

--- a/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
+++ b/ppr-ui/src/components/mhrRegistration/YourHome/HomeCertification.vue
@@ -220,8 +220,8 @@ export default defineComponent({
       today: computed(() => localTodayDate()),
       minDate: computed(() => {
         // Determined by YEAR value in Manufacturers, Make, Model Section
-        const utcDate = createDateFromPacificTime(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
-        return localTodayDate(utcDate)
+        const ptDate = createDateFromPacificTime(getMhrRegistrationHomeDescription.value?.baseInformation.year, 0, 1)
+        return localTodayDate(ptDate)
       }),
       hasNoCertification: getMhrRegistrationHomeDescription.value?.hasNoCertification || false
     })

--- a/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
+++ b/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
@@ -83,7 +83,7 @@
             </div>
           </v-form>
 
-          <div
+          <p
             v-if="!isImmediateDateSelected && selectedPastDate && isTimeSelected"
             class="ml-8 mb-6"
             data-test-id="date-summary-label"
@@ -92,7 +92,7 @@
             <b>
               {{ pacificDate(effectiveDate, true) }}
             </b>
-          </div>
+          </p>
         </v-col>
       </v-row>
     </v-card>
@@ -102,7 +102,7 @@
 <script lang="ts">
 import { computed, defineComponent, onBeforeMount, reactive, ref, toRefs, watch } from 'vue-demi'
 import { EffectiveDateTypes, PeriodTypes } from '@/enums/'
-import { createUtcDate, localTodayDate, pacificDate } from '@/utils'
+import { createDateFromPacificTime, localTodayDate, pacificDate } from '@/utils'
 import { ContentIF, FormIF } from '@/interfaces'
 import { useInputRules } from '@/composables'
 import SharedDatePicker from '@/components/common/SharedDatePicker.vue'
@@ -177,7 +177,7 @@ export default defineComponent({
       }
 
       const date = new Date(localState.selectedPastDate)
-      return createUtcDate(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), hours, minutes)
+      return createDateFromPacificTime(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), hours, minutes)
     }
 
     onBeforeMount((): void => {

--- a/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
+++ b/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
@@ -155,7 +155,7 @@ export default defineComponent({
         (!localState.isImmediateDateSelected && !!localState.selectedPastDate &&
           localState.isTimeSelected)
       ),
-      showBorderError: computed(() => {
+      showBorderError: computed((): boolean => {
         return props.validate &&
         !localState.isImmediateDateSelected &&
         !(localState.isEffectiveDateTimeFormValid && localState.selectedPastDate !== '')
@@ -164,20 +164,23 @@ export default defineComponent({
     })
 
     const buildFullDate = (): Date => {
+      const YearMonthDay = localState.selectedPastDate.split('-')
+      const year = parseInt(YearMonthDay[0])
+      const month = parseInt(YearMonthDay[1]) - 1
+      const day = parseInt(YearMonthDay[2])
       let hours = parseInt(localState.selectHour)
       const minutes = parseInt(localState.selectMinute)
 
       // convert 12 am -> 0
-      if (localState.selectPeriod === PeriodTypes.AM && localState.selectHour === 12) {
+      if (localState.selectPeriod === PeriodTypes.AM && hours === 12) {
         hours = hours - 12
       }
       // convert 1-11 pm -> 13-23
-      if (localState.selectPeriod === PeriodTypes.PM && localState.selectHour < 12) {
+      if (localState.selectPeriod === PeriodTypes.PM && hours < 12) {
         hours = hours + 12
       }
 
-      const date = new Date(localState.selectedPastDate)
-      return createDateFromPacificTime(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), hours, minutes)
+      return createDateFromPacificTime(year, month, day, hours, minutes)
     }
 
     onBeforeMount((): void => {

--- a/ppr-ui/src/components/unitNotes/ExpiryDate.vue
+++ b/ppr-ui/src/components/unitNotes/ExpiryDate.vue
@@ -57,7 +57,7 @@
 <script lang="ts">
 import { computed, defineComponent, onBeforeMount, reactive, ref, toRefs, watch } from 'vue-demi'
 import { EffectiveDateTypes } from '@/enums/'
-import { createUtcDate, localTodayDate } from '@/utils'
+import { createDateFromPacificTime, localTodayDate } from '@/utils'
 import { ContentIF, FormIF } from '@/interfaces'
 import { useInputRules } from '@/composables'
 import SharedDatePicker from '@/components/common/SharedDatePicker.vue'
@@ -112,7 +112,7 @@ export default defineComponent({
     // build a full UTC date based on selected future date
     const buildFullDate = (): Date => {
       const date = new Date(localState.selectedFutureDate)
-      return createUtcDate(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+      return createDateFromPacificTime(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
     }
 
     onBeforeMount((): void => {

--- a/ppr-ui/src/components/unitNotes/ExpiryDate.vue
+++ b/ppr-ui/src/components/unitNotes/ExpiryDate.vue
@@ -111,8 +111,11 @@ export default defineComponent({
 
     // build a full UTC date based on selected future date
     const buildFullDate = (): Date => {
-      const date = new Date(localState.selectedFutureDate)
-      return createDateFromPacificTime(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+      const YearMonthDay = localState.selectedFutureDate.split('-')
+      const year = parseInt(YearMonthDay[0])
+      const month = parseInt(YearMonthDay[1]) - 1
+      const day = parseInt(YearMonthDay[2])
+      return createDateFromPacificTime(year, month, day)
     }
 
     onBeforeMount((): void => {

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -7,7 +7,7 @@
       </v-col>
       <v-col cols="9">
         <span class="info-text fs-14">
-          {{ pacificDate(note.effectiveDateTime) }}
+          {{ pacificDate(note.effectiveDateTime, true) }}
         </span>
       </v-col>
     </v-row>
@@ -18,7 +18,7 @@
       </v-col>
       <v-col cols="9">
         <span class="info-text fs-14">
-          {{ pacificDate(note.expiryDateTime) }}
+          {{ pacificDate(note.expiryDateTime, true) }}
         </span>
       </v-col>
     </v-row>

--- a/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNotePanel.vue
@@ -77,7 +77,6 @@ import { useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { UnitNotesInfo } from '@/resources'
 import { UnitNoteIF } from '@/interfaces/unit-note-interfaces/unit-note-interface'
-import { pacificDate } from '@/utils'
 import UnitNoteHeaderInfo from './UnitNoteHeaderInfo.vue'
 import UnitNoteContentInfo from './UnitNoteContentInfo.vue'
 import { useMhrUnitNote } from '@/composables'
@@ -140,7 +139,6 @@ export default defineComponent({
 
     return {
       handleOptionSelection,
-      pacificDate,
       UnitNoteDocTypes,
       UnitNotesInfo,
       noteOptions

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -54,11 +54,11 @@ export function convertDate (date: Date, includeTime: boolean, includeTz: boolea
 export function pacificDate (date: Date | string, omitSeconds = false): string {
   // Converts date to string and pacific time
   // Example Output: August 11, 2023 at 10:38 AM
-  let pacificDate = (new Intl.DateTimeFormat('en-US', { dateStyle: 'long',
+  let pacificDate = new Intl.DateTimeFormat('en-US', { dateStyle: 'long',
     timeStyle: omitSeconds ? 'short' : 'medium',
     timeZone: 'America/Vancouver',
     hour12: true })
-    .format(new Date(date)))
+    .format(new Date(date))
 
   // Convert AM/PM to lowercase
   pacificDate = pacificDate.replace('AM', 'am')

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -86,8 +86,6 @@ export function isInt (intValue) {
 /**
  * Takes a pacific time and creates a new date adjusted to user localtime.
  * (This works regardless of user's local clock/timezone.)
- * @example "2021, 0, 1, 0, 0" -> "2021-01-01T08:00:00.000Z"
- * @example "2021, 6, 1, 0, 0" -> "2021-07-01T07:00:00.000Z"
  */
 export function createDateFromPacificTime (year: number, month: number, day: number,
   hours: number = 0, minutes: number = 0): Date {
@@ -102,7 +100,7 @@ export function createDateFromPacificTime (year: number, month: number, day: num
     return createDateFromPacificTime(year, month, day, hours, minutes)
   }
 
-  // zero out seconds and milliseconds
+  // Zero out seconds and milliseconds
   currUserTime.setSeconds(0, 0)
   currPacificTime.setSeconds(0, 0)
 
@@ -112,12 +110,12 @@ export function createDateFromPacificTime (year: number, month: number, day: num
   // Date object is always set to the localtime zone in javascript
   const adjustedDateObject = new Date(new Date(year, month, day, hours, minutes).getTime() + timeZoneDiff)
 
-  return adjustedDateObject // Date Objects are always in user localtime
+  return adjustedDateObject
 }
 
 /**
  * Converts a date string (YYYY-MM-DD) to a Date object at 12:00:00 am Pacific time.
- * @example 2021-11-22 -> 2021-11-22T08:00:00.00Z
+ * @example 2021-11-22 -> 2021-11-22T00:00:00.00 Pacific Time
  */
 export function yyyyMmDdToDate (dateStr: string): Date {
   // safety checks

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -52,10 +52,19 @@ export function convertDate (date: Date, includeTime: boolean, includeTz: boolea
 }
 
 export function pacificDate (date: Date | string, omitSeconds = false): string {
-  date = new Date(date.toLocaleString('en-US', { timeZone: 'America/Vancouver' }))
-  const datetime = format12HourTime(date, omitSeconds)
+  // Converts date to string and pacific time
+  // Example Output: August 11, 2023 at 10:38 AM
+  let pacificDate = (new Intl.DateTimeFormat('en-US', { dateStyle: 'long',
+    timeStyle: omitSeconds ? 'short' : 'medium',
+    timeZone: 'America/Vancouver',
+    hour12: true })
+    .format(new Date(date)))
 
-  return moment(date).format('MMMM D, Y') + ` at ${datetime} Pacific time`
+  // Convert AM/PM to lowercase
+  pacificDate = pacificDate.replace('AM', 'am')
+  pacificDate = pacificDate.replace('PM', 'pm')
+
+  return `${pacificDate} Pacific time`
 }
 
 export function tzOffsetMinutes (date: Date): number {

--- a/ppr-ui/tests/unit/EffectiveDateTime.spec.ts
+++ b/ppr-ui/tests/unit/EffectiveDateTime.spec.ts
@@ -5,6 +5,7 @@ import { createComponent, getTestId } from './utils'
 import { EffectiveDateTime } from '@/components/unitNotes'
 import { SharedDatePicker } from '@/components/common'
 import { useStore } from '@/store/store'
+import { PeriodTypes } from '@/enums'
 
 Vue.use(Vuetify)
 const store = useStore()
@@ -64,5 +65,20 @@ describe('EffectiveDateTime', () => {
     const dateSummaryLabel = EffectiveDateTimeComponent.find(getTestId('date-summary-label'))
     expect(dateSummaryLabel.exists()).toBeTruthy()
     expect(dateSummaryLabel.text()).toContain('July 1, 2023 at 10:25 am')
+
+    wrapper.vm.selectHour = '12'
+    wrapper.vm.selectMinute = '00'
+
+    await Vue.nextTick()
+
+    expect(dateSummaryLabel.text()).toContain('July 1, 2023 at 12:00 am')
+
+    wrapper.vm.selectHour = '9'
+    wrapper.vm.selectMinute = '45'
+    wrapper.vm.selectPeriod = PeriodTypes.PM
+
+    await Vue.nextTick()
+
+    expect(dateSummaryLabel.text()).toContain('July 1, 2023 at 9:45 pm')
   })
 })

--- a/ppr-ui/tests/unit/UnitNotePanels.spec.ts
+++ b/ppr-ui/tests/unit/UnitNotePanels.spec.ts
@@ -68,7 +68,7 @@ const verifyBodyContent = (note: UnitNoteIF, content: Wrapper<any>) => {
     const effectiveDate = content.findAll('h3').at(0).text()
     const effectiveDateTime = content.findAll('.info-text.fs-14').at(0).text()
     expect(effectiveDate).toBe('Effective Date and Time')
-    expect(effectiveDateTime).toBe(pacificDate(note.effectiveDateTime))
+    expect(effectiveDateTime).toBe(pacificDate(note.effectiveDateTime, true))
   }
 
   // Check the expiry date and time
@@ -76,7 +76,7 @@ const verifyBodyContent = (note: UnitNoteIF, content: Wrapper<any>) => {
     const expiryDate = content.findAll('h3').at(1).text()
     const expiryDateTime = content.findAll('.info-text.fs-14').at(1).text()
     expect(expiryDate).toBe('Expiry Date and Time')
-    expect(expiryDateTime).toBe(pacificDate(note.expiryDateTime))
+    expect(expiryDateTime).toBe(pacificDate(note.expiryDateTime, true))
   }
 
   // Check the remarks

--- a/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
+++ b/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
@@ -8,8 +8,8 @@ export const mockUnitNotes: Array<UnitNoteIF> = [
     documentRegistrationNumber: '123456',
     documentDescription: 'Notice of Caution',
     createDateTime: '2023-12-30T09:00:00Z',
-    effectiveDateTime: '2023-13-01T12:00:00Z',
-    expiryDateTime: '2023-13-30T23:59:59Z',
+    effectiveDateTime: '2024-01-01T12:00:00Z',
+    expiryDateTime: '2024-01-30T23:59:59Z',
     remarks: 'This is a notice of caution.',
     givingNoticeParty: {
       businessName: 'HALSTON MODULAR HOMES LTD.',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16833

*Description of changes:*
- Avoids reparsing date to fix issue, as reparsing date uses local computer time.
- Omit seconds in panel.
- Fix invalid data used in mocks.

INFO FOR REVIEWERS:

![image](https://github.com/bcgov/ppr/assets/77707952/53efaa12-0cbd-470f-9ce9-143053370b8e)

https://stackoverflow.com/questions/15141762/how-to-initialize-a-javascript-date-to-a-particular-time-zone


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
