### PR TITLE
alignment for 'start a new ppr' and 'ppr #'

### DIFF
--- a/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
+++ b/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
@@ -215,7 +215,7 @@ export default defineComponent({
   label {
     color: $gray7 !important;
     font-size: 14px;
-    margin-top: -2px;
+    margin-top: -5px;
     padding-left: 6px;
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17530

*Description of changes:*

the problem:
![image](https://github.com/bcgov/ppr/assets/144158684/8bcd5e66-7792-4b0b-b3e9-930045b2821e)

And now the problem is fixed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
