### PR TITLE
Unit Test Fixes - Mhr Manufacturer 

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/tests/unit/Attention.spec.ts
+++ b/ppr-ui/tests/unit/Attention.spec.ts
@@ -13,6 +13,7 @@ import { createComponent, getLastEvent, getTestId } from './utils'
 import { attentionConfig, attentionConfigManufacturer } from '@/resources/attnRefConfigs'
 import { mockedManufacturerAuthRoles } from './test-data'
 import { useStore } from '@/store/store'
+import { ProductCode } from '@/enums'
 
 Vue.use(Vuetify)
 const store = useStore()
@@ -56,6 +57,7 @@ describe('Attention', () => {
 
   it('has the right configurations for manufacturer', async () => {
     await store.setAuthRoles(mockedManufacturerAuthRoles)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
     const wrapper = await createComponent(Attention, attentionProps)
 
     const description = wrapper.find(getTestId(`${sectionId}-description`))

--- a/ppr-ui/tests/unit/HomeCertification.spec.ts
+++ b/ppr-ui/tests/unit/HomeCertification.spec.ts
@@ -10,7 +10,7 @@ import { SharedDatePicker } from '@/components/common'
 import flushPromises from 'flush-promises'
 import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
-import { HomeCertificationOptions, AuthRoles } from '@/enums'
+import { HomeCertificationOptions, AuthRoles, ProductCode } from '@/enums'
 import { createComponent } from './utils'
 
 Vue.use(Vuetify)
@@ -170,6 +170,7 @@ describe('Home Certification - manufacturer', () => {
     await store.setRegistrationType(MhrRegistrationType)
     // When a manufacturer registration is inited it sets the certificatonOption to CSA
     await store.setMhrHomeDescription({ key: 'certificationOption', value: HomeCertificationOptions.CSA })
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
   })
 
   beforeEach(async () => {

--- a/ppr-ui/tests/unit/ManufacturerMakeModel.spec.ts
+++ b/ppr-ui/tests/unit/ManufacturerMakeModel.spec.ts
@@ -8,6 +8,7 @@ import { getTestId } from './utils'
 import { ManufacturerMakeModel, ManufacturedYearInput, ManufacturedYearSelect } from '@/components/mhrRegistration'
 import { MhrRegistrationType } from '@/resources'
 import { mockedManufacturerAuthRoles } from './test-data'
+import { ProductCode } from '@/enums'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
@@ -145,6 +146,7 @@ describe('ManufacturerMakeModel component - manufacturer', () => {
   beforeAll(async () => {
     await store.setAuthRoles(mockedManufacturerAuthRoles)
     await store.setRegistrationType(MhrRegistrationType)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
   })
 
   beforeEach(async () => {

--- a/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
@@ -12,7 +12,7 @@ import { HomeLocationReview, HomeOwnersReview,
   SubmittingPartyReview, YourHomeReview } from '@/components/mhrRegistration/ReviewConfirm'
 import { AccountInfo, Attention, CautionBox, CertifyInformation,
   ContactUsToggle, FolioOrReferenceNumber, FormField } from '@/components/common'
-import { HomeTenancyTypes, RouteNames } from '@/enums'
+import { HomeTenancyTypes, ProductCode, RouteNames } from '@/enums'
 import mockRouter from './MockRouter'
 import { mockedFractionalOwnership, mockedPerson } from './test-data/mock-mhr-registration'
 import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces/mhr-registration-interfaces'
@@ -206,6 +206,7 @@ describe('Mhr Manufacturer Registration Review and Confirm', () => {
     defaultFlagSet['mhr-registration-enabled'] = true
     await store.setAuthRoles(mockedManufacturerAuthRoles)
     await store.setRegistrationType(MhrRegistrationType)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
   })
 
   beforeEach(async () => {

--- a/ppr-ui/tests/unit/Stepper.spec.ts
+++ b/ppr-ui/tests/unit/Stepper.spec.ts
@@ -137,8 +137,8 @@ describe('Stepper - MHR Manufacturer Registration', () => {
   let expectedSteps: StepIF[]
   beforeAll(async () => {
     await store.setAuthRoles(mockedManufacturerAuthRoles)
-    await store.setUserProductSubscriptionsCodes([ProductCode.MHR])
     await store.setRegistrationType(MhrRegistrationType)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
     expectedSteps = await store.getMhrSteps
   })
 

--- a/ppr-ui/tests/unit/YourHome.spec.ts
+++ b/ppr-ui/tests/unit/YourHome.spec.ts
@@ -18,7 +18,7 @@ import {
 import { MhrRegistrationType } from '@/resources'
 import { defaultFlagSet } from '@/utils'
 import mockRouter from './MockRouter'
-import { RouteNames } from '@/enums'
+import { ProductCode, RouteNames } from '@/enums'
 import { getTestId } from './utils'
 import { mockedManufacturerAuthRoles } from './test-data'
 import { HomeCertificationPrompt, ManufacturerMakeModelPrompt } from '@/resources/mhr-registration'
@@ -99,6 +99,7 @@ describe('Your Home - Manufacturer', () => {
     defaultFlagSet['mhr-registration-enabled'] = true
     await store.setAuthRoles(mockedManufacturerAuthRoles)
     await store.setRegistrationType(MhrRegistrationType)
+    await store.setUserProductSubscriptionsCodes([ProductCode.MHR, ProductCode.MANUFACTURER])
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17535

*Description of changes:*
* After removing the workaround and enforcing a product check, resulted in some unit tests that failed to set up role. 
* This fixes the broken tests, missing the setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
