### PR TITLE
MHR API fix legacy serial number compressed key generation.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -158,6 +158,12 @@ class Db2Descript(db.Model):
             descript.strip()
         return descript
 
+    def update_serial_keys(self):
+        """Set the serial number compressed key value for searching."""
+        if self.compressed_keys:
+            for key in self.compressed_keys:
+                key.update_serial_key()
+
     @property
     def json(self):
         """Return a dict of this object, with keys in JSON format."""
@@ -351,6 +357,7 @@ class Db2Descript(db.Model):
             key = Db2Cmpserno.create_from_registration(registration.id,
                                                        1,
                                                        model_utils.get_serial_number_key(descript.serial_number_1))
+            key.serial_number = descript.serial_number_1
             descript.compressed_keys.append(key)
         if descript.section_count > 1 and len(sections) > 1:
             section = sections[1]
@@ -362,6 +369,7 @@ class Db2Descript(db.Model):
             key = Db2Cmpserno.create_from_registration(registration.id,
                                                        2,
                                                        model_utils.get_serial_number_key(descript.serial_number_2))
+            key.serial_number = descript.serial_number_2
             descript.compressed_keys.append(key)
         else:
             descript.serial_number_2 = ''
@@ -379,6 +387,7 @@ class Db2Descript(db.Model):
             key = Db2Cmpserno.create_from_registration(registration.id,
                                                        3,
                                                        model_utils.get_serial_number_key(descript.serial_number_3))
+            key.serial_number = descript.serial_number_3
             descript.compressed_keys.append(key)
         else:
             descript.serial_number_3 = ''
@@ -396,6 +405,7 @@ class Db2Descript(db.Model):
             key = Db2Cmpserno.create_from_registration(registration.id,
                                                        4,
                                                        model_utils.get_serial_number_key(descript.serial_number_4))
+            key.serial_number = descript.serial_number_4
             descript.compressed_keys.append(key)
         else:
             descript.serial_number_4 = ''

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -213,6 +213,11 @@ class Db2Manuhome(db.Model):
             current_app.logger.error('Db2Manuhome.save_permit exception: ' + str(db_exception))
             raise DatabaseException(db_exception)
 
+    def update_serial_keys(self):
+        """Set the serial number compressed key value for searching."""
+        if self.reg_descript:
+            self.reg_descript.update_serial_keys()
+
     @classmethod
     def find_by_id(cls, id: int, search: bool = False):
         """Return the mh matching the id."""

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -397,6 +397,9 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 self.manuhome = Db2Manuhome.create_from_note(self, self.reg_json)
                 self.manuhome.save_note()
         db.session.commit()
+        if model_utils.is_legacy() and self.registration_type == MhrRegistrationTypes.MHREG:
+            self.manuhome.update_serial_keys()
+            db.session.commit()
 
     def save_exemption(self):
         """Set the state of the original MH registration to exempt."""

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.3'  # pylint: disable=invalid-name
+__version__ = '1.5.4'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17760

*Description of changes:*
- Fix the compressed key generated by the API so it will work with legacy and mhr serial number searches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
