### PR TITLE
Has no person giving notice

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.56",
+  "version": "2.0.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.56",
+      "version": "2.0.57",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.56",
+  "version": "2.0.57",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -678,6 +678,10 @@ tr.registration-row.draft-registration-row.added-reg-effect td.actions-cell,
   padding-top: 30px !important;
 }
 
+.pb-20 {
+  padding-bottom: 80px !important;
+}
+
 // borders
 .border-btm {
   border-bottom: 1px solid $gray3;

--- a/ppr-ui/src/components/common/ContactInformation.vue
+++ b/ppr-ui/src/components/common/ContactInformation.vue
@@ -317,13 +317,6 @@ export default defineComponent({
 
     watch(() => [props.validate, props.isDisabled], async ([validate, isDisabled]) => {
       if (validate && !isDisabled) contactInfoForm.value?.validate()
-      if (isDisabled) {
-        localState.contactInfoType = ContactTypes.PERSON
-        localState.contactInfoModel = cloneDeep(emptyContactInfo)
-        await nextTick()
-        contactAddress.value?.resetValidation()
-        contactInfoForm.value?.resetValidation()
-      }
     })
 
     watch(() => localState.contactInfoModel.personName, async () => {
@@ -333,6 +326,16 @@ export default defineComponent({
         (0 || localState.contactInfoModel.personName?.middle?.length) +
         (0 || localState.contactInfoModel.personName?.last?.length) > 40
     }, { deep: true })
+
+    watch(() => props.isDisabled, async (isDisabled: boolean) => {
+      if (isDisabled) {
+        localState.contactInfoType = ContactTypes.PERSON
+        localState.contactInfoModel = cloneDeep(emptyContactInfo)
+        await nextTick()
+        contactAddress.value?.resetValidation()
+        contactInfoForm.value?.resetValidation()
+      }
+    })
 
     const firstNameRules = customRules(
       required('Enter a first name'),

--- a/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
@@ -34,13 +34,23 @@
         :sectionNumber="3"
         :content="contactInfoContent"
         :validate="validate"
-        :isInfoOptional="isPersonGivingNoticeOptional()"
+        :isDisabled="hasNoPersonGivingNotice"
         @setStoreProperty="handleStoreUpdate('givingNoticeParty', $event)"
         @isValid="handleComponentValid(MhrCompVal.PERSON_GIVING_NOTICE_VALID, $event)"
         enableCombinedNameValidation
         hidePartySearch
         hideDeliveryAddress
-      />
+      >
+        <template #preForm v-if="isPersonGivingNoticeOptional()">
+          <v-checkbox
+              id="no-person-giving-notice-checkbox"
+              class="mb-n3 mt-n2"
+              label="There is not a Person Giving Notice for this unit note."
+              v-model="hasNoPersonGivingNotice"
+              hide-details
+          />
+        </template>
+      </ContactInformation>
     </section>
   </div>
 </template>
@@ -107,6 +117,7 @@ export default defineComponent({
           : personGivingNoticeContent
       ),
       isNoticeOfTaxSale: computed((): boolean => props.docType === UnitNoteDocTypes.NOTICE_OF_TAX_SALE),
+      hasNoPersonGivingNotice: (getMhrUnitNote.value as UnitNoteIF).hasNoPersonGivingNotice || false,
 
       // Remarks
       unitNoteRemarks: (getMhrUnitNote.value as UnitNoteIF).remarks || '',
@@ -126,6 +137,11 @@ export default defineComponent({
     const handleStoreUpdate = (key: string, val) => {
       setMhrUnitNote({ key: key, value: val })
     }
+
+    watch(() => localState.hasNoPersonGivingNotice, (val) => {
+      setValidation(MhrSectVal.UNIT_NOTE_VALID, MhrCompVal.PERSON_GIVING_NOTICE_VALID, val)
+      handleStoreUpdate('hasNoPersonGivingNotice', val)
+    })
 
     watch(() => [localState.isUnitNoteValid, props.validate], () => {
       emit('isValid', localState.isUnitNoteValid)

--- a/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
@@ -34,7 +34,7 @@
         :sectionNumber="3"
         :content="contactInfoContent"
         :validate="validate"
-        :isDisabled="hasNoPersonGivingNotice"
+        :isHidden="hasNoPersonGivingNotice"
         @setStoreProperty="handleStoreUpdate('givingNoticeParty', $event)"
         @isValid="handleComponentValid(MhrCompVal.PERSON_GIVING_NOTICE_VALID, $event)"
         enableCombinedNameValidation
@@ -45,7 +45,7 @@
           <v-checkbox
               id="no-person-giving-notice-checkbox"
               class="mb-n3 mt-n2"
-              label="There is not a Person Giving Notice for this unit note."
+              :label="hasNoPersonGivingNoticeText"
               v-model="hasNoPersonGivingNotice"
               hide-details
           />
@@ -65,7 +65,8 @@ import { ContactInformationContentIF, UnitNoteIF } from '@/interfaces'
 import { useMhrUnitNote, useMhrValidations } from '@/composables'
 import { MhrCompVal, MhrSectVal } from '@/composables/mhrRegistration/enums'
 import { DocumentId, Remarks, ContactInformation } from '@/components/common'
-import { personGivingNoticeContent, collectorInformationContent, remarksContent } from '@/resources'
+import { personGivingNoticeContent, collectorInformationContent, remarksContent,
+  hasNoPersonGivingNoticeText } from '@/resources'
 
 export default defineComponent({
   name: 'UnitNoteAdd',
@@ -154,6 +155,7 @@ export default defineComponent({
       handleComponentValid,
       isPersonGivingNoticeOptional,
       remarksContent,
+      hasNoPersonGivingNoticeText,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -56,7 +56,7 @@
       </v-col>
       <v-col v-if="!note.givingNoticeParty" cols="9">
         <span id="no-person-giving-notice" class="info-text fs-14">
-          There is not a Person Giving Notice for this unit note.
+          {{ hasNoPersonGivingNoticeText }}
         </span>
       </v-col>
     </v-row>
@@ -109,7 +109,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue-demi'
-import { UnitNotesInfo, personGivingNoticeTableHeaders } from '@/resources'
+import { UnitNotesInfo, personGivingNoticeTableHeaders, hasNoPersonGivingNoticeText } from '@/resources'
 import { UnitNoteIF } from '@/interfaces/unit-note-interfaces/unit-note-interface'
 import { pacificDate } from '@/utils'
 import { PartyIF } from '@/interfaces'
@@ -165,6 +165,7 @@ export default defineComponent({
       getNoticePartyName,
       isNoticeOfCautionOrRelatedDocType,
       personGivingNoticeTableHeaders,
+      hasNoPersonGivingNoticeText,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
@@ -76,7 +76,7 @@
       />
     </section>
 
-    <section id="staff-transfer-payment-section" class="mt-10 pt-4 pb-10" v-if="isRoleStaffReg">
+    <section id="staff-transfer-payment-section" class="mt-10 pt-4" v-if="isRoleStaffReg">
       <h2>Staff Payment</h2>
       <v-card flat class="mt-6 pa-6" :class="{ 'border-error-left': validateStaffPayment }">
         <StaffPayment

--- a/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
@@ -32,10 +32,18 @@
         </v-col>
       </v-row>
       <v-divider class="my-3 mx-0" />
-      <div class="px">
+      <v-row no-gutters v-if="unitNote.hasNoPersonGivingNotice">
+        <v-col cols="3">
+          <h3>{{ contactInfoTitle }}</h3>
+        </v-col>
+        <v-col cols="9" class="no-person-giving-notice">
+          There is not a Person Giving Notice for this unit note.
+        </v-col>
+      </v-row>
+      <template v-else>
         <h3>{{ contactInfoTitle }}</h3>
 
-        <v-simple-table v-if="unitNote" class="giving-notice-party-table" data-test-id="party-info-table">
+        <v-simple-table class="giving-notice-party-table" data-test-id="party-info-table">
           <template v-slot:default>
             <thead>
               <tr>
@@ -48,7 +56,7 @@
             <tbody>
               <tr>
                 <td class="person-name">
-                  <span v-if="hasName">
+                  <span>
                     <v-icon class="mt-n2">
                       {{ givingNoticeParty.businessName ? 'mdi-domain' : 'mdi-account' }}
                     </v-icon>
@@ -56,16 +64,13 @@
                       {{ displayFullOrBusinessName }}
                     </span>
                   </span>
-                  <span v-else class="text-not-entered">(Not Entered)</span>
                 </td>
                 <td>
                   <base-address
-                    v-if="hasAddress"
                     :editing="false"
                     :schema="PartyAddressSchema"
                     :value="givingNoticeParty.address"
                   />
-                  <span v-else class="text-not-entered">(Not Entered)</span>
                 </td>
                 <td>
                   <span :class="{'text-not-entered': !givingNoticeParty.emailAddress}">
@@ -81,7 +86,7 @@
             </tbody>
           </template>
         </v-simple-table>
-      </div>
+      </template>
     </section>
   </v-card>
 </template>
@@ -118,17 +123,6 @@ export default defineComponent({
           ? props.unitNote.additionalRemarks + '<br/>' + props.unitNote.remarks
           : props.unitNote.remarks
       ),
-      hasName: computed((): boolean => {
-        return !!(localState.givingNoticeParty.businessName ||
-          localState.givingNoticeParty.personName.first ||
-          localState.givingNoticeParty.personName.middle ||
-          localState.givingNoticeParty.personName.last)
-      }),
-      hasAddress: computed((): boolean => {
-        return !!(localState.givingNoticeParty.address?.street ||
-        localState.givingNoticeParty.address?.streetAdditional ||
-        localState.givingNoticeParty.address?.city)
-      }),
       displayFullOrBusinessName: computed((): string => {
         if (localState.givingNoticeParty?.businessName.length > 0) { return localState.givingNoticeParty.businessName }
         const { first, middle, last } = localState.givingNoticeParty.personName
@@ -165,6 +159,11 @@ export default defineComponent({
       color: $gray7;
     }
     .remarks {
+      padding: 6px 0;
+      line-height: 24px;
+      color: $gray7;
+    }
+    .no-person-giving-notice {
       padding: 6px 0;
       line-height: 24px;
       color: $gray7;

--- a/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
@@ -37,7 +37,7 @@
           <h3>{{ contactInfoTitle }}</h3>
         </v-col>
         <v-col cols="9" class="no-person-giving-notice">
-          There is not a Person Giving Notice for this unit note.
+          {{ hasNoPersonGivingNoticeText }}
         </v-col>
       </v-row>
       <template v-else>
@@ -97,7 +97,7 @@ import { BaseAddress } from '@/composables/address'
 import { PartyIF, UnitNoteIF } from '@/interfaces'
 import { PartyAddressSchema } from '@/schemas'
 import { toDisplayPhone } from '@/utils'
-import { personGivingNoticeContent, collectorInformationContent } from '@/resources'
+import { personGivingNoticeContent, collectorInformationContent, hasNoPersonGivingNoticeText } from '@/resources'
 import { UnitNoteDocTypes } from '@/enums/unitNoteDocTypes'
 
 export default defineComponent({
@@ -140,6 +140,7 @@ export default defineComponent({
     })
 
     return {
+      hasNoPersonGivingNoticeText,
       toDisplayPhone,
       PartyAddressSchema,
       ...toRefs(localState)

--- a/ppr-ui/src/composables/address/BaseAddress.vue
+++ b/ppr-ui/src/composables/address/BaseAddress.vue
@@ -270,7 +270,6 @@ export default defineComponent({
       schemaLocal,
       useCountryRegions,
       ...uniqueIds,
-      resetValidation,
       validate
     }
   }

--- a/ppr-ui/src/composables/address/BaseAddress.vue
+++ b/ppr-ui/src/composables/address/BaseAddress.vue
@@ -270,6 +270,7 @@ export default defineComponent({
       schemaLocal,
       useCountryRegions,
       ...uniqueIds,
+      resetValidation,
       validate
     }
   }

--- a/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrUnitNote.ts
@@ -15,7 +15,7 @@ export const useMhrUnitNote = () => {
   // Build Unit Note payload data with all the submission rules
   const buildPayload = (unitNoteData: UnitNoteRegistrationIF): UnitNoteRegistrationIF => {
     // Person Giving Notice is optional for Decal Replacement (102), Public Note (NPUB), Confidential Note (NCON)
-    // The givingNoticeParty obj would be removed if it contains no date
+    // The givingNoticeParty obj would be removed if it contains no data
     deleteEmptyProperties(unitNoteData)
 
     if (unitNoteData.note.additionalRemarks) {
@@ -35,6 +35,11 @@ export const useMhrUnitNote = () => {
     // Remove the hasUsedPartyLookup flag from submittingParty as its not used by the API
     if (unitNoteData.submittingParty.hasUsedPartyLookup) {
       delete unitNoteData.submittingParty.hasUsedPartyLookup
+    }
+
+    // Remove the hasNoPersonGivingNotice flag as its not used by the API
+    if (unitNoteData.note.hasNoPersonGivingNotice) {
+      delete unitNoteData.note.hasNoPersonGivingNotice
     }
 
     // status is not required
@@ -197,6 +202,7 @@ export const useMhrUnitNote = () => {
           emailAddress: '',
           phoneNumber: ''
         } as PartyIF,
+        hasNoPersonGivingNotice: false, // local property not sent to API
         destroyed: false
       }
     }

--- a/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
+++ b/ppr-ui/src/interfaces/unit-note-interfaces/unit-note-interface.ts
@@ -13,6 +13,7 @@ export interface UnitNoteIF {
   remarks?: string
   additionalRemarks?: string
   givingNoticeParty?: PartyIF
+  hasNoPersonGivingNotice?: boolean // local property not sent to API
   status?: UnitNoteStatusTypes
   destroyed?: boolean
 }

--- a/ppr-ui/src/resources/unitNotes.ts
+++ b/ppr-ui/src/resources/unitNotes.ts
@@ -120,3 +120,5 @@ export const remarksContent = {
   sideLabel: 'Add Remarks',
   checkboxLabel: 'A notice pursuant to section 645/656 of the Local Government Act was filed'
 }
+
+export const hasNoPersonGivingNoticeText = 'There is no Person Giving Notice for this unit note.'

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -362,6 +362,7 @@ export const stateModel: StateModelIF = {
         emailAddress: '',
         phoneNumber: ''
       } as PartyIF,
+      hasNoPersonGivingNotice: false,
       destroyed: false
     }
   },

--- a/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
@@ -12,7 +12,7 @@
       @proceed="handleDialogResp($event)"
     />
 
-    <div class="view-container px-15 pt-0 pb-5">
+    <div class="view-container px-15 pt-0 pb-20">
       <div class="container pa-0 pt-4">
         <v-row no-gutters>
           <v-col cols="9">
@@ -229,4 +229,6 @@ export default defineComponent({
 })
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+</style>

--- a/ppr-ui/tests/unit/MhrUnitNote.spec.ts
+++ b/ppr-ui/tests/unit/MhrUnitNote.spec.ts
@@ -21,7 +21,7 @@ import {
 import { StaffPayment } from '@bcrs-shared-components/staff-payment'
 import { MhrUnitNoteValidationStateIF } from '@/interfaces'
 import { isEqual } from 'lodash'
-import { collectorInformationContent, remarksContent } from '@/resources'
+import { collectorInformationContent, remarksContent, hasNoPersonGivingNoticeText } from '@/resources'
 
 Vue.use(Vuetify)
 
@@ -247,7 +247,7 @@ describe('MHR Unit Note Filing', () => {
     expect(store.getMhrUnitNote.hasNoPersonGivingNotice).toBe(true)
 
     // Assert contact form is disabled
-    expect(PersonGivingNoticeComponent.find('#contact-info').classes('v-card--disabled')).toBe(true)
+    expect(PersonGivingNoticeComponent.find('#contact-info').exists()).toBeFalsy()
 
     // Asserts error not shown after checking the checkbox (1 error remains from doucment ID)
     expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(1)
@@ -277,9 +277,9 @@ describe('MHR Unit Note Filing', () => {
     // should be on the Review & Confirm screen
     expect(wrapper.findComponent(UnitNoteReview).exists()).toBeTruthy()
 
-    // 'There is not a person giving' should be shown next to Person Giving Notice
+    // 'There no Person Giving Notice...' should be shown next to Person Giving Notice
     expect(wrapper.find('.no-person-giving-notice').text())
-      .toBe('There is not a Person Giving Notice for this unit note.')
+      .toBe(hasNoPersonGivingNoticeText)
 
     // Return to the Unit Note Add screen and check the checkbox is still checked and errors are not shown
     await wrapper.find('#btn-stacked-back').trigger('click')

--- a/ppr-ui/tests/unit/MhrUnitNote.spec.ts
+++ b/ppr-ui/tests/unit/MhrUnitNote.spec.ts
@@ -105,6 +105,9 @@ describe('MHR Unit Note Filing', () => {
       UnitNoteAddComponent.findComponent(Remarks).find(getTestId('additional-remarks-checkbox')).exists()
     ).toBeFalsy()
 
+    // Person giving notice for notice of caution is mandatory
+    expect(UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').exists()).toBeFalsy()
+
     expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(0)
     expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(0)
   })
@@ -217,10 +220,10 @@ describe('MHR Unit Note Filing', () => {
     expect(wrapper.findAll('.border-error-left').length).toBe(5)
   })
 
-  it('should not show field errors for optional Party Giving Notice', async () => {
+  it('should not show field errors when no person giving notice checkbox is checked', async () => {
     wrapper = await createUnitNoteComponent(UnitNoteDocTypes.DECAL_REPLACEMENT)
 
-    const UnitNoteAddComponent = wrapper.findComponent(UnitNoteAdd)
+    let UnitNoteAddComponent = wrapper.findComponent(UnitNoteAdd)
     expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(0)
 
     await wrapper.find('#btn-stacked-submit').trigger('click')
@@ -228,13 +231,44 @@ describe('MHR Unit Note Filing', () => {
 
     expect(wrapper.findComponent(UnitNoteReview).exists()).toBeFalsy()
 
-    // only one error for Document ID should be shown, as the other fields are optional
-    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(1)
-    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(1)
+    // Asserts error shown before checking the checkbox
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(2)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(2)
 
     const PersonGivingNoticeComponent = UnitNoteAddComponent.findComponent(ContactInformation)
-    expect(PersonGivingNoticeComponent.exists()).toBeTruthy()
+
+    // Asserts form is not disabled and showcases errors
+    expect(PersonGivingNoticeComponent.find('#contact-info').classes('v-card--disabled')).toBe(false)
+    expect(PersonGivingNoticeComponent.findAll('.error-text').length).toBeGreaterThan(0)
+
+    // check the checkbox
+    await UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').trigger('click')
+    await nextTick()
+    expect(store.getMhrUnitNote.hasNoPersonGivingNotice).toBe(true)
+
+    // Assert contact form is disabled
+    expect(PersonGivingNoticeComponent.find('#contact-info').classes('v-card--disabled')).toBe(true)
+
+    // Asserts error not shown after checking the checkbox (1 error remains from doucment ID)
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(1)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(1)
     expect(PersonGivingNoticeComponent.findAll('.error-text').length).toBe(0)
+
+    // uncheck the checkbox
+    await UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').trigger('click')
+    await nextTick()
+    expect(store.getMhrUnitNote.hasNoPersonGivingNotice).toBe(false)
+
+    // Asserts error shown after the checkbox is unchecked and form is not disabled
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(2)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(2)
+    expect(PersonGivingNoticeComponent.findAll('.error-text').length).toBeGreaterThan(0)
+    expect(PersonGivingNoticeComponent.find('#contact-info').classes('v-card--disabled')).toBe(false)
+
+    // recheck check box
+    await UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').trigger('click')
+    await nextTick()
+    expect(store.getMhrUnitNote.hasNoPersonGivingNotice).toBe(true)
 
     await wrapper.findComponent(UnitNoteAdd).vm.$emit('isValid', true)
     await wrapper.find('#btn-stacked-submit').trigger('click')
@@ -243,8 +277,18 @@ describe('MHR Unit Note Filing', () => {
     // should be on the Review & Confirm screen
     expect(wrapper.findComponent(UnitNoteReview).exists()).toBeTruthy()
 
-    // 'Not Entered' should be shown 4 times for each column in the table
-    expect(wrapper.find(getTestId('party-info-table')).findAll('.text-not-entered').length).toBe(4)
+    // 'There is not a person giving' should be shown next to Person Giving Notice
+    expect(wrapper.find('.no-person-giving-notice').text())
+      .toBe('There is not a Person Giving Notice for this unit note.')
+
+    // Return to the Unit Note Add screen and check the checkbox is still checked and errors are not shown
+    await wrapper.find('#btn-stacked-back').trigger('click')
+    await nextTick()
+
+    UnitNoteAddComponent = wrapper.findComponent(UnitNoteAdd)
+    expect(UnitNoteAddComponent.exists()).toBeTruthy()
+    expect((UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').element as HTMLInputElement)
+      .checked).toBe(true)
   })
 
   // eslint-disable-next-line max-len


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17369

*Description of changes:*
- Uses slots to separate no person giving notice logic from common component
- Adds disabled prop and handles disabled state
- Adds logic to state to maintain the hasNoPersonGivingNotice state, when navigating between pages.
- Adds test to check multiple scenarios.

Note for reviewers:
Personally I prefer to keep the common component lean and have the checkbox live in the parent via slots, especially because this is a one time use case so far, but I am open to differing opinions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
