### PR TITLE
Fix DB2 registration timestamp timezone.

### DIFF
--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -246,7 +246,12 @@ def format_local_ts(time_stamp):
     formatted_ts: str = None
     if time_stamp:
         try:
-            formatted_ts = time_stamp.replace(tzinfo=LOCAL_TZ).replace(microsecond=0).isoformat()
+            local_ts = LOCAL_TZ.localize(time_stamp, is_dst=True)
+            formatted_ts: str = local_ts.replace(microsecond=0).isoformat()
+            if formatted_ts.endswith('-07:53'):   # Correct DB2 conversion idiosyncrasy.
+                formatted_ts.replace('-07:53', '-08:00')
+            elif formatted_ts.endswith('-06:53'):
+                formatted_ts.replace('-06:53', '-07:00')
         except Exception as format_exception:   # noqa: B902; return nicer error
             current_app.logger.error('format_ts exception: ' + str(format_exception))
             formatted_ts = time_stamp.isoformat()

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.1'  # pylint: disable=invalid-name
+__version__ = '1.5.2'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_document.py
+++ b/mhr_api/tests/unit/models/db2/test_document.py
@@ -188,8 +188,8 @@ def test_document_json(session):
     doc.affirm_by_name = 'affirmByName'
     doc.liens_with_consent = 'liensWithConsent'
     doc.client_reference_id = 'clientReferenceId'
-    doc.draft_ts = model_utils.ts_from_iso_format('1995-11-10T17:20:22+00:00')
-    doc.registration_ts = model_utils.ts_from_iso_format('1995-11-14T08:00:01+00:00')
+    doc.draft_ts = model_utils.ts_from_iso_format('1995-11-10T17:20:22-08:00')
+    doc.registration_ts = model_utils.ts_from_iso_format('1995-11-14T08:00:01-08:00')
     doc.transfer_execution_date = model_utils.date_from_iso_format('0001-01-01')
 
     test_json = {
@@ -216,8 +216,8 @@ def test_document_json(session):
         'affirmByName': doc.affirm_by_name,
         'liensWithConsent': doc.liens_with_consent,
         'clientReferenceId': doc.client_reference_id,
-        'draftDateTime': '1995-11-10T17:20:22-07:53',
-        'createDateTime': '1995-11-14T08:00:01-07:53',
+        'draftDateTime': '1995-11-11T01:20:22+00:00',
+        'createDateTime': '1995-11-14T16:00:01+00:00'
         # 'transferDate': '0001-01-01'
     }
     assert doc.json == test_json


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17438

*Description of changes:*
- Correct API formatted DB2 timestamp with incorrect UTC timezone. Change from -07:53 to -08:00, and from -06:53 to -07:00


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
