### PR TITLE
Frozen State & Document Types + Tax Notice UXA

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/assets/svgs/lockicon_white.svg
+++ b/ppr-ui/src/assets/svgs/lockicon_white.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 7 9" style="enable-background:new 0 0 7 9;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g id="Page-1">
+	<path id="Shape" class="st0" d="M7,4.8v3.2C7,8.5,6.5,9,5.9,9H1C0.5,9,0,8.5,0,7.8V4.7c0-0.5,0.5-1.1,1-1.1V2.2C1,1,2.3,0,3.5,0
+		s2.4,1,2.4,2.2v1.3C6.5,3.6,7,4.1,7,4.8z M4.8,2.2c0-0.7-0.6-1.2-1.3-1.2S2.2,1.5,2.2,2.2v1.3h2.6V2.2z"/>
+</g>
+</svg>

--- a/ppr-ui/src/components/common/InfoChip.vue
+++ b/ppr-ui/src/components/common/InfoChip.vue
@@ -7,7 +7,7 @@
     :textColor="chipColors.textColor"
     :data-test-id="`${action}-badge`"
   >
-    <v-icon v-if="isLockedAction" class="mr-1">mdi-lock</v-icon><b>{{ action }}</b>
+    <img v-if="isLockedAction" src="@/assets/svgs/lockicon_white.svg" /><b>{{ action }}</b>
   </v-chip>
 </template>
 
@@ -55,7 +55,8 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
-.info-chip-badge .mdi-lock {
-  font-size: 9px !important;
+.info-chip-badge img {
+  height: 9px;
+  margin-right: 6px;
 }
 </style>

--- a/ppr-ui/src/components/common/InfoChip.vue
+++ b/ppr-ui/src/components/common/InfoChip.vue
@@ -8,6 +8,7 @@
     :data-test-id="`${action}-badge`"
   >
     <v-icon v-if="isLockedAction" class="mr-1">mdi-lock</v-icon><b>{{ action }}</b>
+    <v-icon class="mr-1">mdi-lock</v-icon><b>{{ action }}</b>
   </v-chip>
 </template>
 

--- a/ppr-ui/src/components/common/InfoChip.vue
+++ b/ppr-ui/src/components/common/InfoChip.vue
@@ -8,7 +8,6 @@
     :data-test-id="`${action}-badge`"
   >
     <v-icon v-if="isLockedAction" class="mr-1">mdi-lock</v-icon><b>{{ action }}</b>
-    <v-icon class="mr-1">mdi-lock</v-icon><b>{{ action }}</b>
   </v-chip>
 </template>
 

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -65,7 +65,12 @@
 
       <!-- Caution message for Frozen MHR state -->
       <v-row
-        v-if="!isPpr && !isChild && item.statusType === MhApiStatusTypes.FROZEN && item.frozenDocumentType === 'AFFE'"
+        v-if="
+          !isPpr &&
+          !isChild &&
+          item.statusType === MhApiStatusTypes.FROZEN &&
+          item.frozenDocumentType === MhApiFrozenDocumentTypes.TRANS_AFFIDAVIT
+        "
         class="mt-8"
         :class="item.changes && 'pt-4'"
       >
@@ -445,8 +450,7 @@ import {
   BaseHeaderIF,
   DraftResultIF,
   MhRegistrationSummaryIF,
-  RegistrationSummaryIF,
-  RegTableNewItemI
+  RegistrationSummaryIF
 } from '@/interfaces'
 /* eslint-enable no-unused-vars */
 import {
@@ -458,7 +462,8 @@ import {
   TableActions,
   UIRegistrationClassTypes,
   UITransferTypes,
-  MhApiStatusTypes
+  MhApiStatusTypes,
+  MhApiFrozenDocumentTypes
 } from '@/enums'
 import { useRegistration } from '@/composables/useRegistration'
 import { useTransferOwners } from '@/composables'
@@ -858,6 +863,7 @@ export default defineComponent({
       isTransAffi,
       hasFrozenParentReg,
       hasLockedState,
+      MhApiFrozenDocumentTypes,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -65,7 +65,7 @@
 
       <!-- Caution message for Frozen MHR state -->
       <v-row
-        v-if="!isPpr && !isChild && item.statusType === MhApiStatusTypes.FROZEN"
+        v-if="!isPpr && !isChild && item.statusType === MhApiStatusTypes.FROZEN && item.frozenDocumentType === 'AFFE'"
         class="mt-8"
         :class="item.changes && 'pt-4'"
       >

--- a/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
+++ b/ppr-ui/src/components/unitNotes/EffectiveDateTime.vue
@@ -88,7 +88,7 @@
             class="ml-8 mb-6"
             data-test-id="date-summary-label"
           >
-            Caution on this home effective: <br />
+            {{ content.dateSummaryLabel }} <br />
             <b>
               {{ pacificDate(effectiveDate, true) }}
             </b>

--- a/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
@@ -29,7 +29,8 @@
           title: 'Effective Date and Time',
           description: `Select the effective date and time for this ${unitNoteType.header}.  ` +
           'Custom date and time can be a date and time in the past.' + effectiveDateDescForCAU,
-          sideLabel: 'Effective Date and Time'
+          sideLabel: 'Effective Date and Time',
+          dateSummaryLabel: `${unitNoteType.header} on this home effective: `
         }"
         :validate="validate"
         @setStoreProperty="handleEffectiveDateUpdate($event)"

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -15,6 +15,7 @@ import {
   HomeCertificationOptions,
   HomeLocationTypes,
   HomeTenancyTypes,
+  MhApiFrozenDocumentTypes,
   MhApiStatusTypes,
   UIRegistrationTypes,
   UITransferTypes
@@ -24,6 +25,7 @@ import { cloneDeep } from 'lodash'
 import { useHomeOwners, useTransferOwners } from '@/composables'
 import { computed, reactive, toRefs } from 'vue-demi'
 import { storeToRefs } from 'pinia'
+import { QSLockedStateUnitNoteTypes } from '@/resources'
 
 export const useMhrInformation = () => {
   const {
@@ -47,9 +49,9 @@ export const useMhrInformation = () => {
   const {
     // Getters
     isRoleStaffReg,
+    isRoleQualifiedSupplier,
     getStaffPayment,
     getMhrInformation,
-    isRoleQualifiedSupplier,
     getMhrTransferDeclaredValue,
     getMhrTransferConsideration,
     getMhrTransferDate,
@@ -73,6 +75,17 @@ export const useMhrInformation = () => {
   const localState = reactive({
     isFrozenMhr: computed((): boolean => {
       return getMhrInformation.value.statusType === MhApiStatusTypes.FROZEN
+    }),
+    isFrozenMhrDueToAffidavit: computed((): boolean => {
+      return localState.isFrozenMhr &&
+        getMhrInformation.value?.frozenDocumentType === MhApiFrozenDocumentTypes.TRANS_AFFIDAVIT
+    }),
+    isFrozenMhrDueToUnitNote: computed((): boolean => {
+      return (
+        isRoleQualifiedSupplier.value &&
+        localState.isFrozenMhr &&
+        QSLockedStateUnitNoteTypes.includes(getMhrInformation.value?.frozenDocumentType)
+      )
     })
   })
 

--- a/ppr-ui/src/enums/statusTypes.ts
+++ b/ppr-ui/src/enums/statusTypes.ts
@@ -29,3 +29,7 @@ export enum MhApiStatusTypes {
   CANCELLED = 'CANCELLED',
   EXPIRED = 'EXPIRED'
 }
+
+export enum MhApiFrozenDocumentTypes {
+  TRANS_AFFIDAVIT = 'AFFE'
+}

--- a/ppr-ui/src/resources/unitNotes.ts
+++ b/ppr-ui/src/resources/unitNotes.ts
@@ -131,8 +131,6 @@ export const remarksContent = {
   checkboxLabel: 'A notice pursuant to section 645/656 of the Local Government Act was filed'
 }
 
-export const hasNoPersonGivingNoticeText = 'There is no Person Giving Notice for this unit note.'
-
 // List of Unit Notes that can put MHR in Locked state for Qualified Suppliers
 export const QSLockedStateUnitNoteTypes: string[] = [
   UnitNoteDocTypes.NOTICE_OF_TAX_SALE,

--- a/ppr-ui/src/resources/unitNotes.ts
+++ b/ppr-ui/src/resources/unitNotes.ts
@@ -131,6 +131,8 @@ export const remarksContent = {
   checkboxLabel: 'A notice pursuant to section 645/656 of the Local Government Act was filed'
 }
 
+export const hasNoPersonGivingNoticeText = 'There is no Person Giving Notice for this unit note.'
+
 // List of Unit Notes that can put MHR in Locked state for Qualified Suppliers
 export const QSLockedStateUnitNoteTypes: string[] = [
   UnitNoteDocTypes.NOTICE_OF_TAX_SALE,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -458,6 +458,7 @@ export default defineComponent({
     } = storeToRefs(useStore())
     const {
       isFrozenMhr,
+      isFrozenMhrDueToAffidavit,
       buildApiData,
       initMhrTransfer,
       getUiTransferType,
@@ -503,7 +504,7 @@ export default defineComponent({
         folioNumber: '',
         isPriority: false
       },
-      showTransferType: !!getMhrInformation.value.draftNumber || isFrozenMhr.value || false,
+      showTransferType: !!getMhrInformation.value.draftNumber || isFrozenMhrDueToAffidavit.value || false,
       cancelOptions: unsavedChangesDialog,
       showCancelDialog: false,
       showCancelChangeDialog: false,
@@ -556,7 +557,7 @@ export default defineComponent({
         // not all MHR Info will have the frozenDocumentType
         if (!getMhrInformation.value?.frozenDocumentType && !localState.hasAlertMsg) return
         // display alert message based o the locker document type
-        const unitNoteType = UnitNotesInfo[getMhrInformation.value?.frozenDocumentType].header
+        const unitNoteType = UnitNotesInfo[getMhrInformation.value?.frozenDocumentType]?.header
         return isRoleStaffReg.value
           ? `A ${unitNoteType} has been filed against this home. This will prevent qualified suppliers from making any changes to this home. See Unit Notes for further details.` // eslint-disable-line max-len
           : `A ${unitNoteType} has been filed against this home and you will be unable to make any changes. If you require further information please contact BC Registries staff.` // eslint-disable-line max-len

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -83,7 +83,7 @@
       </template>
 
       <!-- Add/Remove Owner Actions -->
-      <v-row no-gutters v-if="!isReadonlyTable && enableAddHomeOwners()">
+      <v-row no-gutters v-if="!isReadonlyTable && enableAddHomeOwners() && !isFrozenMhrDueToUnitNote">
         <v-col cols="12">
           <v-btn
             outlined
@@ -136,7 +136,7 @@
         </v-col>
       </v-row>
 
-      <v-row>
+      <v-row v-if="!isFrozenMhrDueToUnitNote">
         <v-col
           class="transfer-table-error"
         >
@@ -340,7 +340,8 @@ export default defineComponent({
     } = storeToRefs(useStore())
 
     const {
-      getUiTransferType
+      getUiTransferType,
+      isFrozenMhrDueToUnitNote
     } = useMhrInformation()
 
     const {
@@ -557,6 +558,7 @@ export default defineComponent({
       enableDeleteAllGroupsActions,
       getMhrTransferDeclaredValue,
       handleUndo,
+      isFrozenMhrDueToUnitNote,
       ...toRefs(localState)
     }
   },

--- a/ppr-ui/tests/unit/TableRow.spec.ts
+++ b/ppr-ui/tests/unit/TableRow.spec.ts
@@ -494,9 +494,9 @@ describe('Mhr TableRow tests', () => {
     }
   })
 
-  it('displays caution icon for Frozen Mhrs', async () => {
+  it('displays caution icon for Frozen Affidavit Mhrs', async () => {
     const frozenRegistrationHistory: (MhRegistrationSummaryIF)[] = [
-      { ...mockedMhRegistration, statusType: MhApiStatusTypes.FROZEN }
+      { ...mockedMhRegistration, statusType: MhApiStatusTypes.FROZEN, frozenDocumentType: 'AFFE' }
     ]
 
     for (let i = 0; i < frozenRegistrationHistory.length; i++) {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#17187
- bcgov/entity#17130

*Description of changes:*
- This PR follows recent API changes  #1467 where `status` and `frozenDocumentType` values need to be checked to display the correct frozen state in the UI
- Checking only if status is FROZEN is not enough to determine what should be shown on UI
- _Unit Notes_ of _Affidavit_ frozen types lock the MHR in different ways 
- Other small UXA feedback items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
