### PR TITLE
Qualified suppliers/manufacturers account info add DELETE and PUT end…

### DIFF
--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.20.0
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.11
-git+https://github.com/bcgov/registry-schemas.git@1.8.1#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.8.2#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.8.1#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.8.2#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -333,7 +333,7 @@ class Db2Descript(db.Model):
                                square_feet=new_info.get('squareFeet', 0),
                                year_made=str(base_info.get('year', '')),
                                circa=' ',
-                               manufacturer_name=new_info.get('manufacturer', ''),
+                               manufacturer_name=str(new_info.get('manufacturer', ''))[0:65],
                                make_model=make_model[0:64],
                                engineer_name=new_info.get('engineerName', ''),
                                rebuilt_remarks=new_info.get('rebuiltRemarks', ''),

--- a/mhr_api/src/mhr_api/models/db2/location.py
+++ b/mhr_api/src/mhr_api/models/db2/location.py
@@ -397,7 +397,7 @@ class Db2Location(db.Model):
                                land_district=new_info.get('landDistrict', ''),
                                plan=new_info.get('plan', ''),
                                except_plan=new_info.get('exceptionPlan', ''),
-                               dealer_name=new_info.get('dealerName', ''),
+                               dealer_name=str(new_info.get('dealerName', ''))[0:60],
                                additional_description=additional_desc,
                                leave_bc='N',
                                tax_certificate='N')

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -913,6 +913,10 @@ def update_note_json(registration, note_json: dict) -> dict:
                     note_json['effectiveDateTime'] = model_utils.format_ts(note.effective_ts)
                 if note.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE):
                     note_json['remarks'] = note.remarks
+                # Use modernized person giving notice data if available.
+                notice_party = note.get_giving_notice()
+                if notice_party:
+                    note_json['givingNoticeParty'] = notice_party.json
     return note_json
 
 

--- a/mhr_api/src/mhr_api/models/mhr_description.py
+++ b/mhr_api/src/mhr_api/models/mhr_description.py
@@ -36,7 +36,7 @@ class MhrDescription(db.Model):  # pylint: disable=too-many-instance-attributes
     circa = db.Column('circa', db.String(1), nullable=True)
     engineer_date = db.Column('engineer_date', db.DateTime, nullable=True)
     engineer_name = db.Column('engineer_name', db.String(150), nullable=True)
-    manufacturer_name = db.Column('manufacturer_name', db.String(150), nullable=True)
+    manufacturer_name = db.Column('manufacturer_name', db.String(310), nullable=True)
     make = db.Column('make', db.String(60), nullable=True)
     model = db.Column('model', db.String(60), nullable=True)
     rebuilt_remarks = db.Column('rebuilt_remarks', db.String(300), nullable=True)

--- a/mhr_api/src/mhr_api/models/mhr_location.py
+++ b/mhr_api/src/mhr_api/models/mhr_location.py
@@ -31,7 +31,7 @@ class MhrLocation(db.Model):  # pylint: disable=too-many-instance-attributes
     id = db.Column('id', db.Integer, db.Sequence('mhr_location_id_seq'), primary_key=True)
     ltsa_description = db.Column('ltsa_description', db.String(1000), nullable=True)
     additional_description = db.Column('additional_description', db.String(250), nullable=True)
-    dealer_name = db.Column('dealer_name', db.String(150), nullable=True)
+    dealer_name = db.Column('dealer_name', db.String(310), nullable=True)
     exception_plan = db.Column('exception_plan', db.String(150), index=True, nullable=True)
     leave_province = db.Column('leave_province', db.String(1), nullable=True)
     tax_certification = db.Column('tax_certification', db.String(1), nullable=True)

--- a/mhr_api/src/mhr_api/models/mhr_note.py
+++ b/mhr_api/src/mhr_api/models/mhr_note.py
@@ -178,6 +178,6 @@ class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
             if not note.remarks:
                 note.remarks = REMARKS_CAUC_NO_EXPIRY
             elif note.remarks.lower().find(REMARKS_CAUC_NO_EXPIRY.lower()) < 0:
-                note.remarks += ' ' + REMARKS_CAUC_NO_EXPIRY
+                note.remarks = REMARKS_CAUC_NO_EXPIRY + ' ' + note.remarks
             reg_json['remarks'] = note.remarks
         return note

--- a/mhr_api/src/mhr_api/models/mhr_qualified_supplier.py
+++ b/mhr_api/src/mhr_api/models/mhr_qualified_supplier.py
@@ -84,6 +84,49 @@ class MhrQualifiedSupplier(db.Model):  # pylint: disable=too-many-instance-attri
         db.session.add(self)
         db.session.commit()
 
+    def update(self, json_data: dict):
+        """Update the qualified supplier information."""
+        if not json_data:
+            return
+        if json_data.get('businessName'):
+            self.business_name = json_data['businessName'].strip().upper()
+            self.last_name = None
+            self.first_name = None
+            self.middle_name = None
+        else:
+            self.business_name = None
+            self.last_name = json_data['personName']['last'].strip().upper()
+            self.first_name = json_data['personName']['first'].strip().upper()
+            if json_data['personName'].get('middle'):
+                self.middle_name = json_data['personName']['middle'].strip().upper()
+        if json_data.get('dbaName'):
+            self.dba_name = json_data['dbaName'].strip().upper()
+        else:
+            self.dba_name = None
+        if json_data.get('authorizationName'):
+            self.authorization_name = json_data['authorizationName'].strip()
+        else:
+            self.authorization_name = None
+        self.email_id = json_data['emailAddress'].strip() if json_data.get('emailAddress') else None
+        self.phone_number = json_data['phoneNumber'].strip() if json_data.get('phoneNumber') else None
+        self.phone_extension = json_data['phoneExtension'].strip() if json_data.get('phoneExtension') else None
+        self.terms_accepted = 'Y' if json_data.get('termsAccepted') else None
+        if json_data.get('address') != self.address.json:
+            self.address = Address.create_from_json(json_data['address'])
+        db.session.add(self)
+        db.session.commit()
+
+    @classmethod
+    def delete(cls, account_id: str):
+        """Delete a qualified supplier by account ID."""
+        supplier = None
+        if account_id:
+            supplier = cls.find_by_account_id(account_id)
+        if supplier:
+            db.session.delete(supplier)
+            db.session.commit()
+        return supplier
+
     @classmethod
     def find_by_id(cls, supplier_id: int = None):
         """Return a qualified supplier party object by primary key ID."""

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -58,7 +58,8 @@ select r.id, r.account_id, r.registration_ts, rr.id, rr.report_data, rr.batch_st
    and r.account_id = m.account_id
    and r.registration_type = 'MHREG'
    and r.registration_ts between (now() - interval '1 days') and now()
-"""
+  order by r.account_id, r.mhr_number
+ """
 QUERY_BATCH_MANUFACTURER_MHREG = """
 select r.id, r.account_id, r.registration_ts, rr.id, rr.report_data, rr.batch_storage_url
   from mhr_registrations r, mhr_manufacturers m, mhr_registration_reports rr
@@ -67,6 +68,7 @@ select r.id, r.account_id, r.registration_ts, rr.id, rr.report_data, rr.batch_st
    and r.registration_type = 'MHREG'
    and r.registration_ts between to_timestamp(:query_val1, 'YYYY-MM-DD HH24:MI:SS')
                              and to_timestamp(:query_val2, 'YYYY-MM-DD HH24:MI:SS')
+  order by r.account_id, r.mhr_number
 """
 UPDATE_BATCH_REG_REPORT = """
 update mhr_registration_reports

--- a/mhr_api/src/mhr_api/resources/v1/manufacturer.py
+++ b/mhr_api/src/mhr_api/resources/v1/manufacturer.py
@@ -47,8 +47,8 @@ def get_account_manufacturer():
         # Verify request JWT and account ID
         if not authorized(account_id, jwt):
             return resource_utils.unauthorized_error_response(account_id)
-        # Try to get bcol account from account ID: from business an account should have at most 1 bcol number.
-        current_app.logger.info(f'Getting manufacturer information for account number for {account_id}.')
+        # Try to get manufacturer by account ID: only one per account.
+        current_app.logger.info(f'Getting manufacturer information for account {account_id}.')
         manufacturer: MhrManufacturer = MhrManufacturer.find_by_account_id(account_id)
         if manufacturer:
             return jsonify(manufacturer.json), HTTPStatus.OK
@@ -73,6 +73,9 @@ def post_account_manufacturer():
         account_id = resource_utils.get_account_id(request)
         if account_id is None:
             return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
         current_app.logger.info(f'Creating manufacturer information for account id {account_id}.')
         manufacturer: MhrManufacturer = MhrManufacturer.find_by_account_id(account_id)
         if manufacturer:
@@ -93,6 +96,65 @@ def post_account_manufacturer():
         return jsonify(manufacturer.json), HTTPStatus.OK
     except DatabaseException as db_exception:
         return resource_utils.db_exception_response(db_exception, account_id, 'GET manufacturer info')
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('', methods=['DELETE', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def delete_account_manufacturer():
+    """Delete a manufacturer by account id."""
+    try:
+        # Quick check: must be staff or provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        current_app.logger.info(f'delete_account_manufacturer account_id={account_id}')
+        # Try to delete the account manufacturer.
+        MhrManufacturer.delete(account_id)
+        return '', HTTPStatus.NO_CONTENT
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except DatabaseException as db_exception:   # noqa: B902; return nicer default error
+        return resource_utils.db_exception_response(db_exception, account_id, f'DELETE account id={account_id}')
+    except Exception as default_exception:   # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route('', methods=['PUT', 'OPTIONS'])
+@cross_origin(origin='*')
+@jwt.requires_auth
+def put_account_manufacturer():
+    """Replace existing account manufacturer information with updated values."""
+    try:
+        # Quick check: must have an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        if not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        request_json = request.get_json(silent=True)
+        valid_format, errors = schema_utils.validate(request_json, 'manufacturerInfo', 'mhr')
+        # Additional validation not covered by the schema.
+        extra_validation_msg = manufacturer_validator.validate_manufacturer(request_json)
+        if not valid_format or extra_validation_msg != '':
+            return resource_utils.validation_error_response(errors, reg_utils.VAL_ERROR, extra_validation_msg)
+        manufacturer: MhrManufacturer = MhrManufacturer.find_by_account_id(account_id)
+        if not manufacturer:
+            current_app.logger.info(f'No manufacturer info found for account {account_id}.')
+            return resource_utils.not_found_error_response('manufacturer information', account_id)
+        current_app.logger.info(f'Updating manufacturer information for account {account_id}.')
+        manufacturer.update(request_json)
+        return jsonify(manufacturer.json), HTTPStatus.OK
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, account_id, 'PUT manufacturer info')
     except BusinessException as exception:
         return resource_utils.business_exception_response(exception)
     except Exception as default_exception:   # noqa: B902; return nicer default error

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.0'  # pylint: disable=invalid-name
+__version__ = '1.5.1'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/api/test_manufacturers.py
+++ b/mhr_api/tests/unit/api/test_manufacturers.py
@@ -27,6 +27,55 @@ from mhr_api.services.authz import COLIN_ROLE, MHR_ROLE, STAFF_ROLE
 from tests.unit.services.utils import create_header_account, create_header
 from tests.unit.utils.test_registration_data import MANUFACTURER_VALID
 
+MANUFACTURER_UPDATE = {
+    'dbaName': 'DBA NAME',
+    'authorizationName': 'John Smith',
+    'termsAccepted': True,
+    'description': {
+        'manufacturer': 'NEW REAL ENGINEERED HOMES INC'
+    }, 
+  'location': {
+    'address': {
+      'city': 'VICTORIA', 
+      'country': 'CA', 
+      'postalCode': 'V2R 7A1', 
+      'region': 'BC', 
+      'street': 'NEW 1725 GOVERNMENT ST.'
+    }, 
+    'dealerName': 'NEW REAL ENGINEERED HOMES INC', 
+    'locationType': 'MANUFACTURER'
+  }, 
+  'ownerGroups': [
+    {
+      'groupId': 1, 
+      'owners': [
+        {
+          'address': {
+            'city': 'VICTORIA',
+            'country': 'CA', 
+            'postalCode': 'V2R 7A1', 
+            'region': 'BC', 
+            'street': 'NEW 1725 GOVERNMENT ST.'
+          }, 
+          'organizationName': 'NEW REAL ENGINEERED HOMES INC', 
+          'partyType': 'OWNER_BUS'
+        }
+      ], 
+      'type': 'SOLE'
+    }
+  ], 
+  'submittingParty': {
+    'address': {
+      'city': 'PENTICTON', 
+      'country': 'CA', 
+      'postalCode': 'V2A 7A1', 
+      'region': 'BC', 
+      'street': '1704 GOVERNMENT ST.'
+    }, 
+    'businessName': 'REAL ENGINEERED HOMES INC', 
+    'phoneNumber': '2507701067'
+  }
+}
 
 # testdata pattern is ({desc}, {roles}, {account_id}, {status}, {size})
 TEST_ACCOUNT_DATA = [
@@ -42,10 +91,23 @@ TEST_CREATE_DATA = [
     ('Invalid exists', [MHR_ROLE], '2523', HTTPStatus.BAD_REQUEST, True),
     ('Invalid validation error', [MHR_ROLE], 'TEST', HTTPStatus.BAD_REQUEST, False)
 ]
+# testdata pattern is ({desc}, {roles}, {account_id}, {status}, {size})
+TEST_DELETE_DATA = [
+    ('Valid', [MHR_ROLE], '2523', HTTPStatus.NO_CONTENT),
+    ('Valid no results', [MHR_ROLE], '1234', HTTPStatus.NO_CONTENT),
+    ('Staff no account', [MHR_ROLE, STAFF_ROLE], None, HTTPStatus.BAD_REQUEST),
+    ('Unauthorized', [COLIN_ROLE], '1234', HTTPStatus.UNAUTHORIZED)
+]
+# testdata pattern is ({desc}, {roles}, {account_id}, {status}, {has_submitting})
+TEST_UPDATE_DATA = [
+    ('Invalid does not exist', [MHR_ROLE], 'JUNK-TEST', HTTPStatus.NOT_FOUND, True),
+    ('Invalid validation error', [MHR_ROLE], '2523', HTTPStatus.BAD_REQUEST, False),
+    ('Valid', [MHR_ROLE], '2523', HTTPStatus.OK, True)
+]
 
 
 @pytest.mark.parametrize('desc,roles,account_id,status,size', TEST_ACCOUNT_DATA)
-def test_account_manufacturer(session, client, jwt, desc, roles, account_id, status, size):
+def test_get_account_manufacturer(session, client, jwt, desc, roles, account_id, status, size):
     """Assert that the GET account manufacturer info endpoint behaves as expected."""
     # setup
     headers = create_header_account(jwt, roles, 'test-user', account_id) if account_id else create_header(jwt, roles)
@@ -79,7 +141,7 @@ def test_account_manufacturer(session, client, jwt, desc, roles, account_id, sta
 
 @pytest.mark.parametrize('desc,roles,account,status,has_submitting', TEST_CREATE_DATA)
 def test_create(session, client, jwt, desc, roles, account, status, has_submitting):
-    """Assert that a post MH information works as expected."""
+    """Assert that the POST manufacturer information endpoint works as expected."""
     # setup
     headers = None
     json_data = copy.deepcopy(MANUFACTURER_VALID)
@@ -98,6 +160,54 @@ def test_create(session, client, jwt, desc, roles, account, status, has_submitti
     # check
     current_app.logger.debug(response.json)
     assert response.status_code == status
-    if response.status_code == HTTPStatus.CREATED:
+    if response.status_code == HTTPStatus.OK:
         manufacturer: MhrManufacturer = MhrManufacturer.find_by_account_id(account)
         assert manufacturer
+
+
+@pytest.mark.parametrize('desc,roles,account_id,status', TEST_DELETE_DATA)
+def test_delete_account_manufacturer(session, client, jwt, desc, roles, account_id, status):
+    """Assert that the DELETE account manufacturer info endpoint behaves as expected."""
+    # setup
+    headers = create_header_account(jwt, roles, 'test-user', account_id) if account_id else create_header(jwt, roles)
+    # test
+    rv = client.delete('/api/v1/manufacturers', headers=headers)
+    # check
+    assert rv.status_code == status
+
+
+@pytest.mark.parametrize('desc,roles,account,status,has_submitting', TEST_UPDATE_DATA)
+def test_update_account_manufacturer(session, client, jwt, desc, roles, account, status, has_submitting):
+    """Assert that the PUT manufacturer info endpoint works as expected."""
+    # setup
+    headers = None
+    json_data = copy.deepcopy(MANUFACTURER_UPDATE)
+    if not has_submitting:
+        del json_data['submittingParty']
+    if account:
+        headers = create_header_account(jwt, roles, 'UT-TEST', account)
+    else:
+        headers = create_header(jwt, roles)
+    # test
+    response = client.put('/api/v1/manufacturers',
+                          json=json_data,
+                          headers=headers,
+                          content_type='application/json')
+
+    # check
+    # current_app.logger.debug(response.json)
+    assert response.status_code == status
+    if response.status_code == HTTPStatus.OK:
+        response_data = response.json
+        assert response_data
+        assert json_data.get('dbaName') == response_data.get('dbaName')
+        assert json_data.get('authorizationName') == response_data.get('authorizationName')
+        assert json_data.get('termsAccepted') == response_data.get('termsAccepted')
+        owner1 = json_data['ownerGroups'][0]['owners'][0]
+        owner2 = response_data['ownerGroups'][0]['owners'][0]
+        assert owner1.get('organizationName') == owner2.get('organizationName')
+        name: str = owner1.get('organizationName') + ' / ' + json_data.get('dbaName')
+        assert owner1.get('address') == owner2.get('address')
+        assert name == response_data['description']['manufacturer']
+        assert name == response_data['location']['dealerName']
+        assert json_data['location']['address'] == response_data['location']['address']

--- a/mhr_api/tests/unit/models/test_mhr_manufacturer.py
+++ b/mhr_api/tests/unit/models/test_mhr_manufacturer.py
@@ -16,6 +16,8 @@
 
 Test-Suite to ensure that the MHR manufacturer Model is working as expected.
 """
+import copy
+
 from flask import current_app
 
 import pytest
@@ -199,8 +201,12 @@ def test_manufacturer_json(session):
                                                     dba_name=MANUFACTURER_JSON.get('dbaName'),
                                                     authorization_name=MANUFACTURER_JSON.get('authorizationName'))
     manufacturer.manufacturer_name=MANUFACTURER_JSON['description'].get('manufacturer')
-    current_app.logger.debug(manufacturer.json)
-    assert MANUFACTURER_JSON == manufacturer.json
+    man_json = copy.deepcopy(MANUFACTURER_JSON)
+    name = man_json['ownerGroups'][0]['owners'][0].get('organizationName') + ' / ' + man_json.get('dbaName')
+    man_json['location']['dealerName'] = name
+    man_json['description']['manufacturer'] = name
+    # current_app.logger.debug(manufacturer.json)
+    assert man_json == manufacturer.json
 
 
 def test_create_from_json(session):


### PR DESCRIPTION
…points

*Issue #:* /bcgov/entity#17412

*Description of changes:*
- Add DELETE and PUT endpoints to manufacturer account information
- Add DELETE and PUT endpoints to qualified supplier account information
- Update CAUC no expiry date remarks order of auto-generated text (prepend instead of append).
- MH registration current/composite view use the Postgres unit note information if it is available (email address).  
- 17433 update batch email manufacturer report sort order

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
