### PR TITLE
Small UX changes for unit notes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.59",
+  "version": "2.0.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.59",
+      "version": "2.0.60",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.59",
+  "version": "2.0.60",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -37,13 +37,13 @@
       </v-col>
     </v-row>
 
-    <v-row v-if="note.remarks" no-gutters class="my-7">
+    <v-row no-gutters class="my-7">
       <v-col cols="3">
         <h3 class="fs-14">Remarks</h3>
       </v-col>
       <v-col cols="9">
         <span v-if=!separatedRemarks class="info-text fs-14">
-          {{ note.remarks }}
+          {{ note.remarks || '(Not Entered)' }}
         </span>
         <template v-else>
           <span id="separated-remarks" class="info-text fs-14">

--- a/ppr-ui/src/components/unitNotes/UnitNotePanels.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNotePanels.vue
@@ -69,7 +69,7 @@
         />
       </v-expansion-panels>
       <v-col v-else class="empty-notes-msg text-center pt-8 pb-3">
-        <p class="gray7 fs-14">A unit note has not been filed for this manufactured home.</p>
+        <p class="gray7 fs-14">A Unit Note has not been filed for this manufactured home.</p>
       </v-col>
     </v-row>
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -42,12 +42,12 @@
 
                   <!-- Unit Note Info -->
                   <p v-if="getMhrUnitNotes && getMhrUnitNotes.length >= 1">
-                    There are unit notes attached to this manufactured home.
+                    There are Unit Notes attached to this manufactured home.
                     <span v-if="isRoleStaffReg">
                       <a href="#unit-note-component">See Unit Notes</a>
                     </span>
                     <span v-else>
-                      To view unit note information on this home, complete a manufactured home search.
+                      To view Unit Note information on this home, complete a manufactured home search.
                     </span>
 
                     <!-- Has Alert Message (Notice of Tax Sale, and others) -->
@@ -565,7 +565,7 @@ export default defineComponent({
         let baseMsg = 'A Caution has been filed against this home.'
 
         return isRoleStaffReg.value
-          ? `${baseMsg} See unit notes for further details.`
+          ? `${baseMsg} See Unit Notes for further details.`
           : `${baseMsg} If you require further information please contact BC Registries staff.`
       })
     })

--- a/ppr-ui/tests/unit/UnitNotePanels.spec.ts
+++ b/ppr-ui/tests/unit/UnitNotePanels.spec.ts
@@ -287,7 +287,7 @@ describe('UnitNotePanels', () => {
 
     const emptyMsg = wrapper.find('.empty-notes-msg')
     expect(emptyMsg.exists()).toBe(true)
-    expect(emptyMsg.text()).toBe('A unit note has not been filed for this manufactured home.')
+    expect(emptyMsg.text()).toBe('A Unit Note has not been filed for this manufactured home.')
   })
 
   it('displays continued and extension notice of caution buttons', async () => {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#17311 
- bcgov/entity#17309

*Description of changes:*
- Capitalized Unit Notes and Unit Note
![image](https://github.com/bcgov/ppr/assets/77707952/6ff5e68b-6d7a-4d4b-aa94-1c826c010c45)

- Shows remarks or '(Not Entered)'
![image](https://github.com/bcgov/ppr/assets/77707952/6007ee18-a0f6-491a-8993-1a9cd14e669b)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
