### PR TITLE
Makes x-icon white

### DIFF
--- a/ppr-ui/src/assets/styles/overrides.scss
+++ b/ppr-ui/src/assets/styles/overrides.scss
@@ -681,6 +681,7 @@ input#reg-textfield.v-text-field.v-input--dense:not(.v-text-field--outlined),
   background-color: transparent;
   height: 14px;
   width: 14px;
+  color: white !important;
 }
 
 .pdf-btn {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17356

*Description of changes:*
- Changes close icon on snackbar to white

![image](https://github.com/bcgov/ppr/assets/77707952/fec3290f-ad28-43d8-9ec1-354cb1d84d92)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
