### PR TITLE
MHR API exemption (res and non-res) updates

### DIFF
--- a/mhr_api/report-templates/exemptionV2.html
+++ b/mhr_api/report-templates/exemptionV2.html
@@ -29,8 +29,14 @@
         <td>{{createDateTime}}</td>
       </tr>
       <tr>
-        <td>Destroyed Date and Time:</td>
-        <td>{{note.effectiveDateTime}}</td>
+        <td>Destroyed Date:</td>
+        <td>
+          {% if note.expiryDateTime is defined and note.expiryDateTime != '' %}
+            {{note.expiryDateTime}}
+          {% else %}
+            N/A
+          {% endif %}
+        </td>
       </tr>
       <tr>
         <td>Folio Number:</td>
@@ -57,7 +63,7 @@
       {% endif %}
     </div>
 
-    {% if note is defined and note.givingNoticeParty is defined %}
+    {% if note is defined %}
       [[registration/givingNoticeParty.html]]
     {% endif %}
 

--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -34,7 +34,7 @@
                 </tr>
                 <tr>
                     <td class="section-sub-title">
-                        {% if note.documentType == 'EXNR' %}Destroyed Date:{% else %}Expiry Date:{% endif %}
+                        {% if note.documentType in ('EXNR', 'EXRS') %}Destroyed Date:{% else %}Expiry Date:{% endif %}
                     </td>
                     <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
                             {{note.expiryDate}}

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -408,6 +408,8 @@ class Db2Manuhome(db.Model):
             for note in self.reg_notes:
                 if note.reg_document_id == doc_id:
                     man_home['note'] = note.json
+                    if man_home['note'].get('documentType') == MhrDocumentTypes.EXNR:
+                        man_home['nonResidential'] = True
         elif doc.document_type in (Db2Document.DocumentTypes.PERMIT, Db2Document.DocumentTypes.PERMIT_TRIM,
                                    Db2Document.DocumentTypes.PERMIT_EXTENSION):
             for note in self.reg_notes:

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -141,6 +141,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 reg_json = self.set_transfer_group_json(reg_json)
             elif self.registration_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
                 reg_json = self.set_note_json(reg_json)
+                if reg_json['note'].get('documentType') == MhrDocumentTypes.EXNR:
+                    reg_json['nonResidential'] = True
             elif self.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and \
                     (not self.notes or doc_json.get('documentType') in (MhrDocumentTypes.NCAN,
                                                                         MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE)):
@@ -741,7 +743,6 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             registration.parties.append(MhrParty.create_from_json(notice_json, MhrPartyTypes.CONTACT, registration.id))
         doc: MhrDocument = registration.documents[0]
         if json_data.get('note'):
-            json_data['note']['destroyed'] = True
             registration.notes = [MhrNote.create_from_json(json_data.get('note'), base_reg.id, doc.id,
                                                            registration.registration_ts, registration.id)]
         if base_reg:

--- a/mhr_api/src/mhr_api/utils/manufacturer_validator.py
+++ b/mhr_api/src/mhr_api/utils/manufacturer_validator.py
@@ -96,7 +96,7 @@ def validate_submitting_party(json_data, manufacturer: MhrManufacturer):
     return error_msg
 
 
-def validate_location(json_data, manufacturer: MhrManufacturer):
+def validate_location(json_data: dict, manufacturer: dict):
     """Verify location matches manufacturer location information."""
     error_msg = ''
     if not json_data.get('location'):
@@ -110,7 +110,7 @@ def validate_location(json_data, manufacturer: MhrManufacturer):
     return error_msg
 
 
-def validate_owner(json_data, manufacturer: MhrManufacturer):
+def validate_owner(json_data: dict, manufacturer: dict):
     """Verify owner matches manufacturer owner information."""
     error_msg = ''
     if not json_data.get('ownerGroups'):
@@ -133,7 +133,7 @@ def validate_owner(json_data, manufacturer: MhrManufacturer):
     return error_msg
 
 
-def validate_description(json_data, manufacturer: MhrManufacturer):
+def validate_description(json_data: dict, manufacturer: dict):
     """Verify description passes manufacturer rules."""
     error_msg = ''
     if not json_data.get('description'):

--- a/mhr_api/src/mhr_api/utils/note_validator.py
+++ b/mhr_api/src/mhr_api/utils/note_validator.py
@@ -51,10 +51,13 @@ def validate_note(registration: MhrRegistration, json_data, staff: bool = False,
             error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
         error_msg += validate_doc_id(json_data)
         error_msg += validator_utils.validate_submitting_party(json_data)
-        error_msg += validator_utils.validate_registration_state(registration, staff, MhrRegistrationTypes.REG_NOTE)
         doc_type: str = None
         if json_data.get('note') and json_data['note'].get('documentType'):
             doc_type = json_data['note'].get('documentType')
+        error_msg += validator_utils.validate_registration_state(registration,
+                                                                 staff,
+                                                                 MhrRegistrationTypes.REG_NOTE,
+                                                                 doc_type)
         error_msg += validate_giving_notice(json_data, doc_type)
         error_msg += validate_effective_ts(json_data, doc_type)
         error_msg += validate_expiry_ts(registration, json_data, doc_type)

--- a/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
@@ -1,0 +1,250 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds common validation functions for legacy DB2 manufactured homes.
+
+Refactored from registration_validator.
+"""
+from flask import current_app
+
+from mhr_api.models import Db2Manuhome, Db2Owngroup, Db2Document, Db2Mhomnote, Db2Owner
+from mhr_api.models.type_tables import MhrDocumentTypes, MhrRegistrationTypes, MhrTenancyTypes
+from mhr_api.models.db2.owngroup import NEW_TENANCY_LEGACY
+from mhr_api.models.db2.utils import get_db2_permit_count
+from mhr_api.models.utils import to_db2_ind_name
+
+
+STATE_NOT_ALLOWED = 'The MH registration is not in a state where changes are allowed. '
+STATE_FROZEN_AFFIDAVIT = 'A transfer to a benificiary is pending after an AFFIDAVIT transfer. '
+STATE_FROZEN_NOTE = 'Registration not allowed: this manufactured home has an active TAXN, NCON, or REST unit note. '
+EXEMPT_EXNR_INVALID = 'Registration not allowed: the home is exempt because of an existing non-residential exemption. '
+EXEMPT_EXRS_INVALID = 'Residential exemption registration not allowed: the home is already exempt. '
+DELETE_GROUP_ID_INVALID = 'The owner group with ID {group_id} is not active and cannot be changed. '
+DELETE_GROUP_ID_NONEXISTENT = 'No owner group with ID {group_id} exists. '
+DELETE_GROUP_TYPE_INVALID = 'The owner group tenancy type with ID {group_id} is invalid. '
+GROUP_INTEREST_MISMATCH = 'The owner group interest numerator sum does not equal the interest common denominator. '
+
+
+def validate_registration_state(registration, staff: bool, reg_type: str, doc_type: str = None):
+    """Validate registration state: changes are only allowed on active homes."""
+    error_msg = ''
+    current_app.logger.debug('Validating registration state  with the legacy DB.')
+    if not registration or not registration.manuhome:
+        return error_msg
+    manuhome: Db2Manuhome = registration.manuhome
+    if reg_type and reg_type == MhrDocumentTypes.EXRE:
+        return validate_registration_state_exre(manuhome)
+    if reg_type and reg_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
+        return validate_registration_state_exemption(manuhome, reg_type, staff)
+    if manuhome.mh_status != manuhome.StatusTypes.REGISTERED:
+        if manuhome.mh_status == manuhome.StatusTypes.CANCELLED or \
+                doc_type is None or \
+                doc_type != MhrDocumentTypes.NPUB:
+            error_msg += STATE_NOT_ALLOWED
+    elif manuhome.reg_documents:
+        last_doc: Db2Document = manuhome.reg_documents[-1]
+        if not staff and last_doc.document_type == Db2Document.DocumentTypes.TRANS_AFFIDAVIT:
+            error_msg += STATE_NOT_ALLOWED
+        elif staff and last_doc.document_type == Db2Document.DocumentTypes.TRANS_AFFIDAVIT and \
+                reg_type != MhrRegistrationTypes.TRANS:
+            error_msg += STATE_NOT_ALLOWED
+            error_msg += STATE_FROZEN_AFFIDAVIT
+    return check_state_note(manuhome, staff, error_msg)
+
+
+def validate_registration_state_exre(manuhome: Db2Manuhome):
+    """Validate registration state for rescind exemption requests."""
+    error_msg = ''
+    if manuhome.mh_status == manuhome.StatusTypes.EXEMPT:
+        return error_msg
+    return STATE_NOT_ALLOWED
+
+
+def validate_registration_state_exemption(manuhome: Db2Manuhome, reg_type: str, staff: bool):
+    """Validate registration state for residential/non-residential exemption requests."""
+    error_msg = ''
+    if manuhome.mh_status == manuhome.StatusTypes.REGISTERED:
+        return check_state_note(manuhome, staff, error_msg)
+    if manuhome.mh_status == manuhome.StatusTypes.CANCELLED:
+        error_msg += STATE_NOT_ALLOWED
+    elif reg_type == MhrRegistrationTypes.EXEMPTION_RES:
+        error_msg += EXEMPT_EXRS_INVALID
+    else:
+        for note in manuhome.reg_notes:
+            if note.document_type == MhrDocumentTypes.EXNR and note.status == Db2Mhomnote.StatusTypes.ACTIVE:
+                error_msg += EXEMPT_EXNR_INVALID
+    return error_msg
+
+
+def get_existing_location(registration):
+    """Get the currently active location JSON."""
+    if not registration or not registration.manuhome:
+        return {}
+    manuhome: Db2Manuhome = registration.manuhome
+    if manuhome and manuhome.reg_location:
+        return manuhome.reg_location.registration_json
+    return {}
+
+
+def get_permit_count(mhr_number: str, name: str) -> int:
+    """Execute a query to count existing transport permit registrations on a home."""
+    return get_db2_permit_count(mhr_number, name)
+
+
+def get_existing_group_count(registration) -> int:
+    """Count number of existing owner groups."""
+    group_count: int = 0
+    if not registration or not registration.manuhome:
+        return group_count
+    manuhome: Db2Manuhome = registration.manuhome
+    for existing in manuhome.reg_owner_groups:
+        if existing.status in (Db2Owngroup.StatusTypes.ACTIVE, Db2Owngroup.StatusTypes.EXEMPT):
+            group_count += 1
+    return group_count
+
+
+def check_state_note(manuhome: Db2Manuhome, staff: bool, error_msg: str) -> str:
+    """Check registration state for non-staff: frozen if active TAXN, NCON, or REST unit note."""
+    if staff:
+        return error_msg
+    if manuhome.notes:
+        for note in manuhome.reg_notes:
+            if note.document_type in (MhrDocumentTypes.TAXN, MhrDocumentTypes.NCON, MhrDocumentTypes.REST) and \
+                    note.status == Db2Mhomnote.StatusTypes.ACTIVE:
+                error_msg += STATE_FROZEN_NOTE
+    return error_msg
+
+
+def owner_name_match(registration=None, request_owner: dict = None) -> bool:
+    """Verify the request owner name matches one of the current owner names."""
+    request_name: str = ''
+    match: bool = False
+    if not registration or not registration.manuhome or not registration.manuhome.reg_owner_groups or not request_owner:
+        return match
+    is_business = request_owner.get('organizationName')
+    if is_business:
+        request_name = request_owner.get('organizationName').strip().upper()
+    elif request_owner.get('individualName') and request_owner['individualName'].get('first') and \
+            request_owner['individualName'].get('last'):
+        request_name = to_db2_ind_name(request_owner.get('individualName')).strip()
+    if not request_name:
+        return False
+    for group in registration.manuhome.reg_owner_groups:
+        if group.status == Db2Owngroup.StatusTypes.ACTIVE:
+            for owner in group.owners:
+                if owner.owner_type == Db2Owner.OwnerTypes.BUSINESS and is_business and \
+                        owner.name.strip() == request_name:
+                    return True
+                if owner.owner_type == Db2Owner.OwnerTypes.INDIVIDUAL and not is_business and \
+                        owner.name.strip() == request_name:
+                    return True
+    return match
+
+
+def validate_delete_owners(registration=None, json_data: dict = None) -> str:
+    """Check groups id's and owners are valid for deleted groups."""
+    error_msg = ''
+    if not registration or not registration.manuhome or not registration.manuhome.reg_owner_groups:
+        return error_msg
+    for deleted in json_data['deleteOwnerGroups']:
+        if deleted.get('groupId'):
+            group_id = deleted['groupId']
+            found: bool = False
+            for existing in registration.manuhome.reg_owner_groups:
+                if existing.group_id == group_id:
+                    found = True
+                    tenancy_type = deleted.get('type')
+                    if existing.status != Db2Owngroup.StatusTypes.ACTIVE:
+                        error_msg += DELETE_GROUP_ID_INVALID.format(group_id=group_id)
+                    if tenancy_type and NEW_TENANCY_LEGACY.get(tenancy_type) and \
+                            existing.tenancy_type != NEW_TENANCY_LEGACY.get(tenancy_type) and \
+                            tenancy_type != MhrTenancyTypes.NA:
+                        error_msg += DELETE_GROUP_TYPE_INVALID.format(group_id=group_id)
+            if not found:
+                error_msg += DELETE_GROUP_ID_NONEXISTENT.format(group_id=group_id)
+    return error_msg
+
+
+def delete_group(group_id: int, delete_groups):
+    """Check if owner group is flagged for deletion."""
+    if not delete_groups or group_id < 1:
+        return False
+    for group in delete_groups:
+        if group.get('groupId', 0) == group_id:
+            return True
+    return False
+
+
+def interest_required(groups, registration=None, delete_groups=None) -> bool:
+    """Determine if group interest is required."""
+    group_count: int = len(groups)  # Verify interest if multiple groups or existing interest.
+    if group_count > 1:
+        return True
+    if registration and registration.manuhome and registration.manuhome.reg_owner_groups:
+        for existing in registration.manuhome.reg_owner_groups:
+            if existing.status == Db2Owngroup.StatusTypes.ACTIVE and \
+                    existing.tenancy_type != Db2Owngroup.TenancyTypes.SOLE and \
+                    not delete_group(existing.group_id, delete_groups) and \
+                    existing.get_interest_fraction(False) > 0:
+                group_count += 1
+    return group_count > 1
+
+
+def validate_group_interest(groups,  # pylint: disable=too-many-branches
+                            denominator: int,
+                            registration=None,
+                            delete_groups=None) -> str:
+    """Verify owner group interest values are valid."""
+    error_msg = ''
+    numerator_sum: int = 0
+    group_count: int = len(groups)  # Verify interest if multiple groups or existing interest.
+    if registration and registration.manuhome and registration.manuhome.reg_owner_groups:
+        for existing in registration.manuhome.reg_owner_groups:
+            if existing.status == Db2Owngroup.StatusTypes.ACTIVE and \
+                    existing.tenancy_type != Db2Owngroup.TenancyTypes.SOLE and \
+                    not delete_group(existing.group_id, delete_groups):
+                den = existing.get_interest_fraction(False)
+                if den > 0:
+                    group_count += 1
+                    if den == denominator:
+                        numerator_sum += existing.interest_numerator
+                    elif den < denominator:
+                        numerator_sum += (denominator/den * existing.interest_numerator)
+                    else:
+                        numerator_sum += int((denominator * existing.interest_numerator)/den)
+    current_app.logger.debug(f'group_count={group_count} denominator={denominator}')
+    if group_count < 2:  # Could have transfer of joint tenants with no interest.
+        return error_msg
+    for group in groups:
+        num = group.get('interestNumerator', 0)
+        den = group.get('interestDenominator', 0)
+        if num and den and num > 0 and den > 0:
+            if den == denominator:
+                numerator_sum += num
+            else:
+                numerator_sum += (denominator/den * num)
+    if numerator_sum != denominator:
+        error_msg = GROUP_INTEREST_MISMATCH
+    return error_msg
+
+
+def get_modified_group(registration, group_id: int) -> dict:
+    """Find the existing owner group as JSON, matching on the group id."""
+    group = {}
+    if not registration or not registration.manuhome or not group_id:
+        return group
+    for existing in registration.manuhome.reg_owner_groups:
+        if existing.group_id == group_id:
+            group = existing.json
+            break
+    return group

--- a/mhr_api/tests/unit/api/test_exemptions.py
+++ b/mhr_api/tests/unit/api/test_exemptions.py
@@ -92,6 +92,20 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
     # check
     assert response.status_code == status
     if response.status_code == HTTPStatus.CREATED:
-        registration: MhrRegistration = MhrRegistration.find_by_mhr_number(response.json['mhrNumber'],
-                                                                           account)
+        resp_json = response.json
+        assert resp_json.get('mhrNumber')
+        assert resp_json.get('documentId')
+        assert resp_json.get('documentDescription')
+        assert resp_json.get('documentRegistrationNumber')
+        assert resp_json.get('createDateTime')
+        assert resp_json.get('status')
+        assert resp_json.get('registrationType')
+        assert resp_json.get('submittingParty')
+        assert resp_json.get('location')
+        assert resp_json.get('ownerGroups')
+        if resp_json.get('note') and resp_json['note'].get('expiryDateTime'):
+            assert resp_json['note'].get('destroyed')
+        registration: MhrRegistration = MhrRegistration.find_by_document_id(resp_json.get('documentId'),
+                                                                            account,
+                                                                            True)
         assert registration

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -25,6 +25,7 @@ from registry_schemas.example_data.mhr import REGISTRATION, LOCATION, TRANSFER, 
 
 from mhr_api.exceptions import BusinessException
 from mhr_api.models import Db2Document, Db2Manuhome, Db2Mhomnote, Db2Owngroup, MhrRegistration, Db2Location
+from mhr_api.models import utils as model_utils
 from mhr_api.models.db2.manuhome import LEGACY_STATUS_DESCRIPTION
 from mhr_api.models.type_tables import MhrPartyTypes, MhrTenancyTypes, MhrDocumentTypes
 from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE, STAFF_ROLE
@@ -202,556 +203,573 @@ TEST_DATA_ADMIN = [
 @pytest.mark.parametrize('tenancy_type,group_id,mhr_num,party_type', TEST_DATA_GROUP_TYPE)
 def test_group_type(session, tenancy_type, group_id, mhr_num, party_type):
     """Assert that find manufauctured home by mhr_number contains all expected elements."""
-    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
-    assert manuhome
-    json_data = manuhome.registration_json
-    for group in json_data.get('ownerGroups'):
-        if group.get('groupId') == group_id:
-            assert group['type'] == tenancy_type
-            if party_type and group.get('owners'):
-                for owner in group.get('owners'):
-                    assert owner.get('partyType') == party_type
+    if model_utils.is_legacy():
+        manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
+        assert manuhome
+        json_data = manuhome.registration_json
+        for group in json_data.get('ownerGroups'):
+            if group.get('groupId') == group_id:
+                assert group['type'] == tenancy_type
+                if party_type and group.get('owners'):
+                    for owner in group.get('owners'):
+                        assert owner.get('partyType') == party_type
 
 
 @pytest.mark.parametrize('exists,id,mhr_num,status,doc_id', TEST_DATA)
 def test_find_by_id(session, exists, id, mhr_num, status, doc_id):
     """Assert that find manufauctured home by id contains all expected elements."""
-    manuhome: Db2Manuhome = Db2Manuhome.find_by_id(id)
-    if exists:
-        assert manuhome
-        assert manuhome.id == id
-        assert manuhome.mhr_number == mhr_num
-        assert manuhome.mh_status == status
-        assert manuhome.reg_document_id == doc_id
-        assert manuhome.exempt_flag is not None
-        assert manuhome.presold_decal is not None
-        assert manuhome.update_count is not None
-        assert manuhome.update_id is not None
-        assert manuhome.update_date is not None
-        assert manuhome.update_time is not None
-        assert manuhome.accession_number is not None
-        assert manuhome.box_number is not None
-        assert manuhome.reg_documents
-        assert manuhome.reg_owner_groups
-        assert manuhome.reg_location
-        assert manuhome.reg_descript
-        assert manuhome.reg_notes
-        report_json = manuhome.registration_json
-        assert report_json['mhrNumber'] == mhr_num
-        assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
-        assert report_json.get('createDateTime')
-        assert report_json.get('clientReferenceId') is not None
-        assert report_json.get('declaredValue') >= 0
-        assert report_json.get('ownerGroups')
-        assert report_json.get('location')
-        assert report_json.get('description')
-        assert report_json.get('notes')
-    else:
-        assert not manuhome
+    if model_utils.is_legacy():
+        manuhome: Db2Manuhome = Db2Manuhome.find_by_id(id)
+        if exists:
+            assert manuhome
+            assert manuhome.id == id
+            assert manuhome.mhr_number == mhr_num
+            assert manuhome.mh_status == status
+            assert manuhome.reg_document_id == doc_id
+            assert manuhome.exempt_flag is not None
+            assert manuhome.presold_decal is not None
+            assert manuhome.update_count is not None
+            assert manuhome.update_id is not None
+            assert manuhome.update_date is not None
+            assert manuhome.update_time is not None
+            assert manuhome.accession_number is not None
+            assert manuhome.box_number is not None
+            assert manuhome.reg_documents
+            assert manuhome.reg_owner_groups
+            assert manuhome.reg_location
+            assert manuhome.reg_descript
+            assert manuhome.reg_notes
+            report_json = manuhome.registration_json
+            assert report_json['mhrNumber'] == mhr_num
+            assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
+            assert report_json.get('createDateTime')
+            assert report_json.get('clientReferenceId') is not None
+            assert report_json.get('declaredValue') >= 0
+            assert report_json.get('ownerGroups')
+            assert report_json.get('location')
+            assert report_json.get('description')
+            assert report_json.get('notes')
+        else:
+            assert not manuhome
 
 
 @pytest.mark.parametrize('http_status,id,mhr_num,status,doc_id,own_land', TEST_MHR_NUM_DATA)
 def test_find_by_mhr_number(session, http_status, id, mhr_num, status, doc_id, own_land):
     """Assert that find a manufactured home by mhr_number contains all expected elements."""
-    if http_status == HTTPStatus.OK:
-        manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
-        assert manuhome
-        assert manuhome.id == id
-        assert manuhome.mhr_number == mhr_num
-        assert manuhome.mh_status == status
-        assert manuhome.reg_document_id == doc_id
-        assert manuhome.exempt_flag is not None
-        assert manuhome.presold_decal is not None
-        assert manuhome.update_count is not None
-        assert manuhome.update_id is not None
-        assert manuhome.update_date is not None
-        assert manuhome.update_time is not None
-        assert manuhome.accession_number is not None
-        assert manuhome.box_number is not None
-        assert manuhome.reg_documents
-        assert manuhome.reg_owner_groups
-        assert manuhome.reg_location
-        assert manuhome.reg_descript
-        assert manuhome.reg_notes
-        report_json = manuhome.registration_json
-        assert report_json['mhrNumber'] == mhr_num
-        assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
-        assert report_json.get('createDateTime')
-        assert report_json.get('clientReferenceId') is not None
-        assert report_json.get('declaredValue') >= 0
-        assert report_json.get('ownerGroups')
-        assert report_json.get('location')
-        assert report_json.get('description')
-        assert report_json.get('notes')
-        assert report_json['ownLand'] == own_land
-        for note in report_json.get('notes'):
-            assert note.get('documentRegistrationNumber')
-    else:
-        with pytest.raises(BusinessException) as request_err:
-            Db2Manuhome.find_by_mhr_number(mhr_num)
-        # check
-        assert request_err
-        assert request_err.value.status_code == http_status
+    if model_utils.is_legacy():
+        if http_status == HTTPStatus.OK:
+            manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
+            assert manuhome
+            assert manuhome.id == id
+            assert manuhome.mhr_number == mhr_num
+            assert manuhome.mh_status == status
+            assert manuhome.reg_document_id == doc_id
+            assert manuhome.exempt_flag is not None
+            assert manuhome.presold_decal is not None
+            assert manuhome.update_count is not None
+            assert manuhome.update_id is not None
+            assert manuhome.update_date is not None
+            assert manuhome.update_time is not None
+            assert manuhome.accession_number is not None
+            assert manuhome.box_number is not None
+            assert manuhome.reg_documents
+            assert manuhome.reg_owner_groups
+            assert manuhome.reg_location
+            assert manuhome.reg_descript
+            assert manuhome.reg_notes
+            report_json = manuhome.registration_json
+            assert report_json['mhrNumber'] == mhr_num
+            assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
+            assert report_json.get('createDateTime')
+            assert report_json.get('clientReferenceId') is not None
+            assert report_json.get('declaredValue') >= 0
+            assert report_json.get('ownerGroups')
+            assert report_json.get('location')
+            assert report_json.get('description')
+            assert report_json.get('notes')
+            assert report_json['ownLand'] == own_land
+            for note in report_json.get('notes'):
+                assert note.get('documentRegistrationNumber')
+        else:
+            with pytest.raises(BusinessException) as request_err:
+                Db2Manuhome.find_by_mhr_number(mhr_num)
+            # check
+            assert request_err
+            assert request_err.value.status_code == http_status
 
 
 @pytest.mark.parametrize('mhr_num,staff,current,has_notes,ncan_doc_id', TEST_MHR_NUM_DATA_NOTE)
 def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, ncan_doc_id):
     """Assert that find a manufactured home by mhr_number conditionally includes notes."""
-    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
-    assert manuhome
-    manuhome.current_view = current
-    manuhome.staff = staff
-    reg_json = manuhome.new_registration_json
-    if has_notes:
-        assert reg_json.get('notes')
-        has_ncan: bool = False
-        for note in reg_json.get('notes'):
-            assert note.get('documentRegistrationNumber')
-            assert note.get('documentId')
-            if ncan_doc_id and note.get('documentId') == ncan_doc_id:
-                has_ncan = True
-                assert note.get('cancelledDocumentType')
-                assert note.get('cancelledDocumentRegistrationNumber')
-            assert note.get('createDateTime')
-            assert note.get('status')
-            assert 'remarks' in note
-            assert note.get('givingNoticeParty')
-        if ncan_doc_id:
-            assert has_ncan
-    elif staff and current:
-        assert 'notes' in reg_json
-        assert not reg_json.get('notes')
-    else:
-        assert not reg_json.get('notes')
-    # search version
-    reg_json = manuhome.registration_json
-    if has_notes:
-        assert reg_json.get('notes')
-        has_ncan: bool = False
-        for note in reg_json.get('notes'):
-            assert note.get('documentRegistrationNumber')
-            assert note.get('documentId')
-            if ncan_doc_id and note.get('documentId') == ncan_doc_id:
-                has_ncan = True
-                assert note.get('cancelledDocumentType')
-                assert note.get('cancelledDocumentRegistrationNumber')
-            assert note.get('createDateTime')
-            assert note.get('status')
-            assert 'remarks' in note
-            assert note.get('givingNoticeParty')
-        if ncan_doc_id:
-            assert has_ncan
-    else:
-        assert 'notes' not in reg_json
+    if model_utils.is_legacy():
+        manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number(mhr_num)
+        assert manuhome
+        manuhome.current_view = current
+        manuhome.staff = staff
+        reg_json = manuhome.new_registration_json
+        if has_notes:
+            assert reg_json.get('notes')
+            has_ncan: bool = False
+            for note in reg_json.get('notes'):
+                assert note.get('documentRegistrationNumber')
+                assert note.get('documentId')
+                if ncan_doc_id and note.get('documentId') == ncan_doc_id:
+                    has_ncan = True
+                    assert note.get('cancelledDocumentType')
+                    assert note.get('cancelledDocumentRegistrationNumber')
+                assert note.get('createDateTime')
+                assert note.get('status')
+                assert 'remarks' in note
+                assert note.get('givingNoticeParty')
+            if ncan_doc_id:
+                assert has_ncan
+        elif staff and current:
+            assert 'notes' in reg_json
+            assert not reg_json.get('notes')
+        else:
+            assert not reg_json.get('notes')
+        # search version
+        reg_json = manuhome.registration_json
+        if has_notes:
+            assert reg_json.get('notes')
+            has_ncan: bool = False
+            for note in reg_json.get('notes'):
+                assert note.get('documentRegistrationNumber')
+                assert note.get('documentId')
+                if ncan_doc_id and note.get('documentId') == ncan_doc_id:
+                    has_ncan = True
+                    assert note.get('cancelledDocumentType')
+                    assert note.get('cancelledDocumentRegistrationNumber')
+                assert note.get('createDateTime')
+                assert note.get('status')
+                assert 'remarks' in note
+                assert note.get('givingNoticeParty')
+            if ncan_doc_id:
+                assert has_ncan
+        else:
+            assert 'notes' not in reg_json
 
 
 @pytest.mark.parametrize('http_status,id,mhr_num,status,doc_id,own_land', TEST_MHR_NUM_DATA)
 def test_find_original_by_mhr_number(session, http_status, id, mhr_num, status, doc_id, own_land):
     """Assert that find the original manufauctured home information by mhr_number contains all expected elements."""
-    if http_status == HTTPStatus.OK:
-        manuhome: Db2Manuhome = Db2Manuhome.find_original_by_mhr_number(mhr_num)
-        assert manuhome
-        assert manuhome.id == id
-        assert manuhome.mhr_number == mhr_num
-        assert manuhome.mh_status == status
-        assert manuhome.reg_document_id == doc_id
-        assert manuhome.exempt_flag is not None
-        assert manuhome.presold_decal is not None
-        assert manuhome.update_count is not None
-        assert manuhome.update_id is not None
-        assert manuhome.update_date is not None
-        assert manuhome.update_time is not None
-        assert manuhome.accession_number is not None
-        assert manuhome.box_number is not None
-        assert manuhome.reg_documents
-        assert manuhome.reg_owner_groups
-        assert manuhome.reg_location
-        assert manuhome.reg_descript
-        report_json = manuhome.new_registration_json
-        # current_app.logger.info(report_json)
-        assert report_json['mhrNumber'] == mhr_num
-        assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
-        assert report_json.get('createDateTime')
-        assert report_json.get('clientReferenceId') is not None
-        assert report_json.get('declaredValue') >= 0
-        assert report_json.get('ownerGroups')
-        assert report_json.get('location')
-        assert report_json.get('description')
-        assert report_json['ownLand'] == own_land
-    else:
-        with pytest.raises(BusinessException) as request_err:
-            Db2Manuhome.find_by_mhr_number(mhr_num)
-        # check
-        assert request_err
-        assert request_err.value.status_code == http_status
+    if model_utils.is_legacy():
+        if http_status == HTTPStatus.OK:
+            manuhome: Db2Manuhome = Db2Manuhome.find_original_by_mhr_number(mhr_num)
+            assert manuhome
+            assert manuhome.id == id
+            assert manuhome.mhr_number == mhr_num
+            assert manuhome.mh_status == status
+            assert manuhome.reg_document_id == doc_id
+            assert manuhome.exempt_flag is not None
+            assert manuhome.presold_decal is not None
+            assert manuhome.update_count is not None
+            assert manuhome.update_id is not None
+            assert manuhome.update_date is not None
+            assert manuhome.update_time is not None
+            assert manuhome.accession_number is not None
+            assert manuhome.box_number is not None
+            assert manuhome.reg_documents
+            assert manuhome.reg_owner_groups
+            assert manuhome.reg_location
+            assert manuhome.reg_descript
+            report_json = manuhome.new_registration_json
+            # current_app.logger.info(report_json)
+            assert report_json['mhrNumber'] == mhr_num
+            assert report_json['status'] == LEGACY_STATUS_DESCRIPTION.get(status)
+            assert report_json.get('createDateTime')
+            assert report_json.get('clientReferenceId') is not None
+            assert report_json.get('declaredValue') >= 0
+            assert report_json.get('ownerGroups')
+            assert report_json.get('location')
+            assert report_json.get('description')
+            assert report_json['ownLand'] == own_land
+        else:
+            with pytest.raises(BusinessException) as request_err:
+                Db2Manuhome.find_by_mhr_number(mhr_num)
+            # check
+            assert request_err
+            assert request_err.value.status_code == http_status
 
 
 @pytest.mark.parametrize('http_status,doc_id,mhr_num,doc_type', TEST_DATA_DOC_ID)
 def test_find_by_document_id(session, http_status, doc_id, mhr_num, doc_type):
     """Assert that find manufauctured home information by document id contains all expected elements."""
-    if http_status == HTTPStatus.OK:
-        manuhome: Db2Manuhome = Db2Manuhome.find_by_document_id(doc_id)
-        assert manuhome
-        assert manuhome.id
-        assert manuhome.mhr_number == mhr_num
-        assert manuhome.reg_documents
-        doc = manuhome.reg_documents[0]
-        assert doc.id == doc_id
-        assert doc.document_type == doc_type
-        report_json = manuhome.json
-        assert report_json['mhrNumber'] == mhr_num
-        assert report_json.get('status')
-        assert report_json.get('createDateTime')
-        assert report_json.get('clientReferenceId') is not None
-        assert report_json.get('documentId') == doc_id
-        assert report_json.get('submittingParty')
-        if doc_type in (Db2Document.DocumentTypes.TRAND, Db2Document.DocumentTypes.TRANS):
-            assert manuhome.reg_owner_groups
-            assert len(manuhome.reg_owner_groups) == 2
-            assert len(report_json.get('deleteOwnerGroups')) + len(report_json.get('addOwnerGroups')) == 2
-    else:
-        with pytest.raises(BusinessException) as request_err:
-            Db2Manuhome.find_by_document_id(doc_id)
-        # check
-        assert request_err
-        assert request_err.value.status_code == http_status
+    if model_utils.is_legacy():
+        if http_status == HTTPStatus.OK:
+            manuhome: Db2Manuhome = Db2Manuhome.find_by_document_id(doc_id)
+            assert manuhome
+            assert manuhome.id
+            assert manuhome.mhr_number == mhr_num
+            assert manuhome.reg_documents
+            doc = manuhome.reg_documents[0]
+            assert doc.id == doc_id
+            assert doc.document_type == doc_type
+            report_json = manuhome.json
+            assert report_json['mhrNumber'] == mhr_num
+            assert report_json.get('status')
+            assert report_json.get('createDateTime')
+            assert report_json.get('clientReferenceId') is not None
+            assert report_json.get('documentId') == doc_id
+            assert report_json.get('submittingParty')
+            if doc_type in (Db2Document.DocumentTypes.TRAND, Db2Document.DocumentTypes.TRANS):
+                assert manuhome.reg_owner_groups
+                assert len(manuhome.reg_owner_groups) == 2
+                assert len(report_json.get('deleteOwnerGroups')) + len(report_json.get('addOwnerGroups')) == 2
+        else:
+            with pytest.raises(BusinessException) as request_err:
+                Db2Manuhome.find_by_document_id(doc_id)
+            # check
+            assert request_err
+            assert request_err.value.status_code == http_status
 
 
 @pytest.mark.parametrize('interest,numerator,denominator,new_interest', TEST_DATA_GROUP_INTEREST)
 def test_adjust_group_interest_new(session, interest, numerator, denominator, new_interest):
     """Assert that adjusting group interest is working as expected."""
-    groups = []
-    group: Db2Owngroup = Db2Owngroup(status=Db2Owngroup.StatusTypes.ACTIVE,
-                                     tenancy_type=Db2Owngroup.TenancyTypes.COMMON,
-                                     interest=interest,
-                                     interest_numerator=numerator,
-                                     interest_denominator=denominator)
-    groups.append(group)
-    Db2Manuhome.adjust_group_interest(groups, True)
-    assert groups[0].interest == new_interest
+    if model_utils.is_legacy():
+        groups = []
+        group: Db2Owngroup = Db2Owngroup(status=Db2Owngroup.StatusTypes.ACTIVE,
+                                        tenancy_type=Db2Owngroup.TenancyTypes.COMMON,
+                                        interest=interest,
+                                        interest_numerator=numerator,
+                                        interest_denominator=denominator)
+        groups.append(group)
+        Db2Manuhome.adjust_group_interest(groups, True)
+        assert groups[0].interest == new_interest
 
 
 @pytest.mark.parametrize('group1,group2,group3,interest1,interest2,interest3', TEST_DATA_GROUP_INTEREST2)
 def test_adjust_group_interest_2(session, group1, group2, group3, interest1, interest2, interest3):
     """Assert that adjusting group interest is working as expected."""
-    groups = []
-    if group1:
-        groups.append(group1)
-    if group2:
-        groups.append(group2)
-    if group3:
-        groups.append(group3)
-    Db2Manuhome.adjust_group_interest(groups, True)
-    for group in groups:
-        if group.group_id == 1:
-            assert group.interest == interest1
-        elif group.group_id == 2:
-            assert group.interest == interest2
-        elif group.group_id == 3:
-            assert group.interest == interest3
+    if model_utils.is_legacy():
+        groups = []
+        if group1:
+            groups.append(group1)
+        if group2:
+            groups.append(group2)
+        if group3:
+            groups.append(group3)
+        Db2Manuhome.adjust_group_interest(groups, True)
+        for group in groups:
+            if group.group_id == 1:
+                assert group.interest == interest1
+            elif group.group_id == 2:
+                assert group.interest == interest2
+            elif group.group_id == 3:
+                assert group.interest == interest3
 
 
 def test_notes_sort_order(session):
     """Assert that manufactured home notes sort order is as expected."""
-    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('053341')
-    report_json = manuhome.registration_json
-    assert len(report_json['notes']) == 2
-    assert report_json['notes'][0]['documentId'] == '90001986'
-    assert report_json['notes'][1]['documentId'] == '43405528'
+    if model_utils.is_legacy():
+        manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('053341')
+        report_json = manuhome.registration_json
+        assert len(report_json['notes']) == 2
+        assert report_json['notes'][0]['documentId'] == '90001986'
+        assert report_json['notes'][1]['documentId'] == '43405528'
 
 
 def test_declared_value(session):
     """Assert that manufauctured home declared value is as expected."""
-    manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('077344')
-    report_json = manuhome.registration_json
-    assert report_json['declaredValue'] == 28200
-    assert str(report_json['declaredDateTime']).startswith('2010-11-09')
+    if model_utils.is_legacy():
+        manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('077344')
+        report_json = manuhome.registration_json
+        assert report_json['declaredValue'] == 28200
+        assert str(report_json['declaredDateTime']).startswith('2010-11-09')
 
 
 def test_create_new_from_json(session):
     """Assert that the new MHR registration is created from registration json correctly."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['location'] = copy.deepcopy(LOCATION)
-    json_data['documentId'] = 'UT000001'
-    json_data['attentionReference'] = 'ATTN_REF'
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_registration(registration, json_data)
-    mh_json = manuhome.new_registration_json
-    current_app.logger.info(mh_json)
-    assert manuhome.id == registration.id
-    assert manuhome.mhr_number == registration.mhr_number
-    assert manuhome.reg_document_id == json_data['documentId'] 
-    assert manuhome.mh_status == Db2Manuhome.StatusTypes.REGISTERED
-    assert manuhome.update_id == current_app.config.get('DB2_RACF_ID')
-    assert manuhome.reg_documents
-    assert len(manuhome.reg_documents) == 1
-    doc: Db2Document = manuhome.reg_documents[0]
-    assert doc.update_id == manuhome.update_id
-    assert manuhome.reg_location
-    assert manuhome.reg_location.status == 'A'
-    assert manuhome.reg_descript
-    assert manuhome.reg_descript.status == 'A'
-    assert manuhome.reg_owner_groups
-    assert len(manuhome.reg_owner_groups) == 2
-    for group in manuhome.reg_owner_groups:
-        assert group.owners
-        assert len(group.owners) == 1
-        assert group.status == Db2Owngroup.StatusTypes.ACTIVE
-        assert group.reg_document_id == json_data['documentId']
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(REGISTRATION)
+        json_data['location'] = copy.deepcopy(LOCATION)
+        json_data['documentId'] = 'UT000001'
+        json_data['attentionReference'] = 'ATTN_REF'
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_registration(registration, json_data)
+        mh_json = manuhome.new_registration_json
+        current_app.logger.info(mh_json)
+        assert manuhome.id == registration.id
+        assert manuhome.mhr_number == registration.mhr_number
+        assert manuhome.reg_document_id == json_data['documentId'] 
+        assert manuhome.mh_status == Db2Manuhome.StatusTypes.REGISTERED
+        assert manuhome.update_id == current_app.config.get('DB2_RACF_ID')
+        assert manuhome.reg_documents
+        assert len(manuhome.reg_documents) == 1
+        doc: Db2Document = manuhome.reg_documents[0]
+        assert doc.update_id == manuhome.update_id
+        assert manuhome.reg_location
+        assert manuhome.reg_location.status == 'A'
+        assert manuhome.reg_descript
+        assert manuhome.reg_descript.status == 'A'
+        assert manuhome.reg_owner_groups
+        assert len(manuhome.reg_owner_groups) == 2
+        for group in manuhome.reg_owner_groups:
+            assert group.owners
+            assert len(group.owners) == 1
+            assert group.status == Db2Owngroup.StatusTypes.ACTIVE
+            assert group.reg_document_id == json_data['documentId']
 
 
 @pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id', TEST_DATA_TRANSFER)
 def test_create_transfer_from_json(session, mhr_num, user_group, doc_id_prefix, account_id):
     """Assert that an MHR tranfer is created from MHR transfer json correctly."""
-    json_data = copy.deepcopy(TRANSFER)
-    del json_data['documentId']
-    del json_data['documentDescription']
-    del json_data['createDateTime']
-    del json_data['payment']
-    json_data['mhrNumber'] = mhr_num
-    json_data['consideration'] = '$120000.00'
-    json_data['declaredValue'] = 120000
-    json_data['ownLand'] = 'Y'
-    json_data['transferDate'] = '2022-10-07T18:43:45+00:00'
-    base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
-    assert base_reg
-    assert base_reg.manuhome
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_transfer_from_json(base_reg,
-                                                                              json_data,
-                                                                              'PS12345',
-                                                                              'userid',
-                                                                              user_group)
-    assert registration.doc_id
-    assert json_data.get('documentId')
-    assert str(json_data.get('documentId')).startswith(doc_id_prefix)
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_transfer(registration, json_data)
-    assert len(manuhome.reg_documents) > 1
-    index: int = len(manuhome.reg_documents) - 1
-    doc: Db2Document = manuhome.reg_documents[index]
-    assert doc.id == registration.doc_id
-    assert doc.document_type == Db2Document.DocumentTypes.TRANS
-    assert doc.document_reg_id == registration.doc_reg_number
-    assert doc.update_id == current_app.config.get('DB2_RACF_ID')
-    assert manuhome.reg_owner_groups
-    assert len(manuhome.reg_owner_groups) > 2
-    for group in manuhome.reg_owner_groups:
-        if group.group_id == 1:
-            assert group.status == Db2Owngroup.StatusTypes.PREVIOUS
-            assert group.can_document_id == registration.doc_id
-        elif group.group_id == 3:
-            assert group.status == Db2Owngroup.StatusTypes.ACTIVE
-            assert group.reg_document_id == registration.doc_id
-    assert doc.consideration_value
-    assert doc.own_land == 'Y'
-    assert doc.declared_value == 120000
-    assert doc.consideration_value == '$120000.00'
-    assert doc.transfer_execution_date
-    assert doc.transfer_execution_date.year == 2022
-    assert doc.transfer_execution_date.month == 10
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(TRANSFER)
+        del json_data['documentId']
+        del json_data['documentDescription']
+        del json_data['createDateTime']
+        del json_data['payment']
+        json_data['mhrNumber'] = mhr_num
+        json_data['consideration'] = '$120000.00'
+        json_data['declaredValue'] = 120000
+        json_data['ownLand'] = 'Y'
+        json_data['transferDate'] = '2022-10-07T18:43:45+00:00'
+        base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+        assert base_reg
+        assert base_reg.manuhome
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_transfer_from_json(base_reg,
+                                                                                json_data,
+                                                                                'PS12345',
+                                                                                'userid',
+                                                                                user_group)
+        assert registration.doc_id
+        assert json_data.get('documentId')
+        assert str(json_data.get('documentId')).startswith(doc_id_prefix)
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_transfer(registration, json_data)
+        assert len(manuhome.reg_documents) > 1
+        index: int = len(manuhome.reg_documents) - 1
+        doc: Db2Document = manuhome.reg_documents[index]
+        assert doc.id == registration.doc_id
+        assert doc.document_type == Db2Document.DocumentTypes.TRANS
+        assert doc.document_reg_id == registration.doc_reg_number
+        assert doc.update_id == current_app.config.get('DB2_RACF_ID')
+        assert manuhome.reg_owner_groups
+        assert len(manuhome.reg_owner_groups) > 2
+        for group in manuhome.reg_owner_groups:
+            if group.group_id == 1:
+                assert group.status == Db2Owngroup.StatusTypes.PREVIOUS
+                assert group.can_document_id == registration.doc_id
+            elif group.group_id == 3:
+                assert group.status == Db2Owngroup.StatusTypes.ACTIVE
+                assert group.reg_document_id == registration.doc_id
+        assert doc.consideration_value
+        assert doc.own_land == 'Y'
+        assert doc.declared_value == 120000
+        assert doc.consideration_value == '$120000.00'
+        assert doc.transfer_execution_date
+        assert doc.transfer_execution_date.year == 2022
+        assert doc.transfer_execution_date.month == 10
 
 
 @pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id', TEST_DATA_EXEMPTION)
 def test_create_exemption_from_json(session, mhr_num, user_group, doc_id_prefix, account_id):
     """Assert that an MHR tranfer is created from MHR exemption json correctly."""
-    json_data = copy.deepcopy(EXEMPTION)
-    del json_data['documentId']
-    del json_data['documentRegistrationNumber']
-    del json_data['documentDescription']
-    del json_data['createDateTime']
-    del json_data['payment']
-    json_data['mhrNumber'] = mhr_num
-    json_data['nonResidential'] = False
-    json_data['note']['remarks'] = 'remarks'
-    json_data['note']['expiryDateTime'] = '2022-10-07T18:43:45+00:00'
-    base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
-    assert base_reg
-    assert base_reg.manuhome
-    assert base_reg.manuhome.reg_documents
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_exemption_from_json(base_reg,
-                                                                               json_data,
-                                                                               'PS12345',
-                                                                               'userid',
-                                                                               user_group)
-    assert registration.doc_id
-    assert json_data.get('documentId')
-    assert str(json_data.get('documentId')).startswith(doc_id_prefix)
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_exemption(registration, json_data)
-    assert manuhome.mh_status == Db2Manuhome.StatusTypes.EXEMPT
-    assert len(manuhome.reg_documents) > 1
-    index: int = len(manuhome.reg_documents) - 1
-    doc: Db2Document = manuhome.reg_documents[index]
-    assert doc.id == registration.doc_id
-    assert doc.document_type == Db2Document.DocumentTypes.RES_EXEMPTION
-    assert doc.document_reg_id == registration.doc_reg_number
-    assert doc.attention_reference
-    assert doc.client_reference_id
-    assert doc.registration_ts
-    assert manuhome.reg_notes
-    note: Db2Mhomnote = manuhome.reg_notes[0]
-    assert note.document_type == doc.document_type
-    assert note.reg_document_id == doc.id
-    assert note.destroyed == 'Y'
-    assert note.remarks == 'remarks'
-    assert note.expiry_date
-    assert note.expiry_date.year == 2022
-    assert note.expiry_date.month == 10
-
-
-@pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id', TEST_DATA_EXEMPTION)
-def test_create_permit_from_json(session, mhr_num, user_group, doc_id_prefix, account_id):
-    """Assert that an MHR tranfer is created from MHR exemption json correctly."""
-    json_data = copy.deepcopy(PERMIT)
-    del json_data['documentId']
-    del json_data['documentRegistrationNumber']
-    del json_data['documentDescription']
-    del json_data['createDateTime']
-    del json_data['payment']
-    del json_data['note']
-    del json_data['registrationType']
-    json_data['mhrNumber'] = mhr_num
-    base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
-    assert base_reg
-    assert base_reg.manuhome
-    assert base_reg.manuhome.reg_documents
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_permit_from_json(base_reg,
-                                                                            json_data,
-                                                                            'PS12345',
-                                                                            'userid',
-                                                                            user_group)
-    assert registration.doc_id
-    assert json_data.get('documentId')
-    assert str(json_data.get('documentId')).startswith(doc_id_prefix)
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_permit(registration, json_data)
-    assert len(manuhome.reg_documents) > 1
-    index: int = len(manuhome.reg_documents) - 1
-    doc: Db2Document = manuhome.reg_documents[index]
-    assert doc.id == registration.doc_id
-    assert doc.document_type == Db2Document.DocumentTypes.PERMIT
-    assert doc.document_reg_id == registration.doc_reg_number
-    assert doc.client_reference_id
-    assert doc.registration_ts
-    assert manuhome.reg_notes
-    note: Db2Mhomnote = manuhome.reg_notes[0]
-    assert note.document_type == doc.document_type
-    assert note.reg_document_id == doc.id
-    assert note.destroyed == 'N'
-    # assert note.remarks
-    assert note.expiry_date
-    assert manuhome.reg_location
-    assert manuhome.reg_location.status == Db2Location.StatusTypes.HISTORICAL
-    assert manuhome.reg_location.can_document_id == doc.id
-    assert manuhome.new_location
-    assert manuhome.new_location.status == Db2Location.StatusTypes.ACTIVE
-    assert manuhome.new_location.reg_document_id == doc.id
-    assert not manuhome.new_location.can_document_id
-    assert manuhome.new_location.manuhome_id == manuhome.id
-
-
-def test_save_new(session):
-    """Assert that saving a new MHR registration is working correctly."""
-    json_data = copy.deepcopy(REGISTRATION)
-    json_data['location'] = copy.deepcopy(LOCATION)
-    json_data['documentId'] = 'UT000001'
-    json_data['attentionReference'] = 'ATTN_REF'
-    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_registration(registration, json_data)
-    manuhome.save()
-    mh_json = manuhome.new_registration_json
-    current_app.logger.info(mh_json)
-    reg_new = Db2Manuhome.find_by_mhr_number(registration.mhr_number)
-    assert reg_new
-    assert manuhome.reg_documents
-    assert len(manuhome.reg_documents) == 1
-    assert manuhome.mh_status == 'R'
-    assert manuhome.reg_location
-    assert manuhome.reg_location.status == 'A'
-    assert manuhome.reg_descript
-    assert manuhome.reg_descript.status == 'A'
-    assert manuhome.reg_owner_groups
-    assert len(manuhome.reg_owner_groups) == 2
-    for group in manuhome.reg_owner_groups:
-        assert group.status == '3'
-
-
-@pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id,doc_type,can_doc_id', TEST_DATA_NOTE)
-def test_create_note_from_json(session, mhr_num, user_group, doc_id_prefix, account_id, doc_type, can_doc_id):
-    """Assert that an MHR unit note registration is created from json correctly."""
-    json_data = copy.deepcopy(NOTE_REGISTRATION)
-    json_data['note']['documentType'] = doc_type
-    if doc_type == MhrDocumentTypes.NCAN:
-        json_data['cancelDocumentId'] = can_doc_id
-    base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
-    assert base_reg
-    existing_count = len(base_reg.manuhome.reg_notes)
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_note_from_json(base_reg,
-                                                                          json_data,
-                                                                          'ppr_staff',
-                                                                          'userid',
-                                                                          user_group)
-    assert registration.id > 0
-    assert registration.doc_id
-    assert json_data.get('documentId')
-    assert str(json_data.get('documentId')).startswith(doc_id_prefix)
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_note(registration, json_data)
-    assert len(manuhome.reg_documents) > 1
-    index: int = len(manuhome.reg_documents) - 1
-    doc: Db2Document = manuhome.reg_documents[index]
-    assert doc.id == registration.doc_id
-    assert doc.document_type.strip() == doc_type
-    assert doc.document_reg_id == registration.doc_reg_number
-    assert doc.attention_reference
-    assert doc.client_reference_id
-    assert doc.registration_ts
-    if doc_type != MhrDocumentTypes.NCAN:
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(EXEMPTION)
+        del json_data['documentId']
+        del json_data['documentRegistrationNumber']
+        del json_data['documentDescription']
+        del json_data['createDateTime']
+        del json_data['payment']
+        json_data['mhrNumber'] = mhr_num
+        json_data['nonResidential'] = False
+        json_data['note']['remarks'] = 'remarks'
+        json_data['note']['expiryDateTime'] = '2022-10-07T18:43:45+00:00'
+        base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+        assert base_reg
+        assert base_reg.manuhome
+        assert base_reg.manuhome.reg_documents
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_exemption_from_json(base_reg,
+                                                                                json_data,
+                                                                                'PS12345',
+                                                                                'userid',
+                                                                                user_group)
+        assert registration.doc_id
+        assert json_data.get('documentId')
+        assert str(json_data.get('documentId')).startswith(doc_id_prefix)
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_exemption(registration, json_data)
+        assert manuhome.mh_status == Db2Manuhome.StatusTypes.EXEMPT
+        assert len(manuhome.reg_documents) > 1
+        index: int = len(manuhome.reg_documents) - 1
+        doc: Db2Document = manuhome.reg_documents[index]
+        assert doc.id == registration.doc_id
+        assert doc.document_type == Db2Document.DocumentTypes.RES_EXEMPTION
+        assert doc.document_reg_id == registration.doc_reg_number
+        assert doc.attention_reference
+        assert doc.client_reference_id
+        assert doc.registration_ts
         assert manuhome.reg_notes
         note: Db2Mhomnote = manuhome.reg_notes[0]
         assert note.document_type == doc.document_type
         assert note.reg_document_id == doc.id
         assert note.destroyed == 'N'
-        assert note.remarks
-        assert note.status
+        assert note.remarks == 'remarks'
         assert note.expiry_date
-        assert note.name
-        assert note.phone_number
-        assert note.legacy_address
-    else:
-        assert len(manuhome.reg_notes) == existing_count
+        assert note.expiry_date.year == 2022
+        assert note.expiry_date.month == 10
+
+
+@pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id', TEST_DATA_EXEMPTION)
+def test_create_permit_from_json(session, mhr_num, user_group, doc_id_prefix, account_id):
+    """Assert that an MHR tranfer is created from MHR exemption json correctly."""
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(PERMIT)
+        del json_data['documentId']
+        del json_data['documentRegistrationNumber']
+        del json_data['documentDescription']
+        del json_data['createDateTime']
+        del json_data['payment']
+        del json_data['note']
+        del json_data['registrationType']
+        json_data['mhrNumber'] = mhr_num
+        base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+        assert base_reg
+        assert base_reg.manuhome
+        assert base_reg.manuhome.reg_documents
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_permit_from_json(base_reg,
+                                                                                json_data,
+                                                                                'PS12345',
+                                                                                'userid',
+                                                                                user_group)
+        assert registration.doc_id
+        assert json_data.get('documentId')
+        assert str(json_data.get('documentId')).startswith(doc_id_prefix)
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_permit(registration, json_data)
+        assert len(manuhome.reg_documents) > 1
+        index: int = len(manuhome.reg_documents) - 1
+        doc: Db2Document = manuhome.reg_documents[index]
+        assert doc.id == registration.doc_id
+        assert doc.document_type == Db2Document.DocumentTypes.PERMIT
+        assert doc.document_reg_id == registration.doc_reg_number
+        assert doc.client_reference_id
+        assert doc.registration_ts
+        assert manuhome.reg_notes
+        note: Db2Mhomnote = manuhome.reg_notes[0]
+        assert note.document_type == doc.document_type
+        assert note.reg_document_id == doc.id
+        assert note.destroyed == 'N'
+        # assert note.remarks
+        assert note.expiry_date
+        assert manuhome.reg_location
+        assert manuhome.reg_location.status == Db2Location.StatusTypes.HISTORICAL
+        assert manuhome.reg_location.can_document_id == doc.id
+        assert manuhome.new_location
+        assert manuhome.new_location.status == Db2Location.StatusTypes.ACTIVE
+        assert manuhome.new_location.reg_document_id == doc.id
+        assert not manuhome.new_location.can_document_id
+        assert manuhome.new_location.manuhome_id == manuhome.id
+
+
+def test_save_new(session):
+    """Assert that saving a new MHR registration is working correctly."""
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(REGISTRATION)
+        json_data['location'] = copy.deepcopy(LOCATION)
+        json_data['documentId'] = 'UT000001'
+        json_data['attentionReference'] = 'ATTN_REF'
+        registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_registration(registration, json_data)
+        manuhome.save()
+        mh_json = manuhome.new_registration_json
+        current_app.logger.info(mh_json)
+        reg_new = Db2Manuhome.find_by_mhr_number(registration.mhr_number)
+        assert reg_new
+        assert manuhome.reg_documents
+        assert len(manuhome.reg_documents) == 1
+        assert manuhome.mh_status == 'R'
+        assert manuhome.reg_location
+        assert manuhome.reg_location.status == 'A'
+        assert manuhome.reg_descript
+        assert manuhome.reg_descript.status == 'A'
+        assert manuhome.reg_owner_groups
+        assert len(manuhome.reg_owner_groups) == 2
+        for group in manuhome.reg_owner_groups:
+            assert group.status == '3'
+
+
+@pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id,doc_type,can_doc_id', TEST_DATA_NOTE)
+def test_create_note_from_json(session, mhr_num, user_group, doc_id_prefix, account_id, doc_type, can_doc_id):
+    """Assert that an MHR unit note registration is created from json correctly."""
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(NOTE_REGISTRATION)
+        json_data['note']['documentType'] = doc_type
+        if doc_type == MhrDocumentTypes.NCAN:
+            json_data['cancelDocumentId'] = can_doc_id
+        base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+        assert base_reg
+        existing_count = len(base_reg.manuhome.reg_notes)
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_note_from_json(base_reg,
+                                                                            json_data,
+                                                                            'ppr_staff',
+                                                                            'userid',
+                                                                            user_group)
+        assert registration.id > 0
+        assert registration.doc_id
+        assert json_data.get('documentId')
+        assert str(json_data.get('documentId')).startswith(doc_id_prefix)
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_note(registration, json_data)
+        assert len(manuhome.reg_documents) > 1
+        index: int = len(manuhome.reg_documents) - 1
+        doc: Db2Document = manuhome.reg_documents[index]
+        assert doc.id == registration.doc_id
+        assert doc.document_type.strip() == doc_type
+        assert doc.document_reg_id == registration.doc_reg_number
+        assert doc.attention_reference
+        assert doc.client_reference_id
+        assert doc.registration_ts
+        if doc_type != MhrDocumentTypes.NCAN:
+            assert manuhome.reg_notes
+            note: Db2Mhomnote = manuhome.reg_notes[0]
+            assert note.document_type == doc.document_type
+            assert note.reg_document_id == doc.id
+            assert note.destroyed == 'N'
+            assert note.remarks
+            assert note.status
+            assert note.expiry_date
+            assert note.name
+            assert note.phone_number
+            assert note.legacy_address
+        else:
+            assert len(manuhome.reg_notes) == existing_count
 
 
 @pytest.mark.parametrize('mhr_num,user_group,doc_id_prefix,account_id,doc_type,can_doc_id', TEST_DATA_ADMIN)
 def test_create_admin_from_json(session, mhr_num, user_group, doc_id_prefix, account_id, doc_type, can_doc_id):
     """Assert that an MHR admin registration is created from json correctly."""
-    json_data = copy.deepcopy(ADMIN_REGISTRATION)
-    json_data['documentType'] = doc_type
-    if doc_type in (MhrDocumentTypes.NRED, MhrDocumentTypes.NCAN):
-        json_data['note']['documentType'] = doc_type
-        json_data['updateDocumentId'] = can_doc_id
-    else:
-        del json_data['note']
-    base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
-    assert base_reg
-    # current_app.logger.info(json_data)
-    registration: MhrRegistration = MhrRegistration.create_admin_from_json(base_reg,
-                                                                           json_data,
-                                                                           account_id,
-                                                                           'userid',
-                                                                           user_group)
-    assert registration.id > 0
-    assert registration.doc_id
-    assert json_data.get('documentId')
-    assert str(json_data.get('documentId')).startswith(doc_id_prefix)
-    manuhome: Db2Manuhome = Db2Manuhome.create_from_admin(registration, json_data)
-    assert len(manuhome.reg_documents) > 1
-    index: int = len(manuhome.reg_documents) - 1
-    doc: Db2Document = manuhome.reg_documents[index]
-    assert doc.id == registration.doc_id
-    assert doc.document_type.strip() == doc_type
-    assert doc.document_reg_id == registration.doc_reg_number
-    assert doc.attention_reference
-    assert doc.client_reference_id
-    assert doc.registration_ts
+    if model_utils.is_legacy():
+        json_data = copy.deepcopy(ADMIN_REGISTRATION)
+        json_data['documentType'] = doc_type
+        if doc_type in (MhrDocumentTypes.NRED, MhrDocumentTypes.NCAN):
+            json_data['note']['documentType'] = doc_type
+            json_data['updateDocumentId'] = can_doc_id
+        else:
+            del json_data['note']
+        base_reg: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account_id)
+        assert base_reg
+        # current_app.logger.info(json_data)
+        registration: MhrRegistration = MhrRegistration.create_admin_from_json(base_reg,
+                                                                            json_data,
+                                                                            account_id,
+                                                                            'userid',
+                                                                            user_group)
+        assert registration.id > 0
+        assert registration.doc_id
+        assert json_data.get('documentId')
+        assert str(json_data.get('documentId')).startswith(doc_id_prefix)
+        manuhome: Db2Manuhome = Db2Manuhome.create_from_admin(registration, json_data)
+        assert len(manuhome.reg_documents) > 1
+        index: int = len(manuhome.reg_documents) - 1
+        doc: Db2Document = manuhome.reg_documents[index]
+        assert doc.id == registration.doc_id
+        assert doc.document_type.strip() == doc_type
+        assert doc.document_reg_id == registration.doc_reg_number
+        assert doc.attention_reference
+        assert doc.client_reference_id
+        assert doc.registration_ts

--- a/mhr_api/tests/unit/models/test_mhr_note.py
+++ b/mhr_api/tests/unit/models/test_mhr_note.py
@@ -32,7 +32,7 @@ TEST_ID_DATA = [
 ]
 TEST_NOTE = MhrNote(id=1,
     status_type='ACTIVE',
-    document_type=MhrDocumentTypes.REG_101,
+    document_type=MhrDocumentTypes.EXRS,
     document_id=200000000,
     remarks='remarks',
     destroyed='N',
@@ -117,7 +117,7 @@ def test_note_json(session):
         'documentId': str(note.document_id),
         'status': note.status_type,
         'documentType': note.document_type,
-        'documentDescription': 'MANUFACTURED HOME REGISTRATION',
+        'documentDescription': 'RESIDENTIAL EXEMPTION',
         'remarks': note.remarks,
         'destroyed': False,
         'effectiveDateTime': model_utils.format_ts(note.effective_ts),

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -82,10 +82,11 @@ TEST_TRANSFER_DATA = [
     ('Invalid FROZEN REST', False, False, None, validator_utils.STATE_FROZEN_NOTE, MhrRegistrationStatusTypes.ACTIVE),
     ('Invalid FROZEN NCON', False, False, None, validator_utils.STATE_FROZEN_NOTE, MhrRegistrationStatusTypes.ACTIVE),
     ('Invalid draft', False, False, None, validator_utils.DRAFT_NOT_ALLOWED, MhrRegistrationStatusTypes.ACTIVE),
-    (DESC_INVALID_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_INVALID, MhrRegistrationStatusTypes.ACTIVE),
-    (DESC_NONEXISTENT_GROUP_ID, False, False, None, validator.DELETE_GROUP_ID_NONEXISTENT,
+    (DESC_INVALID_GROUP_ID, False, False, None, validator_utils.DELETE_GROUP_ID_INVALID,
      MhrRegistrationStatusTypes.ACTIVE),
-    (DESC_INVALID_GROUP_TYPE, False, False, None, validator.DELETE_GROUP_TYPE_INVALID,
+    (DESC_NONEXISTENT_GROUP_ID, False, False, None, validator_utils.DELETE_GROUP_ID_NONEXISTENT,
+     MhrRegistrationStatusTypes.ACTIVE),
+    (DESC_INVALID_GROUP_TYPE, False, False, None, validator_utils.DELETE_GROUP_TYPE_INVALID,
      MhrRegistrationStatusTypes.ACTIVE)
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {tran_dt}, {dec_val}, {consideration}, {message content})
@@ -216,8 +217,8 @@ TEST_TRANSFER_DEATH_NA_DATA = [
 # testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {message content})
 TEST_TRANSFER_DATA_GROUP_INTEREST = [
     ('Valid add', True, 1, 2, None),
-    ('Invalid numerator < 1', False, 1, 4, validator.GROUP_INTEREST_MISMATCH),
-    ('Invalid numerator sum high', False, 3, 4, validator.GROUP_INTEREST_MISMATCH)
+    ('Invalid numerator < 1', False, 1, 4, validator_utils.GROUP_INTEREST_MISMATCH),
+    ('Invalid numerator sum high', False, 3, 4, validator_utils.GROUP_INTEREST_MISMATCH)
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {kc_group}, {mhr_num}, {json_data}, {message content})
 TEST_TRANSFER_DATA_QS = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17407

*Description of changes:*
- Destroyed date cannot be in the future.
- Non-residential allowed when exempt because of a residential exemption
- Document id auto-generated for QS residential exemptions
- NPUB unit note registration allowed with a home in an exempt state
- Final report changes out of scope.
- Refactor of data validation on existing data checks as a set up for data migration: move legacy DB checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
