### PR TITLE
Data migration registration summary queries, filtering, sorting.

### DIFF
--- a/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
+++ b/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
@@ -1,0 +1,75 @@
+-- registration summary view.
+CREATE OR REPLACE VIEW public.mhr_account_reg_vw AS
+SELECT r.mhr_number, r.status_type, r.registration_ts,
+       (SELECT CASE WHEN p.business_name IS NOT NULL THEN p.business_name
+                    WHEN p.middle_name IS NOT NULL THEN p.first_name || ' ' || p.middle_name || ' ' || p.last_name
+                    ELSE p.first_name || ' ' || p.last_name
+               END
+          FROM mhr_parties p
+         WHERE p.registration_id = r.id 
+           AND p.party_type = 'SUBMITTING') AS submitting_name,
+       r.client_reference_id,
+       r.registration_type,       
+       (SELECT string_agg((CASE WHEN p.business_name IS NOT NULL THEN p.business_name
+                                WHEN p.middle_name IS NOT NULL THEN p.first_name || ' ' || p.middle_name || ' ' || p.last_name
+                                ELSE p.first_name || ' ' || p.last_name END), '\n')
+          FROM mhr_registrations ro, mhr_owner_groups og, mhr_parties p
+         WHERE ro.mhr_number = r.mhr_number 
+           AND ro.id = og.registration_id
+           AND og.status_type = 'ACTIVE'
+           AND og.registration_id = p.registration_id
+           AND og.id = p.owner_group_id) AS owner_names,       
+       (SELECT CASE WHEN r.user_id IS NULL THEN ''
+                    ELSE (SELECT u.firstname || ' ' || u.lastname
+                            FROM users u
+                           WHERE u.username = r.user_id FETCH FIRST 1 ROWS ONLY) END) AS registering_name,
+       d.document_id,
+       d.document_registration_number,
+       (SELECT d2.document_type
+          FROM mhr_documents d2
+         WHERE d2.id = (SELECT MAX(d3.id)
+                          FROM mhr_documents d3, mhr_registrations r2
+                         WHERE r2.id = d3.registration_id
+                          AND r2.mhr_number = r.mhr_number)) AS last_doc_type,
+       (SELECT n.status_type
+          FROM mhr_notes n
+         WHERE n.registration_id = r.id) AS note_status,
+       (SELECT n.expiry_date
+          FROM mhr_notes n
+         WHERE n.registration_id = r.id) AS note_expiry,
+       (CASE
+          WHEN d.document_type in ('NCAN', 'NRED') THEN
+            (SELECT n.document_type
+               FROM mhr_notes n
+              WHERE n.status_type != 'ACTIVE'
+                AND n.change_registration_id = r.id
+                AND n.document_type != 'CAUC'
+                AND n.document_type != 'CAUE'
+             FETCH FIRST 1 ROWS ONLY)
+          ELSE NULL
+        END) AS cancel_doc_type,
+       (SELECT n.document_type
+          FROM mhr_notes n, mhr_registrations r2
+         WHERE r2.mhr_number = r.mhr_number
+           AND r2.id = n.registration_id
+           AND n.status_type = 'ACTIVE'
+           AND (n.document_type IN ('TAXN', 'NCON', 'REST') OR 
+                (n.document_type IN ('REG_103', 'REG_103E') AND 
+                 n.expiry_date IS NOT NULL AND n.expiry_date > (now() at time zone 'UTC')))
+         FETCH FIRST 1 ROWS ONLY) AS frozen_doc_type,
+       r.account_id,
+       dt.document_type_desc,
+      (SELECT CASE WHEN r.registration_type != 'MHREG' THEN ''
+            ELSE (SELECT lcv.registration_type
+                    FROM mhr_lien_check_vw lcv
+                   WHERE lcv.mhr_number = r.mhr_number) END) AS ppr_lien_type,
+       d.document_type,
+       r.id AS registration_id,
+       (SELECT mrr.doc_storage_url
+          FROM mhr_registration_reports mrr
+         WHERE mrr.registration_id = r.id) AS doc_storage_url
+  FROM mhr_registrations r, mhr_documents d, mhr_document_types dt
+ WHERE r.id = d.registration_id
+   AND d.document_type = dt.document_type
+;
+ 

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -474,7 +474,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         current_app.logger.debug(f'Account_id={account_id}, mhr_number={formatted_mhr}')
         if model_utils.is_legacy():
             return legacy_utils.find_summary_by_mhr_number(account_id, formatted_mhr, staff)
-        raise DatabaseException('MhrRegistration.find_summary_by_mhr_number PosgreSQL not yet implemented.')
+        return reg_utils.find_summary_by_mhr_number(account_id, formatted_mhr, staff)
 
     @classmethod
     def find_summary_by_doc_reg_number(cls, account_id: str, doc_reg_number: str, staff: bool = False):
@@ -483,7 +483,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         current_app.logger.debug(f'Account_id={account_id}, doc_reg_number={formatted_reg_num}')
         if model_utils.is_legacy():
             return legacy_utils.find_summary_by_doc_reg_number(account_id, formatted_reg_num, staff)
-        raise DatabaseException('MhrRegistration.find_summary_by_doc_reg_number PosgreSQL not yet implemented.')
+        return reg_utils.find_summary_by_doc_reg_number(account_id, formatted_reg_num, staff)
 
     @classmethod
     def find_all_by_account_id(cls, params: reg_utils.AccountRegistrationParams):
@@ -491,8 +491,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         current_app.logger.debug(f'Account_id={params.account_id}')
         if model_utils.is_legacy():
             return legacy_utils.find_all_by_account_id(params)
-
-        raise DatabaseException('MhrRegistration.find_all_by_account_id PosgreSQL not yet implemented.')
+        return reg_utils.find_all_by_account_id(params)
 
     @classmethod
     def get_doc_id_count(cls, doc_id: str):

--- a/mhr_api/src/mhr_api/models/queries.py
+++ b/mhr_api/src/mhr_api/models/queries.py
@@ -1,0 +1,174 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds PostgreSQL query strings."""
+
+
+DOC_ID_COUNT_QUERY = """
+SELECT COUNT(document_id)
+  FROM mhr_documents
+ WHERE document_id = :query_value
+"""
+QUERY_BATCH_MANUFACTURER_MHREG_DEFAULT = """
+select r.id, r.account_id, r.registration_ts, rr.id, rr.report_data, rr.batch_storage_url
+  from mhr_registrations r, mhr_manufacturers m, mhr_registration_reports rr
+ where r.id = rr.registration_id
+   and r.account_id = m.account_id
+   and r.registration_type = 'MHREG'
+   and r.registration_ts between (now() - interval '1 days') and now()
+  order by r.account_id, r.mhr_number
+ """
+QUERY_BATCH_MANUFACTURER_MHREG = """
+select r.id, r.account_id, r.registration_ts, rr.id, rr.report_data, rr.batch_storage_url
+  from mhr_registrations r, mhr_manufacturers m, mhr_registration_reports rr
+ where r.id = rr.registration_id
+   and r.account_id = m.account_id
+   and r.registration_type = 'MHREG'
+   and r.registration_ts between to_timestamp(:query_val1, 'YYYY-MM-DD HH24:MI:SS')
+                             and to_timestamp(:query_val2, 'YYYY-MM-DD HH24:MI:SS')
+  order by r.account_id, r.mhr_number
+"""
+UPDATE_BATCH_REG_REPORT = """
+update mhr_registration_reports
+   set batch_storage_url = '{batch_url}'
+ where id in ({report_ids})
+"""
+QUERY_PPR_LIEN_COUNT = """
+SELECT COUNT(base_registration_num)
+  FROM mhr_lien_check_vw
+ WHERE mhr_number = :query_value
+"""
+QUERY_PERMIT_COUNT = """
+SELECT COUNT(r.id) AS permit_count
+  FROM mhr_registrations r, mhr_parties p
+ WHERE r.mhr_number = :query_value1
+   AND r.registration_type = 'PERMIT'
+   AND r.id = p.registration_id
+   AND p.party_type = 'SUBMITTING'
+   AND p.business_name = :query_value2
+"""
+QUERY_PKEYS = """
+select nextval('mhr_registration_id_seq') AS reg_id,
+       nextval('mhr_document_id_seq') AS doc_id,
+       get_mhr_number() AS mhr_number,
+       get_mhr_doc_reg_number() AS doc_reg_id,
+       get_mhr_draft_number() AS draft_num,
+       nextval('mhr_draft_id_seq') AS draft_id
+"""
+QUERY_PKEYS_NO_DRAFT = """
+select nextval('mhr_registration_id_seq') AS reg_id,
+       nextval('mhr_document_id_seq') AS doc_id,
+       get_mhr_number() AS mhr_number,
+       get_mhr_doc_reg_number() AS doc_reg_id
+"""
+CHANGE_QUERY_PKEYS = """
+select nextval('mhr_registration_id_seq') AS reg_id,
+       nextval('mhr_document_id_seq') AS doc_id,
+       get_mhr_doc_reg_number() AS doc_reg_id,
+       get_mhr_draft_number() AS draft_num,
+       nextval('mhr_draft_id_seq') AS draft_id
+"""
+CHANGE_QUERY_PKEYS_NO_DRAFT = """
+select nextval('mhr_registration_id_seq') AS reg_id,
+       nextval('mhr_document_id_seq') AS doc_id,
+       get_mhr_doc_reg_number() AS doc_reg_id
+"""
+QUERY_REG_ID_PKEY = """
+select nextval('mhr_registration_id_seq') AS reg_id
+"""
+QUERY_ACCOUNT_REG_BASE = """
+SELECT mhr_number, status_type, registration_ts, submitting_name, client_reference_id, registration_type, owner_names,
+       registering_name, document_id, document_registration_number, last_doc_type, note_status, note_expiry,
+       cancel_doc_type, frozen_doc_type, account_id, document_type_desc, ppr_lien_type, document_type, doc_storage_url,
+       (SELECT COUNT(mer.id)
+          FROM mhr_extra_registrations mer
+         WHERE mer.mhr_number = arv.mhr_number
+           AND mer.account_id = arv.account_id
+           AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) AS reg_count,
+       (SELECT COUNT(mer.id)
+          FROM mhr_extra_registrations mer
+         WHERE mer.mhr_number = arv.mhr_number
+           AND mer.account_id = :query_value1
+           AND mer.account_id != arv.account_id
+           AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) AS extra_reg_count
+  FROM mhr_account_reg_vw arv
+"""
+QUERY_ACCOUNT_ADD_REG_MHR = QUERY_ACCOUNT_REG_BASE + """
+ WHERE mhr_number = :query_value2
+ORDER BY registration_ts
+"""
+QUERY_ACCOUNT_ADD_REG_DOC = QUERY_ACCOUNT_REG_BASE + """
+ WHERE mhr_number = (SELECT r.mhr_number
+                       FROM mhr_registrations r, mhr_documents d
+                      WHERE r.id = d.registration_id
+                        AND d.document_registration_number = :query_value2)
+ORDER BY registration_ts
+"""
+QUERY_ACCOUNT_DEFAULT = QUERY_ACCOUNT_REG_BASE + """
+ WHERE mhr_number IN (SELECT DISTINCT mer.mhr_number
+                           FROM mhr_extra_registrations mer
+                          WHERE account_id = :query_value1
+                            AND (removed_ind IS NULL OR removed_ind != 'Y')
+                          UNION (
+                         SELECT DISTINCT mr.mhr_number
+                           FROM mhr_registrations mr
+                          WHERE account_id = :query_value1
+                            AND mr.registration_type = 'MHREG'))
+"""
+
+REG_ORDER_BY_DATE = ' ORDER BY registration_ts DESC'
+REG_ORDER_BY_MHR_NUMBER = ' ORDER BY mhr_number'
+REG_ORDER_BY_REG_TYPE = ' ORDER BY document_type'
+REG_ORDER_BY_STATUS = ' ORDER BY status_type'
+REG_ORDER_BY_SUBMITTING_NAME = ' ORDER BY submitting_name'
+REG_ORDER_BY_CLIENT_REF = ' ORDER BY client_reference_id'
+REG_ORDER_BY_USERNAME = ' ORDER BY registering_name'
+REG_ORDER_BY_OWNER_NAME = ' ORDER BY owner_names'
+REG_ORDER_BY_EXPIRY_DAYS = ' ORDER BY mhr_number'
+REG_FILTER_REG_TYPE = " AND document_type = '?'"
+REG_FILTER_REG_TYPE_COLLAPSE = """
+ AND mhr_number IN (SELECT DISTINCT r2.mhr_number
+                      FROM mhr_registrations r2, mhr_documents d2
+                     WHERE r2.id = d2.registration_id
+                       AND d2.document_type = '?')
+"""
+REG_FILTER_STATUS = " AND status_type = '?'"
+REG_FILTER_SUBMITTING_NAME = " AND submitting_name LIKE '%?%'"
+REG_FILTER_SUBMITTING_NAME_COLLAPSE = """
+ AND mhr_number IN (SELECT DISTINCT arv2.mhr_number
+                      FROM mhr_account_reg_vw arv2
+                     WHERE arv2.submitting_name LIKE '%?%')
+"""
+REG_FILTER_CLIENT_REF = " AND UPPER(client_reference_id) LIKE '%?%'"
+REG_FILTER_CLIENT_REF_COLLAPSE = """
+ AND mhr_number IN (SELECT DISTINCT r2.mhr_number
+                      FROM mhr_registrations r2
+                     WHERE arv.registration_id = r2.id
+                       AND UPPER(r2.client_reference_id) LIKE '%?%')
+"""
+REG_FILTER_USERNAME = " AND registering_name LIKE '%?%'"
+REG_FILTER_USERNAME_COLLAPSE = """
+ AND mhr_number IN (SELECT DISTINCT arv2.mhr_number
+                      FROM mhr_account_reg_vw arv2
+                     WHERE arv2.registering_name LIKE '%?%')
+"""
+REG_FILTER_DATE = ' AND registration_ts BETWEEN :query_start AND :query_end'
+REG_FILTER_DATE_COLLAPSE = """
+ AND mhr_number IN (SELECT DISTINCT r2.mhr_number
+                      FROM mhr_registrations r2
+                     WHERE arv.registration_id = r2.id
+                       AND r2.registration_ts BETWEEN :query_start AND :query_end)
+"""
+ACCOUNT_SORT_DESCENDING = ' DESC'
+ACCOUNT_SORT_ASCENDING = ' ASC'
+DEFAULT_SORT_ORDER = ' ORDER BY registration_ts DESC'

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -759,6 +759,16 @@ def search_ts_local(date_iso: str, start: bool = True):
     return _datetime.combine(date_part, day_time)
 
 
+def search_ts(date_iso: str, start: bool = True):
+    """Get a search timestamp in utc time zone as start or end of day."""
+    date_part = date.fromisoformat(date_iso[0:10])
+    if start:
+        day_time = time(0, 0, 1, tzinfo=timezone.utc)
+        return _datetime.combine(date_part, day_time)
+    day_time = time(23, 59, 59, tzinfo=timezone.utc)
+    return _datetime.combine(date_part, day_time)
+
+
 def compute_caution_expiry(effective_ts, end_of_day: bool = False):
     """For Notice of Caution add 90 days to the effective timestamp."""
     if effective_ts and not end_of_day:

--- a/mhr_api/test_data/db2_data_files/test0005.sql
+++ b/mhr_api/test_data/db2_data_files/test0005.sql
@@ -3,6 +3,7 @@
 -- UT-0028 000927 new MH registration for a manufacturer
 -- UT-0029 000928 EXEMPT non-residential MH registration
 -- UT-0030 000929 COMMON registration 1 ADMINISTRATOR.
+-- UT-0031 000930 Registration with expired transport permit registration.
 INSERT INTO amhrtdb.manuhome(MANHOMID, MHREGNUM, MHSTATUS, REGDOCID, UPDATECT, UPDATEID, UPDATEDA, UPDATETI)
      VALUES (200000037, '000926', 'R', 'UT000037', 1, 'PS12345 ', current date, current time)
 ;
@@ -119,7 +120,7 @@ INSERT INTO amhrtdb.cmpserno(MANHOMID, CMPSERID, SERIALNO)
 ;
 -- UT-0029 000928 non-residential MH registration
 INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
-     VALUES ('UT000041', '000929', current timestamp, current timestamp, 'EXNR', '90499041', 'N', 'PS12345 ', '6041234567', 
+     VALUES ('UT000041', '000928', current timestamp, current timestamp, 'EXNR', '90499041', 'N', 'PS12345 ', '6041234567', 
              'SUBMITTING', 
              '1234 TEST-0029                                                                  CITY                                    BC CA                            V8R 3A5', 
              'TESTUSER', 'UT-0029')
@@ -136,9 +137,9 @@ INSERT INTO amhrtdb.manuhome(MANHOMID, MHREGNUM, MHSTATUS, REGDOCID, UPDATECT, U
 ;
 INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
      VALUES ('UT000042', '000929', current timestamp, current timestamp, '101 ', '90499042', 'N', 'PS12345 ', '6041234567', 
-             'SUBMITTING', 
+             'IVERSON                DONNA', 
              '1234 TEST-0030                                                                  CITY                                    BC CA                            V8R 3A5', 
-             'TESTUSER', 'UT-0030')
+             'TEST USER', 'UT-0030')
 ;
 INSERT INTO amhrtdb.descript(MANHOMID, DESCRNID, STATUS, REGDOCID, CSANUMBR, CSASTAND, NUMBSECT, YEARMADE,
                              SERNUMB1, LENGTH1, LENGIN1, WIDTH1, WIDIN1,
@@ -168,4 +169,57 @@ INSERT INTO amhrtdb.owner(MANHOMID, OWNGRPID, OWNERID, OWNSEQNO, VERIFIED, OWNRT
 ;
 INSERT INTO amhrtdb.cmpserno(MANHOMID, CMPSERID, SERIALNO)
      VALUES (200000042, 1, (SELECT serialno FROM amhrtdb.cmpserno WHERE manhomid = 40865 AND CMPSERID = 1))
+;
+-- UT-0031 000930 Registration with expired transport permit registration.
+INSERT INTO amhrtdb.manuhome(MANHOMID, MHREGNUM, MHSTATUS, REGDOCID, UPDATECT, UPDATEID, UPDATEDA, UPDATETI)
+     VALUES (200000043, '000930', 'R', 'UT000043', 1, 'PS12345 ', current date, current time)
+;
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000043', '000930', current timestamp - 2 days, current timestamp - 2 days, '101 ', '90499043', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0031                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0031')
+;
+INSERT INTO amhrtdb.descript(MANHOMID, DESCRNID, STATUS, REGDOCID, CSANUMBR, CSASTAND, NUMBSECT, YEARMADE,
+                             SERNUMB1, LENGTH1, LENGIN1, WIDTH1, WIDIN1,
+                             MANUNAME, MAKEMODL, REBUILTR, OTHERREM, ENGIDATE)
+     VALUES (200000043, 1, 'A', 'UT000043', '77777', '1234', 1, '2000', '888888', 60, 10, 14, 11,
+             'REAL ENGINEERED HOMES INC', 'make model', 'rebuilt', 'other', TO_DATE('0001-01-01', 'YYYY-MM-DD'))
+;
+INSERT INTO amhrtdb.location(MANHOMID, LOCATNID, STATUS, REGDOCID, STNUMBER, STNAME, TOWNCITY, PROVINCE, MAHPNAME,
+                             MAHPPAD, PIDNUMB, TAXCERT, TAXDATE, MHDEALER)
+     VALUES (200000043, 1, 'A', 'UT000043', '1234', 'TEST-0031', 'CITY', 'BC', '', '', '', 'N',
+             TO_DATE('0001-01-01', 'YYYY-MM-DD'), 'REAL ENGINEERED HOMES INC')
+;
+INSERT INTO amhrtdb.owngroup(MANHOMID, OWNGRPID, COPGRPID, GRPSEQNO, STATUS, REGDOCID, TENYTYPE, INTEREST, INTNUMER, TENYSPEC)
+     VALUES (200000043, 1, 0, 1, '3', 'UT000043', 'SO', '', 0, 'Y')
+;
+INSERT INTO amhrtdb.owner(MANHOMID, OWNGRPID, OWNERID, OWNSEQNO, VERIFIED, OWNRTYPE, COMPNAME, OWNRFONE, OWNRPOCO, OWNRNAME, OWNRSUFF, OWNRADDR)
+     VALUES (200000043, 1, 1, 1, ' ', 'B', 'TESTEXPIREDPERMIT', '6041234567', 'V8R 3A5', 'TEST EXPIRED PERMIT', '',
+             '1234 TEST-0031                          CITY                                    BC CA')
+;
+INSERT INTO amhrtdb.cmpserno(MANHOMID, CMPSERID, SERIALNO)
+     VALUES (200000043, 1, (SELECT serialno FROM amhrtdb.cmpserno WHERE manhomid = 40865 AND CMPSERID = 1))
+;
+-- Expired transport permit registration
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000044', '000930', current timestamp - 1 days, current timestamp - 1 days, '103 ', '90499044', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0031                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0031')
+;
+INSERT INTO amhrtdb.location(MANHOMID, LOCATNID, STATUS, REGDOCID, STNUMBER, STNAME, TOWNCITY, PROVINCE, MAHPNAME,
+                             MAHPPAD, PIDNUMB, TAXCERT, TAXDATE)
+     VALUES (200000043, 2, 'A', 'UT000044', '1234', 'TEST-0031', 'CITY', 'BC', 'PARK NAME', '1234', '', 'N',
+             TO_DATE('0001-01-01', 'YYYY-MM-DD'))
+;
+INSERT INTO amhrtdb.mhomnote(MANHOMID, MHNOTEID, MHNOTENO, REGDOCID, CANDOCID, DOCUTYPE, STATUS, DESTROYD, EXPIRYDA, PHONE, NAME, ADDRESS, REMARKS)
+     VALUES (200000043, 1, 1, 'UT000044', '', '103 ', 'A', '', current date - 1 days, '6041234567', 
+             'PERSON GIVING NOTICE', 
+             '1234 TEST-0031                                                                  CITY                                    BC CA                            V8R 3A5', 
+             '')
+;
+UPDATE amhrtdb.location
+   SET status = 'H', candocid = 'UT000044'
+ WHERE regdocid = 'UT000043'
 ;

--- a/mhr_api/test_data/postgres_data_files/test0007.sql
+++ b/mhr_api/test_data/postgres_data_files/test0007.sql
@@ -3,6 +3,9 @@
 -- UT-0028 000927 new MH registration for a manufacturer
 -- UT-0029 000928 EXEMPT non-residential MH registration
 -- UT-0030 000929 COMMON registration 1 ADMINISTRATOR.
+-- UT-0031 000930 Registration with expired transport permit registration.
+
+-- UT-0027 000926 Manufacturer registration with existing transport permit registration.
 INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
                                pay_invoice_id, pay_path, user_id, client_reference_id)
      VALUES (200000037, '000926', 'PS12345', 'MHREG', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0027')
@@ -247,7 +250,7 @@ INSERT INTO addresses(id, street, street_additional, city, region, postal_code, 
 INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
                         last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
                         owner_group_id)
-    VALUES(200000097, 'SUBMITTING', 'ACTIVE', 200000042, 200000042, null, null, null, 'SUBMITTING',
+    VALUES(200000097, 'SUBMITTING', 'ACTIVE', 200000042, 200000042, 'DONNA', null, 'IVERSON', null,
            mhr_name_compressed_key('SUBMITTING'), 190000112, 'test@gmail.com', '6041234567', null, null)
 ;
 INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
@@ -303,6 +306,106 @@ INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_reg
     VALUES(200000099, 'OWNER_IND', 'ACTIVE', 200000042, 200000042, 'SHARON', null, 'HALL', NULL, 
            mhr_name_compressed_key('HALL SHARON'), 190000115, null, '6041234567', null, 200000039,
            null)
+;
+-- UT-0031 000930 Registration with expired transport permit registration.
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000043, '000930', 'PS12345', 'MHREG', (now() at time zone 'UTC') - interval '2 days', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0031')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000116, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000100, 'SUBMITTING', 'ACTIVE', 200000043, 200000043, null, null, null, 'REAL ENGINEERED HOMES INC',
+           mhr_name_compressed_key('REAL ENGINEERED HOMES INC'), 190000116, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000117, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_locations(id, location_type, status_type, registration_id, change_registration_id, address_id, ltsa_description, 
+                        additional_description, dealer_name, exception_plan, leave_province, tax_certification, tax_certification_date, 
+                        park_name, park_pad, pid_number, lot, parcel, block, district_lot, part_of, section,
+                        township, range, meridian, land_district, plan)
+    VALUES(200000043, 'MANUFACTURER', 'ACTIVE', 200000043, 200000043, 190000117,
+           NULL, 'additional', 'REAL ENGINEERED HOMES INC', NULL, 'N', 'Y', now() at time zone 'UTC', NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+;
+INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_standard, number_of_sections, 
+                          square_feet, year_made, circa, engineer_date, engineer_name, manufacturer_name,
+                          make, model, rebuilt_remarks, other_remarks, change_registration_id)
+    VALUES(200000043, 'ACTIVE', 200000043, '7777700000', '1234', 3, NULL, 2015, 'Y', now() at time zone 'UTC',
+           'engineer name', 'REAL ENGINEERED HOMES INC', 'make', 'model', 'rebuilt', 'other', 200000043)
+;
+INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
+                               width_feet, width_inches, change_registration_id)
+    VALUES(200000042, 200000043, 'ACTIVE', mhr_serial_compressed_key('888888'), '888888', 60, 10, 14, 11,
+           200000043)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000043, 'REG_101', 200000043, 'UT000043', '90499043', 'attn', NULL, NULL, 'Y', null, null, null, 200000043)
+;
+INSERT INTO mhr_owner_groups(id, sequence_number, registration_id, status_type, tenancy_type, interest,
+                             tenancy_specified, interest_numerator, interest_denominator, change_registration_id)
+    VALUES(200000040, 1, 200000043, 'ACTIVE', 'SOLE', NULL, 'Y', NULL, NULL, 200000043)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000118, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000101, 'OWNER_BUS', 'ACTIVE', 200000043, 200000043, null, null, null, 'TEST EXPIRED PERMIT', 
+           mhr_name_compressed_key('TEST EXPIRED PERMIT'), 190000118, null, '6041234567', null, 200000040)
+;
+-- Expired transport permit registration
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000044, '000930', 'PS12345', 'PERMIT', (now() at time zone 'UTC') - interval '1 days', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0031')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000119, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000102, 'SUBMITTING', 'ACTIVE', 200000044, 200000044, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000119, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000120, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_locations(id, location_type, status_type, registration_id, change_registration_id, address_id, ltsa_description, 
+                        additional_description, dealer_name, exception_plan, leave_province, tax_certification, tax_certification_date, 
+                        park_name, park_pad, pid_number, lot, parcel, block, district_lot, part_of, section,
+                        township, range, meridian, land_district, plan)
+    VALUES(200000044, 'MH_PARK', 'ACTIVE', 200000044, 200000044, 190000120,
+           NULL, 'additional', NULL, NULL, 'N', 'Y', now() at time zone 'UTC', 'PARK NAME', '1234', NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000044, 'REG_103', 200000044, 'UT000044', '90499044', 'attn', NULL, NULL, 'Y', null, null, null, 200000044)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000121, '1234 TEST-0031', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000103, 'CONTACT', 'ACTIVE', 200000044, 200000044, null, null, null, 'PERSON GIVING NOTICE',
+           mhr_name_compressed_key('PERSON GIVING NOTICE'), 190000121, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_type, remarks, destroyed,
+                      change_registration_id, expiry_date, effective_ts)
+    VALUES(200000032, 'REG_103', 200000044, 200000044, 'ACTIVE', null, 'N', 200000044,
+           (now() at time zone 'UTC') - interval '1 days', now() at time zone 'UTC')
+;
+UPDATE mhr_locations
+   SET status_type = 'HISTORICAL', change_registration_id = 200000044
+ WHERE id = 200000043
 ;
 
 

--- a/mhr_api/tests/unit/api/test_other_registrations.py
+++ b/mhr_api/tests/unit/api/test_other_registrations.py
@@ -29,31 +29,30 @@ from tests.unit.services.utils import create_header, create_header_account
 
 # testdata pattern is ({desc}, {roles}, {status}, {has_account}, {identifier}, is_mhr)
 TEST_GET_DATA = [
-    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '077741', True),
-    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '077741', True),
-    ('Valid request MHR', [MHR_ROLE], HTTPStatus.OK, True, '077741', True),
-    ('Valid request Doc Reg parent', [MHR_ROLE], HTTPStatus.OK, True, '00195878', False),
-    ('Valid request Doc Reg child', [MHR_ROLE], HTTPStatus.OK, True, '221961', False),
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '000928', True),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '000928', True),
+    ('Valid request MHR', [MHR_ROLE], HTTPStatus.OK, True, '000928', True),
+    ('Valid request Doc Reg parent', [MHR_ROLE], HTTPStatus.OK, True, '90499037', False),
+    ('Valid request Doc Reg child', [MHR_ROLE], HTTPStatus.OK, True, '90499038', False),
     ('Invalid MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXX', True),
-    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '077741', True)
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '000928', True)
 ]
 TEST_POST_DATA = [
-    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '077741'),
-    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '077741'),
-    ('Valid request', [MHR_ROLE], HTTPStatus.CREATED, True, '077741'),
-    ('Duplicate/already added request', [MHR_ROLE], HTTPStatus.CONFLICT, True, '045349'),
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '000912'),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '000912'),
+    ('Valid request extra', [MHR_ROLE], HTTPStatus.CREATED, True, '000912'),
+    ('Duplicate/already added request', [MHR_ROLE], HTTPStatus.CONFLICT, True, '000912'),
     ('Invalid MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXX'),
-    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '077741')
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '000912')
 ]
 TEST_DELETE_DATA = [
-    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '045349'),
-    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '045349'),
-    ('Valid request', [MHR_ROLE], HTTPStatus.NO_CONTENT, True, '045349'),
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, False, '000910'),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, True, '000910'),
+    ('Valid request extra', [MHR_ROLE], HTTPStatus.NO_CONTENT, True, '000910'),
     ('Invalid non-existent MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, 'TESTXX'),
     ('Invalid not added MHR number', [MHR_ROLE], HTTPStatus.NOT_FOUND, True, '077741'),
-    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '045349')
+    ('Invalid request staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, '000910')
 ]
-
 
 @pytest.mark.parametrize('desc,roles,status,has_account, identifier, is_mhr', TEST_GET_DATA)
 def test_get_mhr_summary(session, client, jwt, desc, roles, status, has_account, identifier, is_mhr):
@@ -96,7 +95,9 @@ def test_post_other_account_reg(session, client, jwt, desc, roles, status, has_a
     """Assert that adding another account's registration to the current account list works as expected."""
     headers = None
     # setup
-    if has_account:
+    if desc == 'Valid request extra':
+        headers = create_header_account(jwt, roles, 'test-user', 'PS99999')
+    elif has_account:
         headers = create_header_account(jwt, roles)
     else:
         headers = create_header(jwt, roles)

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -138,14 +138,14 @@ TEST_CREATE_MANUFACTURER_DATA = [
 ]
 # testdata pattern is ({description}, {roles}, {status}, {account}, {mhr_num})
 TEST_GET_REGISTRATION = [
-    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, None, '150062'),
-    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, '2523', '150062'),
-    ('Valid Request', [MHR_ROLE], HTTPStatus.OK, '2523', '150062'),
-    ('Valid Request reg staff', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, STAFF_ROLE, '150062'),
-    ('Valid Request bcol helpdesk', [MHR_ROLE, BCOL_HELP], HTTPStatus.OK, ASSETS_HELP, '150062'),
-    ('Valid Request other account', [MHR_ROLE], HTTPStatus.OK, 'PS12345', '150062'),
-    ('Invalid MHR Number', [MHR_ROLE], HTTPStatus.NOT_FOUND, '2523', 'TESTXXXX'),
-    ('Invalid request Staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, None, '150062')
+    ('Missing account', [MHR_ROLE], HTTPStatus.BAD_REQUEST, None, '000900'),
+    ('Invalid role', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345', '000900'),
+    ('Valid Request', [MHR_ROLE], HTTPStatus.OK, 'PS12345', '000900'),
+    ('Valid Request reg staff', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, STAFF_ROLE, '000900'),
+    ('Valid Request bcol helpdesk', [MHR_ROLE, BCOL_HELP], HTTPStatus.OK, ASSETS_HELP, '000900'),
+    ('Valid Request other account', [MHR_ROLE], HTTPStatus.OK, 'PS12345', '000900'),
+    ('Invalid MHR Number', [MHR_ROLE], HTTPStatus.NOT_FOUND, 'PS12345', 'TESTXXXX'),
+    ('Invalid request Staff no account', [MHR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, None, '000900')
 ]
 # testdata pattern is ({description}, {start_ts}, {end_ts}, {status}, {has_key}, {download_link})
 TEST_BATCH_MANUFACTURER_MHREG_DATA = [
@@ -173,24 +173,24 @@ TEST_GET_ACCOUNT_DATA_SORT = [
 ]
 # testdata pattern is ({desc}, {roles}, {status}, {filter_name}, {filter_value})
 TEST_GET_ACCOUNT_DATA_FILTER = [
-    ('Filter mhr number', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.MHR_NUMBER_PARAM, '098487'),
-    ('Filter reg type', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM, 'REGISTER NEW UNIT'),
-    ('Filter reg status', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.STATUS_PARAM, 'ACTIVE'),
-    ('Filter client ref', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.CLIENT_REF_PARAM, 'a000873'),
-    ('Filter user name', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.USER_NAME_PARAM, 'BCREG2'),
-    ('Filter submitting bus name', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
-     'champion'),
-    ('Filter submitting last name', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
+    ('Filter mhr number', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.MHR_NUMBER_PARAM, '000930'),
+    ('Filter reg type', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM, 'REGISTER NEW UNIT'),
+    ('Filter reg status', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.STATUS_PARAM, 'EXEMPT'),
+    ('Filter client ref', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.CLIENT_REF_PARAM, 'UT-0029'),
+    ('Filter user name', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.USER_NAME_PARAM, 'TEST USER'),
+    ('Filter submitting bus name', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
+     'real engineered'),
+    ('Filter submitting last name', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
      'iverson'),
-    ('Filter submitting first name', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
+    ('Filter submitting first name', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.SUBMITTING_NAME_PARAM,
      'donna')
 ]
 # testdata pattern is ({desc}, {roles}, {status}, {collapse}, {filter_start}, {filter_end})
 TEST_GET_ACCOUNT_DATA_FILTER_DATE = [
-    ('Filter reg date range', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, False,
-     '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53'),
-    ('Filter reg date range', '2523', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, True,
-     '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53')
+    ('Filter reg date range', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, False,
+     '2023-09-01T00:00:01-07:00', '2035-09-01T00:00:01-07:00'),
+    ('Filter reg date range', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, True,
+     '2023-09-01T00:00:01-07:00', '2035-09-01T00:00:01-07:00')
 ]
 
 
@@ -372,7 +372,8 @@ def test_get_account_registrations_filter_date(session, client, jwt, desc, accou
     headers = create_header_account(jwt, roles, 'test-user', account_id)
     start_ts: str = reg_utils.START_TS_PARAM
     end_ts: str = reg_utils.END_TS_PARAM
-    params = f'?{start_ts}={filter_start}&{end_ts}={filter_end}'
+    filter_now_end = model_utils.format_ts(model_utils.now_ts())
+    params = f'?{start_ts}={filter_start}&{end_ts}={filter_now_end}'
     if collapse:
         params += '&collapse=true'
     # test

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -221,24 +221,23 @@ ADMIN_REGISTRATION = {
   }
 }
 FROZEN_LIST = [
-    {'mhrNumber': '102605', 'documentType': 'REG_103'},
-    {'mhrNumber': '052711', 'documentType': 'REST'}
+    {'mhrNumber': '000926', 'documentType': 'REG_103'},
+    {'mhrNumber': '000915', 'documentType': 'REST'}
 ]
 # testdata pattern is ({account_id}, {mhr_num}, {exists}, {reg_description}, {in_list})
 TEST_SUMMARY_REG_DATA = [
-#    ('PS12345', '077741', True, CONV_DESCRIPTION, False),
     ('PS12345', 'TESTXX', False, None, False),
-#    ('PS12345', '045349', True, CONV_DESCRIPTION, True),
-    ('PS12345', '000900', True, REG_DESCRIPTION, True)
+    ('PS12345', '000900', True, REG_DESCRIPTION, True),
+    ('PS99999', '000900', True, REG_DESCRIPTION, False)
 ]
 # testdata pattern is ({account_id}, {doc_reg_num}, {mhr_number}, {result_count}, {reg_desc}, {in_list})
 TEST_SUMMARY_DOC_REG_DATA = [
-    ('PS12345', '077741', '077741', 3, CONV_DESCRIPTION, False),
     ('PS12345', 'TESTXX', None, 0, None, False),
-    ('PS12345', '00045349', '045349', 3, CONV_DESCRIPTION, True),
-    ('PS12345', '009301', '009301', 1, CONV_DESCRIPTION, False),
-    ('ppr_staff', '196123', '087219', 5, REG_DESCRIPTION, False),
-    ('ppr_staff', '221961', '087219', 5, REG_DESCRIPTION, False)
+    ('PS12345', '90499043', '000930', 2, REG_DESCRIPTION, True),
+    ('PS12345', '90499044', '000930', 2, REG_DESCRIPTION, True),
+    ('PS12345', '90499042', '000929', 1, REG_DESCRIPTION, True),
+    ('ppr_staff', '90499043', '000930', 2, REG_DESCRIPTION, False),
+    ('ppr_staff', '90499042', '000929', 1, REG_DESCRIPTION, False)
 ]
 # testdata pattern is ({account_id}, {has_results})
 TEST_ACCOUNT_REG_DATA = [
@@ -332,7 +331,7 @@ TEST_DATA_LTSA_PID = [
 # testdata pattern is ({mhr_num}, {account_id}, {status}, {staff}, {doc_type})
 TEST_DATA_STATUS = [
     ('000917', 'PS12345', 'FROZEN', True, 'AFFE'),  # 003936
-#    ('003304', 'PS12345', 'ACTIVE', True, 'AFFE'),  # 003304
+#    ('003304', 'PS12345', 'ACTIVE', True, 'AFFE'),  # 003304 TRAN->AFFE->TRAN
     ('000914', 'PS12345', 'FROZEN', True, 'TAXN'),  # 022873
     ('000914', 'PS12345', 'FROZEN', False, 'TAXN'),
     ('000915', 'PS12345', 'FROZEN', True, 'REST'),  # 052711
@@ -344,13 +343,12 @@ TEST_DATA_STATUS = [
 ]
 # testdata pattern is ({mhr_num}, {staff}, {current}, {has_notes}, {account_id}, {has_caution}, {ncan_doc_id})
 TEST_MHR_NUM_DATA_NOTE = [
-    ('000926', True, True, True, 'PS12345', False, None),  # Expired permit 080282 
-#    ('000926', False, True, False, 'PS12345', False, None),
+    ('000930', True, True, True, 'PS12345', False, None),  # Expired permit
+    ('000930', False, True, False, 'PS12345', False, None),
     ('000900', True, True, False, 'PS12345', False, None),
     ('000900', True, False, False, 'PS12345', False, None),
     ('000900', False, True, False, 'PS12345', False, None),
     ('000916', True, True, True, 'PS12345', True, None),
-#    ('080104', True, True, True, 'PS12345', True, None),
     ('000914', True, True, True, 'PS12345', False, None),
     ('000909', True, True, True, 'PS12345', False, 'UT000012'),
     ('000909', False, True, True, 'PS12345', False, 'UT000012'),
@@ -585,7 +583,7 @@ def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, ac
     assert reg_json.get('hasCaution') == has_caution
     # search version
     reg_json = registration.registration_json
-    if has_notes and mhr_num != '000926':
+    if has_notes and mhr_num != '000930':
         assert reg_json.get('notes')
         has_ncan: bool = False
         for note in reg_json.get('notes'):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14551

*Description of changes:*
- PostgreSQL queries for adding, getting individual registration summary information when adding from another account. 
- PostgreSQL queries for sorting and filtering account registration summary information. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
