### PR TITLE
MHR API bc assessment data feed legacy owner fix

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -265,7 +265,7 @@ class Db2Owner(db.Model):
         owner = Db2Owner(manuhome_id=registration.id,
                          group_id=group_id,
                          owner_id=owner_id,
-                         sequence_number=1,
+                         sequence_number=owner_id,  # Identical value to owner_id in the legacy db.
                          owner_type=owner_type,
                          verified_flag='',
                          phone_number=str(new_info.get('phoneNumber', ''))[0:10],

--- a/mhr_api/tests/unit/models/db2/test_owngroup.py
+++ b/mhr_api/tests/unit/models/db2/test_owngroup.py
@@ -256,3 +256,5 @@ def test_create_type(session, tenancy_type, legacy_tenancy_type, data):
     group_data['type'] = tenancy_type
     group: Db2Owngroup = Db2Owngroup.create_from_registration(registration, group_data, 2)
     assert group.tenancy_type == legacy_tenancy_type
+    for owner in group.owners:
+        assert owner.owner_id == owner.sequence_number

--- a/mhr_api/tests/unit/models/test_mhr_service_agreement.py
+++ b/mhr_api/tests/unit/models/test_mhr_service_agreement.py
@@ -36,10 +36,10 @@ TEST_VERSION_DATA = [
     ('v1', True),
     ('v1000', False)
 ]
-# testdata pattern is ({account_id}, {username}, {has_results})
+# testdata pattern is ({account_id}, {username}, {has_results}, {has_agreement})
 TEST_ACCEPT_DATA = [
-    ('3026', 'UT-test-qa', True),
-    ('JUNK', 'JUNK', False)
+    ('3026', 'UT-test-qa', True, True),
+    ('JUNK', 'JUNK', False, False)
 ]
 # testdata pattern is ({id}, {version}, {current_version}, {agree_type}, {doc_url} )
 TEST_CURRENT_DATA = [
@@ -107,8 +107,8 @@ def test_find_by_current(session, id, version, current_version, agree_type, doc_
     assert agreement.doc_storage_url == doc_url
 
 
-@pytest.mark.parametrize('account_id, username, has_results', TEST_ACCEPT_DATA)
-def test_update_profile(session, account_id, username, has_results):
+@pytest.mark.parametrize('account_id, username, has_results, has_agreement', TEST_ACCEPT_DATA)
+def test_update_profile(session, account_id, username, has_results, has_agreement):
     """Assert that updating the user profile with the service agreement information is as expected."""
     update_count: int = MhrServiceAgreement.update_user_profile(TEST_ACCEPT_JSON, account_id, username)
     if has_results:
@@ -117,13 +117,16 @@ def test_update_profile(session, account_id, username, has_results):
         assert update_count == 0
 
 
-@pytest.mark.parametrize('account_id, username, has_results', TEST_ACCEPT_DATA)
-def test_get_profile(session, account_id, username, has_results):
+@pytest.mark.parametrize('account_id, username, has_results, has_agreement', TEST_ACCEPT_DATA)
+def test_get_profile(session, account_id, username, has_results, has_agreement):
     """Assert that fetching the agreement info from the user profile works as expected."""
     agreement_json: dict = MhrServiceAgreement.get_agreement_profile(account_id, username)
     if has_results:
         assert agreement_json
-        assert 'acceptAgreementRequired' in agreement_json and not agreement_json.get('acceptAgreementRequired')
+        if has_agreement:
+            assert agreement_json.get('acceptAgreementRequired')
+        else:
+            assert 'acceptAgreementRequired' in agreement_json and not agreement_json.get('acceptAgreementRequired')
         assert agreement_json.get('accepted')
         assert agreement_json.get('version')
         assert agreement_json.get('acceptedDateTime')


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- legacy system BC Assessment data feed requires that the db2 table amhrtdb.owner.ownseqno increments and is the same value as amhrtdb.owner.ownerid when the tenancy type is 'JT'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
