### PR TITLE
Revert workaround changes

### DIFF
--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -130,9 +130,9 @@ export const useStore = defineStore('assetsStore', () => {
   })
   const isRoleQualifiedSupplier = computed((): boolean => {
     return state.value.authorization?.authRoles.includes('mhr_transfer_sale') &&
-      ((getUserProductSubscriptionsCodes.value?.some(code =>
+      getUserProductSubscriptionsCodes.value?.some(code =>
         [ProductCode.LAWYERS_NOTARIES, ProductCode.MANUFACTURER, ProductCode.DEALERS].includes(code)
-      ) || isRoleManufacturer.value)) // Temporary work around until Manufacturers are set up with MANUFACTURER product
+      )
   })
   /** The current account label/name. */
   const getAccountLabel = computed((): string => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17535

*Description of changes:*
- Reverts workaround that allows users with manufacturer Keycloack roles to maintain qualified supplier status without manufacturer product.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
