### PR TITLE
Adds option for MHR table only

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.60",
+  "version": "2.0.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.0.60",
+      "version": "2.0.61",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.0.60",
+  "version": "2.0.61",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -353,6 +353,8 @@ export default defineComponent({
           // add base reg drafts length to total reg length
           setRegTableTotalRowCount(getRegTableTotalRowCount.value + historyDraftsCollapsed.drafts.length)
         }
+      } else if (props.isMhr && !props.isTabView) { // If Tab view, Mhr Data will be loaded in dashboardTabs component
+        await fetchMhRegistrations()
       }
       // update columns selected with user settings
       localState.pprColumnSettings = getUserSettings.value[SettingOptions.REGISTRATION_TABLE]?.columns?.length >= 1

--- a/ppr-ui/src/components/registration/RegistrationBar.vue
+++ b/ppr-ui/src/components/registration/RegistrationBar.vue
@@ -4,7 +4,7 @@
       <v-col>
         <div class="actions">
           <v-btn
-            v-if="isMhr && (!isRoleQualifiedSupplier || isRoleStaff || isRoleManufacturer)"
+            v-if="isMhr && (isRoleStaff || isRoleManufacturer)"
             filled
             class="mhr-registration-bar-btn px-5"
             @click="newRegistration(MhrRegistrationType)"

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -98,6 +98,14 @@
             :appReady="appReady"
             @snackBarMsg="snackBarEvent($event)"
           />
+
+          <RegistrationsWrapper
+            v-else-if="hasMhrTableEnabled"
+            isMhr
+            :appLoadingData="appLoadingData"
+            :appReady="appReady"
+            @snackBarMsg="snackBarEvent($event)"
+          />
         </v-col>
       </v-row>
     </div>
@@ -109,7 +117,7 @@ import { computed, defineComponent, onMounted, reactive, toRefs, watch } from 'v
 import { useRouter } from 'vue2-helpers/vue-router'
 import { useStore } from '@/store/store'
 import { storeToRefs } from 'pinia'
-import { ProductCode, ProductStatus, RouteNames } from '@/enums'
+import { ProductStatus, RouteNames } from '@/enums'
 import { getFeatureFlag, searchHistory } from '@/utils'
 import { BaseSnackbar, CautionBox, RegistrationsWrapper } from '@/components/common'
 import { SearchHistory } from '@/components/tables'
@@ -180,13 +188,13 @@ export default defineComponent({
       hasPprRole,
       isNonBillable,
       hasMhrEnabled,
+      hasPprEnabled,
       isRoleStaffBcol,
       isRoleStaffReg,
       getSearchHistory,
       getUserServiceFee,
       getSearchHistoryLength,
-      isRoleQualifiedSupplier,
-      getUserProductSubscriptionsCodes
+      isRoleQualifiedSupplier
     } = storeToRefs(useStore())
 
     const localState = reactive({
@@ -194,10 +202,6 @@ export default defineComponent({
       isMHRSearchType: useSearch().isMHRSearchType,
       snackbarMsg: '',
       toggleSnackbar: false,
-      enableDashboardTabs: computed((): boolean => {
-        return getFeatureFlag('mhr-registration-enabled') &&
-          hasPprRole.value && hasMhrRole.value && (isRoleStaff.value || isRoleQualifiedSupplier.value)
-      }),
       searchHistoryLength: computed((): number => {
         return (getSearchHistory.value as SearchResponseIF[])?.length || 0
       }),
@@ -206,7 +210,7 @@ export default defineComponent({
         if (isRoleStaff.value || isRoleStaffBcol.value || isRoleStaffReg.value) {
           return hasPprRole.value
         } else {
-          return getUserProductSubscriptionsCodes.value.includes(ProductCode.PPR)
+          return hasPprEnabled.value
         }
       }),
       hasMHR: computed((): boolean => {
@@ -216,6 +220,13 @@ export default defineComponent({
         } else {
           return hasMhrEnabled.value
         }
+      }),
+      hasMhrTableEnabled: computed((): boolean => {
+        return getFeatureFlag('mhr-registration-enabled') && localState.hasMHR &&
+        (isRoleStaff.value || isRoleQualifiedSupplier.value) // Ensures that search only clients can't view table
+      }),
+      enableDashboardTabs: computed((): boolean => {
+        return localState.hasPPR && localState.hasMhrTableEnabled
       })
     })
 

--- a/ppr-ui/tests/unit/Dashboard.spec.ts
+++ b/ppr-ui/tests/unit/Dashboard.spec.ts
@@ -48,6 +48,7 @@ import {
 import { getLastEvent, setupIntersectionObserverMock } from './utils'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { defaultFlagSet } from '@/utils'
+import { DashboardTabs } from '@/components/dashboard'
 
 Vue.use(Vuetify)
 
@@ -82,6 +83,16 @@ describe('Dashboard component', () => {
   const draftDocId = 'D0034001'
   const currentAccount = { id: 'test_id' }
   sessionStorage.setItem(SessionStorageKeys.CurrentAccount, JSON.stringify(currentAccount))
+
+  beforeAll(() => {
+    defaultFlagSet['mhr-registration-enabled'] = true
+    defaultFlagSet['mhr-ui-enabled'] = true
+  })
+
+  afterAll(() => {
+    defaultFlagSet['mhr-registration-enabled'] = false
+    defaultFlagSet['mhr-ui-enabled'] = false
+  })
 
   beforeEach(async () => {
     // mock the window.location.assign function
@@ -279,9 +290,10 @@ describe('Dashboard component', () => {
     expect(wrapper.findComponent(Dashboard).exists()).toBe(true)
     expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
     expect(wrapper.findComponent(SearchHistory).exists()).toBe(true)
-    expect(wrapper.findComponent(RegistrationBar).exists()).toBe(true)
-    expect(wrapper.findAllComponents(RegistrationTable).length).toBe(1)
+    expect(wrapper.findComponent(DashboardTabs).exists()).toBe(false)
+    expect(wrapper.findComponent(RegistrationTable).exists()).toBe(true)
     expect(wrapper.findComponent(RegistrationTable).vm.$props.isMhr).toBe(true)
+    expect(wrapper.findComponent(RegistrationBar).exists()).toBe(true)
   })
 })
 

--- a/ppr-ui/tests/unit/Dashboard.spec.ts
+++ b/ppr-ui/tests/unit/Dashboard.spec.ts
@@ -42,7 +42,8 @@ import {
   mockedDebtorNames,
   mockedDraftAmend,
   mockedRegistration2,
-  mockedUpdateRegTableUserSettingsResponse
+  mockedUpdateRegTableUserSettingsResponse,
+  mockedManufacturerAuthRoles
 } from './test-data'
 import { getLastEvent, setupIntersectionObserverMock } from './utils'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
@@ -142,7 +143,6 @@ describe('Dashboard component', () => {
     expect(wrapper.findComponent(SearchHistory).exists()).toBe(true)
     expect(wrapper.findComponent(RegistrationBar).exists()).toBe(true)
     expect(wrapper.findComponent(RegistrationTable).exists()).toBe(true)
-    expect(wrapper.findComponent(Dashboard).exists()).toBe(true)
     // fee settings set correctly based on store
     expect(store.getStateModel.userInfo.feeSettings).toBeNull()
     expect(wrapper.findComponent(SearchBar).vm.$props.isNonBillable).toBe(false)
@@ -268,6 +268,20 @@ describe('Dashboard component', () => {
       .vm.$emit('action', { action: TableActions.EDIT_AMEND, docId: draftDocId, regNum: regNum })
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.AMEND_REGISTRATION)
+  })
+
+  it('Renders dashboard with only MHR table for manufacturer with only MHR product', async () => {
+    // setup
+    await store.setAuthRoles(mockedManufacturerAuthRoles)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR])
+
+    // Test
+    expect(wrapper.findComponent(Dashboard).exists()).toBe(true)
+    expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
+    expect(wrapper.findComponent(SearchHistory).exists()).toBe(true)
+    expect(wrapper.findComponent(RegistrationBar).exists()).toBe(true)
+    expect(wrapper.findAllComponents(RegistrationTable).length).toBe(1)
+    expect(wrapper.findComponent(RegistrationTable).vm.$props.isMhr).toBe(true)
   })
 })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17564

*Description of changes:*
- Allows for MHR table only to be displayed
- Adds simple test

*Update:* 
Holding merge until it can be tested fully.

*Note for reviewers:*

Can not file a registration yet, on the manufacturer account because it is not set up with data in database. 
Will need to wait for that be setup for testing purposes. But the mere fact that its attempting to retrieve data from database for manufacturer indicates that its trying to start the correct registration.
![image](https://github.com/bcgov/ppr/assets/77707952/e89664d9-1e18-46dc-ae6a-6900171e46aa)

 I did verify locally by rendering the Mhr Table only and starting a registration with an account that does have data in the database.

![image](https://github.com/bcgov/ppr/assets/77707952/2e1cb6b2-8231-4a45-8416-2d753e7c74b1)


*Screenshots:*

Account with MHR and no Qualified Supplier access:

![image](https://github.com/bcgov/ppr/assets/77707952/bd448315-5fa8-4642-8173-4ed04d7a32dc)


Account with MHR and Qualified Supplier access but not Manufacturer:

![image](https://github.com/bcgov/ppr/assets/77707952/c2e6816e-107e-4a15-a680-192d0c7e41f4)

Manufacturer account with only MHR:

![image](https://github.com/bcgov/ppr/assets/77707952/666749ac-35ef-477d-be75-944defe16ccb)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
