### PR TITLE
17130 API changes to support UI unit notes.

### DIFF
--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -789,7 +789,7 @@ def expiry_datetime(expiry_iso: str):
 
 def update_reg_status(reg_json: dict, current: bool, staff: bool) -> dict:
     """Conditionally set the status and frozenDocumentType for non-staff based on active unit note doc types."""
-    if not current or staff:
+    if not current:
         return reg_json
     if not reg_json or not reg_json.get('notes') or reg_json.get('status', '') != MhrRegistrationStatusTypes.ACTIVE:
         return reg_json

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -528,6 +528,10 @@ class Report:  # pylint: disable=too-few-public-methods
                             note['givingNoticeParty']['phoneNumber'] = phone[0:3] + '-' + phone[3:6] + '-' + phone[6:]
                         if note.get('effectiveDateTime'):
                             note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'))
+                        if note.get('remarks'):
+                            remarks: str = note.get('remarks')
+                            if remarks.find('\n') >= 0:
+                                note['remarks'] = remarks.replace('\n', '<br>')
 
     def _set_note(self):
         """Add registration note document type description and dates."""
@@ -544,6 +548,10 @@ class Report:  # pylint: disable=too-few-public-methods
             if note.get('givingNoticeParty') and note['givingNoticeParty'].get('phoneNumber'):
                 phone = note['givingNoticeParty'].get('phoneNumber')
                 note['givingNoticeParty']['phoneNumber'] = phone[0:3] + '-' + phone[3:6] + '-' + phone[6:]
+            if note.get('remarks'):
+                remarks: str = note.get('remarks')
+                if remarks.find('\n') >= 0:
+                    note['remarks'] = remarks.replace('\n', '<br>')
 
     def _set_search_additional_message(self):
         """Conditionally add a message to the search report data."""

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.2'  # pylint: disable=invalid-name
+__version__ = '1.5.3'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -523,13 +523,13 @@ TEST_DATA_LTSA_PID = [
 TEST_DATA_STATUS = [
     ('003936', '2523', 'FROZEN', True, 'AFFE'),
     ('003304', '2523', 'ACTIVE', True, 'AFFE'),
-    ('022873', 'ppr_staff', 'ACTIVE', True, 'TAXN'),
+    ('022873', 'ppr_staff', 'FROZEN', True, 'TAXN'),
     ('022873', 'ppr_staff', 'FROZEN', False, 'TAXN'),
-    ('052711', 'PS12345', 'ACTIVE', True, 'REST'),
+    ('052711', 'PS12345', 'FROZEN', True, 'REST'),
     ('052711', 'PS12345', 'FROZEN', False, 'REST'),
-    ('040289', 'ppr_staff', 'ACTIVE', True, 'NCON'),
+    ('040289', 'ppr_staff', 'FROZEN', True, 'NCON'),
     ('040289', 'ppr_staff', 'FROZEN', False, 'NCON'),
-    ('102605', 'PS12345', 'ACTIVE', True, 'REG_103'),
+    ('102605', 'PS12345', 'FROZEN', True, 'REG_103'),
     ('102605', 'PS12345', 'FROZEN', False, 'REG_103')
 ]
 # testdata pattern is ({mhr_num}, {staff}, {current}, {has_notes}, {account_id}, {has_caution}, {ncan_doc_id})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17130

*Description of changes:*
- Replace remarks "\n" with html tag in reports.
- Show FROZEN status and frozenDocumentType in current view of a MH for staff.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
