### PR TITLE
MHR API search report exclude EXRE unit notes.

### DIFF
--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -32,6 +32,7 @@
                         {% endif %}                        
                     </td>
                 </tr>
+                {% if note.documentType not in ('TAXN', 'NCON', 'NPUB', 'REST') %}                
                 <tr>
                     <td class="section-sub-title">
                         {% if note.documentType in ('EXNR', 'EXRS') %}Destroyed Date:{% else %}Expiry Date:{% endif %}
@@ -45,6 +46,7 @@
                         {% endif %}
                     </td>
                 </tr>
+                {% endif %}                
                 <tr>
                     <td class="section-sub-title">Remarks:</td>
                     <td>{% if note.remarks is defined and note.remarks != '' %} 

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -808,7 +808,7 @@ def get_search_json(registration):
             include: bool = True
             doc_type = note.get('documentType', '')
             current_app.logger.debug('updating doc type=' + doc_type)
-            if doc_type in ('103', '103E', 'STAT'):  # Always exclude
+            if doc_type in ('103', '103E', 'STAT', 'EXRE'):  # Always exclude
                 include = False
             elif not registration.staff and doc_type in ('102', 'NCON'):  # Always exclude for non-staff
                 include = False

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -425,7 +425,7 @@ def update_notes_search_json(notes_json: dict, staff: bool) -> dict:
     for note in notes_json:
         include: bool = True
         doc_type = note.get('documentType', '')
-        if doc_type in ('REG_103', 'REG_103E', 'STAT'):  # Always exclude
+        if doc_type in ('REG_103', 'REG_103E', 'STAT', 'EXRE'):  # Always exclude
             include = False
         elif not staff and doc_type in ('REG_102', 'NCON'):  # Always exclude for non-staff
             include = False

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.4'  # pylint: disable=invalid-name
+__version__ = '1.5.5'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17656

*Description of changes:*
- Search report always exclude EXRE unit notes.
- Search report exclude expiry date for some document types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
