### PR TITLE
Updates panel for no person giving notice

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.48",
+      "version": "2.0.49",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -45,7 +45,7 @@
         <h3 class="fs-14">Person Giving Notice</h3>
       </v-col>
       <v-col v-if="!note.givingNoticeParty" cols="9">
-        <span class="info-text fs-14">
+        <span id="no-person-giving-notice" class="info-text fs-14">
           There is not a Person Giving Notice for this unit note.
         </span>
       </v-col>

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Note Information-->
   <div>
-    <v-row v-if="note.effectiveDateTime" no-gutters class="pt-3">
+    <v-row v-if="note.effectiveDateTime" no-gutters class="my-7">
       <v-col cols="3">
         <h3 class="fs-14">Effective Date and Time</h3>
       </v-col>
@@ -12,7 +12,7 @@
       </v-col>
     </v-row>
 
-    <v-row v-if="note.expiryDateTime" no-gutters class="pt-3">
+    <v-row v-if="note.expiryDateTime" no-gutters class="my-7">
       <v-col cols="3">
         <h3 class="fs-14">Expiry Date and Time</h3>
       </v-col>
@@ -23,7 +23,7 @@
       </v-col>
     </v-row>
 
-    <v-row v-if="note.remarks" no-gutters class="mt-1 py-3">
+    <v-row v-if="note.remarks" no-gutters class="my-7">
       <v-col cols="3">
         <h3 class="fs-14">Remarks</h3>
       </v-col>
@@ -40,12 +40,17 @@
     />
 
     <!-- Person Giving Notice Table -->
-    <v-row no-gutters class="pt-2">
+    <v-row no-gutters class="mt-7">
       <v-col cols="3">
-        <h3 class="py-2">Person Giving Notice</h3>
+        <h3 class="fs-14">Person Giving Notice</h3>
+      </v-col>
+      <v-col v-if="!note.givingNoticeParty" cols="9">
+        <span class="info-text fs-14">
+          There is not a Person Giving Notice for this unit note.
+        </span>
       </v-col>
     </v-row>
-    <v-row no-gutters>
+    <v-row v-if="note.givingNoticeParty" no-gutters>
       <v-col>
         <v-simple-table
           id="persons-giving-notice-table"
@@ -66,7 +71,7 @@
             </thead>
 
             <!-- Table Body -->
-            <tbody v-if="note.givingNoticeParty">
+            <tbody>
               <tr>
                 <td class="pl-0">
                   <div class="mr-2">
@@ -81,8 +86,8 @@
                 <td>
                   <BaseAddress :value="note.givingNoticeParty.address"/>
                 </td>
-                <td>{{ note.givingNoticeParty.emailAddress }}</td>
-                <td>{{ note.givingNoticeParty.phoneNumber }}</td>
+                <td>{{ note.givingNoticeParty.emailAddress || '(Not Entered)' }}</td>
+                <td>{{ note.givingNoticeParty.phoneNumber || '(Not Entered)' }}</td>
               </tr>
             </tbody>
           </template>

--- a/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
+++ b/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
@@ -11,7 +11,7 @@ export interface UnitNoteIF {
   effectiveDateTime?: string
   expiryDateTime?: string
   remarks?: string
-  givingNoticeParty: PartyIF
+  givingNoticeParty?: PartyIF
   status?: UnitNoteStatusTypes
   destroyed?: boolean
 }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -147,7 +147,7 @@
                   <Attention
                     v-if="isRoleStaffReg"
                     sectionId="transfer-ref-num-section"
-                    :intialValue="getMhrTransferAttentionReference"
+                    :initialValue="getMhrTransferAttentionReference"
                     :sectionNumber="2"
                     :validate="!getInfoValidation('isRefNumValid')"
                     @isAttentionValid="setValidation('isRefNumValid', $event)"

--- a/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
+++ b/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
@@ -64,7 +64,7 @@
       <Attention
         sectionId="mhr-attention"
         hasWiderInput
-        :intialValue="getMhrAttentionReference"
+        :initialValue="getMhrAttentionReference"
         :sectionNumber="3"
         :validate="validateRefNum"
         @isAttentionValid="setAttentionValidation"

--- a/ppr-ui/tests/unit/UnitNotePanels.spec.ts
+++ b/ppr-ui/tests/unit/UnitNotePanels.spec.ts
@@ -5,7 +5,7 @@ import { useStore } from '../../src/store/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 import { UnitNoteContentInfo, UnitNoteHeaderInfo, UnitNotePanel, UnitNotePanels } from '../../src/components/unitNotes'
 import { UnitNoteDocTypes, UnitNoteStatusTypes } from '../../src/enums'
-import { mockUnitNotes, mockedUnitNotes2 } from './test-data'
+import { mockUnitNotes, mockedUnitNotes2, mockedUnitNotes3 } from './test-data'
 import { BaseAddress } from '@/composables/address'
 import { pacificDate } from '@/utils'
 import { UnitNotesInfo } from '@/resources/unitNotes'
@@ -336,5 +336,23 @@ describe('UnitNotePanels', () => {
 
     // No dropdown menu
     expect(panel3.find('.menu-drop-down-icon').exists()).toBe(false)
+  })
+
+  it('displays the correct text when there is no person giving notice', async () => {
+    const wrapper = createComponent(mockedUnitNotes3)
+    // First panel is an active public note with no person giving notice
+    const panel = wrapper.find('.unit-note-panel')
+
+    // Expand panel
+    const panelShowBtn = panel.find('.unit-note-menu-btn')
+    await panelShowBtn.trigger('click')
+    await nextTick()
+
+    // Check the panel content
+    const content = panel.findComponent(UnitNoteContentInfo)
+    expect(content.exists()).toBe(true)
+
+    expect(content.find('#persons-giving-notice-table').exists()).toBe(false)
+    expect(content.find('#no-person-giving-notice').exists()).toBe(true)
   })
 })

--- a/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
+++ b/ppr-ui/tests/unit/test-data/mock-unit-notes.ts
@@ -196,7 +196,7 @@ export const mockedUnitNotes2 = [
     documentDescription: 'Public Note',
     createDateTime: '2023-07-30T09:00:00Z',
     effectiveDateTime: '2023-12-01T12:00:00Z',
-    expiryDateTime: '2023-13-30T23:59:59Z',
+    expiryDateTime: '2024-01-30T23:59:59Z',
     remarks: 'This is a public Note.',
     givingNoticeParty: {
       businessName: 'HALSTON MODULAR HOMES LTD.',
@@ -258,6 +258,21 @@ export const mockedUnitNotes2 = [
       phoneNumber: '2508289998',
       emailAddress: 'testing@email.com'
     },
+    status: UnitNoteStatusTypes.ACTIVE,
+    destroyed: false
+  }
+]
+
+export const mockedUnitNotes3 = [
+  {
+    documentType: UnitNoteDocTypes.PUBLIC_NOTE,
+    documentId: '1',
+    documentRegistrationNumber: '123456',
+    documentDescription: 'Public Note',
+    createDateTime: '2023-07-30T09:00:00Z',
+    effectiveDateTime: '2023-12-01T12:00:00Z',
+    expiryDateTime: '2024-01-30T23:59:59Z',
+    remarks: 'This is a public Note.',
     status: UnitNoteStatusTypes.ACTIVE,
     destroyed: false
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17252

*Description of changes:*
- Updates panel to showcase 'There is not person giving notice for this unit note' 
- Increases margin after looking design again
- Misc. typo fixes
- Simple test

*Screenshots:*

No person giving notice
![image](https://github.com/bcgov/ppr/assets/77707952/0689319d-99aa-4ee0-baae-95d4db575c68)

Phone or email not entered
![image](https://github.com/bcgov/ppr/assets/77707952/a8def9ea-77f0-4fdb-a5ca-d3bb6ad261c5)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
