### PR TITLE
Minor updates to existing registration types.

### DIFF
--- a/mhr_api/report-templates/template-parts/search-result/notes.html
+++ b/mhr_api/report-templates/template-parts/search-result/notes.html
@@ -24,7 +24,7 @@
                 </tr>
                 {% if note.documentType not in ('EXRS', 'EXNR') %}                
                 <tr>
-                    <td class="section-sub-title">Effective Date and Time:</td>
+                    <td class="section-sub-title">Effective Date:</td>
                     <td>
                         {% if note.effectiveDateTime is defined and note.effectiveDateTime != '' %}
                             {{note.effectiveDateTime}}

--- a/mhr_api/report-templates/unitNoteV2.html
+++ b/mhr_api/report-templates/unitNoteV2.html
@@ -31,9 +31,9 @@
       <tr>
         <td>
             {% if note is defined and note.documentType is defined and note.documentType in ('NCAN', 'NRED') %}
-                Cancelled Date and Time:
+                Cancelled Date:
             {% else %}
-               Effective Date and Time:
+               Effective Date:
             {% endif %}
         </td>
         <td>

--- a/mhr_api/src/mhr_api/models/mhr_note.py
+++ b/mhr_api/src/mhr_api/models/mhr_note.py
@@ -170,11 +170,11 @@ class MhrNote(db.Model):  # pylint: disable=too-many-instance-attributes
         if reg_json.get('remarks'):
             note.remarks = reg_json['remarks']
         if reg_json.get('effectiveDateTime'):
-            note.effective_ts = model_utils.ts_from_iso_format(reg_json['effectiveDateTime'])
+            note.effective_ts = model_utils.start_of_day_datetime(reg_json['effectiveDateTime'])
         else:
             note.effective_ts = registration_ts
         if note.document_type == MhrDocumentTypes.CAU:  # Compute expiry date.
-            note.expiry_date = model_utils.compute_caution_expiry(note.effective_ts, True)
+            note.expiry_date = model_utils.compute_caution_expiry(registration_ts, True)
         elif reg_json.get('expiryDateTime'):
             note.expiry_date = model_utils.expiry_datetime(reg_json['expiryDateTime'])
             if note.document_type == MhrDocumentTypes.EXNR:

--- a/mhr_api/src/mhr_api/models/queries.py
+++ b/mhr_api/src/mhr_api/models/queries.py
@@ -48,6 +48,11 @@ SELECT COUNT(base_registration_num)
   FROM mhr_lien_check_vw
  WHERE mhr_number = :query_value
 """
+QUERY_PPR_REGISTRATION_TYPE = """
+SELECT DISTINCT registration_type
+  FROM mhr_lien_check_vw
+ WHERE mhr_number = :query_value
+"""
 QUERY_PERMIT_COUNT = """
 SELECT COUNT(r.id) AS permit_count
   FROM mhr_registrations r, mhr_parties p

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -36,6 +36,7 @@ from mhr_api.models.queries import (
     QUERY_BATCH_MANUFACTURER_MHREG,
     UPDATE_BATCH_REG_REPORT,
     QUERY_PPR_LIEN_COUNT,
+    QUERY_PPR_REGISTRATION_TYPE,
     QUERY_PERMIT_COUNT,
     QUERY_PKEYS,
     QUERY_PKEYS_NO_DRAFT,
@@ -213,6 +214,22 @@ def get_ppr_lien_count(mhr_number: str) -> int:
         return lien_count
     except Exception as db_exception:   # noqa: B902; return nicer error
         current_app.logger.error('get_ppr_lien_count exception: ' + str(db_exception))
+        raise DatabaseException(db_exception)
+
+
+def get_ppr_registration_type(mhr_number: str) -> str:
+    """Execute a query to get the existing PPR registration type on the MH (must not exist check)."""
+    try:
+        reg_type: str = None
+        query = text(QUERY_PPR_REGISTRATION_TYPE)
+        result = db.session.execute(query, {'query_value': mhr_number})
+        if result:
+            row = result.first()
+            if row:
+                reg_type = str(row[0]) if row[0] else None
+        return reg_type
+    except Exception as db_exception:   # noqa: B902; return nicer error
+        current_app.logger.error('get_ppr_registration_type exception: ' + str(db_exception))
         raise DatabaseException(db_exception)
 
 

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -769,20 +769,20 @@ def search_ts(date_iso: str, start: bool = True):
     return _datetime.combine(date_part, day_time)
 
 
-def compute_caution_expiry(effective_ts, end_of_day: bool = False):
+def compute_caution_expiry(registration_ts, end_of_day: bool = False):
     """For Notice of Caution add 90 days to the effective timestamp."""
-    if effective_ts and not end_of_day:
-        return effective_ts + datedelta(days=90)
-    if effective_ts:
-        base_date = date(effective_ts.year, effective_ts.month, effective_ts.day)
+    if registration_ts and not end_of_day:
+        return registration_ts + datedelta(months=3)
+    if registration_ts:
+        base_date = date(registration_ts.year, registration_ts.month, registration_ts.day)
         # Naive time
         expiry_time = time(23, 59, 59, tzinfo=None)
-        future_ts = _datetime.combine(base_date, expiry_time) + timedelta(days=90)
+        future_ts = _datetime.combine(base_date, expiry_time) + datedelta(months=3)
         # Explicitly set to local timezone which will adjust for daylight savings.
         local_ts = LOCAL_TZ.localize(future_ts)
         # Return as UTC
         return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)
-    return effective_ts
+    return registration_ts
 
 
 def expiry_datetime(expiry_iso: str):

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -528,7 +528,7 @@ class Report:  # pylint: disable=too-few-public-methods
                             phone = note['givingNoticeParty'].get('phoneNumber')
                             note['givingNoticeParty']['phoneNumber'] = phone[0:3] + '-' + phone[3:6] + '-' + phone[6:]
                         if note.get('effectiveDateTime'):
-                            note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'))
+                            note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'), False)
                         if note.get('remarks'):
                             remarks: str = note.get('remarks')
                             if remarks.find('\n') >= 0:
@@ -545,7 +545,7 @@ class Report:  # pylint: disable=too-few-public-methods
             elif note.get('expiryDateTime'):
                 note['expiryDateTime'] = Report._to_report_datetime(note.get('expiryDateTime'), False)
             if note.get('effectiveDateTime'):
-                note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'))
+                note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'), False)
             if note.get('givingNoticeParty') and note['givingNoticeParty'].get('phoneNumber'):
                 phone = note['givingNoticeParty'].get('phoneNumber')
                 note['givingNoticeParty']['phoneNumber'] = phone[0:3] + '-' + phone[3:6] + '-' + phone[6:]

--- a/mhr_api/src/mhr_api/utils/admin_validator.py
+++ b/mhr_api/src/mhr_api/utils/admin_validator.py
@@ -50,8 +50,6 @@ def validate_admin_reg(registration: MhrRegistration, json_data) -> str:
     error_msg: str = ''
     try:
         current_app.logger.info('Validating staff admin registration')
-        if registration:
-            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
         error_msg += validate_doc_id(json_data)  # Initially required for all document types.
         error_msg += validator_utils.validate_submitting_party(json_data)
         doc_type: str = json_data.get('documentType', '')

--- a/mhr_api/src/mhr_api/utils/note_validator.py
+++ b/mhr_api/src/mhr_api/utils/note_validator.py
@@ -47,7 +47,7 @@ def validate_note(registration: MhrRegistration, json_data, staff: bool = False,
     error_msg: str = ''
     try:
         current_app.logger.info(f'Validating unit note registration staff={staff}, group={group_name}')
-        if registration:
+        if not staff and registration:
             error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
         error_msg += validate_doc_id(json_data)
         error_msg += validator_utils.validate_submitting_party(json_data)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.6'  # pylint: disable=invalid-name
+__version__ = '1.5.7'  # pylint: disable=invalid-name

--- a/mhr_api/test_data/db2_data_files/test0005.sql
+++ b/mhr_api/test_data/db2_data_files/test0005.sql
@@ -223,3 +223,56 @@ UPDATE amhrtdb.location
    SET status = 'H', candocid = 'UT000044'
  WHERE regdocid = 'UT000043'
 ;
+-- UT-0032 000931 Non-manufacturer registration with active transport permit registration.
+INSERT INTO amhrtdb.manuhome(MANHOMID, MHREGNUM, MHSTATUS, REGDOCID, UPDATECT, UPDATEID, UPDATEDA, UPDATETI)
+     VALUES (200000045, '000931', 'R', 'UT000045', 1, 'PS12345 ', current date, current time)
+;
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000045', '000931', current timestamp, current timestamp, '101 ', '90499045', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0032                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0032')
+;
+INSERT INTO amhrtdb.descript(MANHOMID, DESCRNID, STATUS, REGDOCID, CSANUMBR, CSASTAND, NUMBSECT, YEARMADE,
+                             SERNUMB1, LENGTH1, LENGIN1, WIDTH1, WIDIN1,
+                             MANUNAME, MAKEMODL, REBUILTR, OTHERREM, ENGIDATE)
+     VALUES (200000045, 1, 'A', 'UT000045', '77777', '1234', 1, '2000', '888888', 60, 10, 14, 11,
+             'REAL ENGINEERED HOMES INC', 'make model', 'rebuilt', 'other', TO_DATE('0001-01-01', 'YYYY-MM-DD'))
+;
+INSERT INTO amhrtdb.location(MANHOMID, LOCATNID, STATUS, REGDOCID, STNUMBER, STNAME, TOWNCITY, PROVINCE, MAHPNAME,
+                             MAHPPAD, PIDNUMB, TAXCERT, TAXDATE, MHDEALER)
+     VALUES (200000045, 1, 'A', 'UT000045', '1234', 'TEST-0032', 'CITY', 'BC', '', '', '', 'N',
+             TO_DATE('0001-01-01', 'YYYY-MM-DD'), '')
+;
+INSERT INTO amhrtdb.owngroup(MANHOMID, OWNGRPID, COPGRPID, GRPSEQNO, STATUS, REGDOCID, TENYTYPE, INTEREST, INTNUMER, TENYSPEC)
+     VALUES (200000045, 1, 0, 1, '3', 'UT000045', 'SO', '', 0, 'Y')
+;
+INSERT INTO amhrtdb.owner(MANHOMID, OWNGRPID, OWNERID, OWNSEQNO, VERIFIED, OWNRTYPE, COMPNAME, OWNRFONE, OWNRPOCO, OWNRNAME, OWNRSUFF, OWNRADDR)
+     VALUES (200000045, 1, 1, 1, ' ', 'B', 'TESTACTIVEPERMIT', '6041234567', 'V8R 3A5', 'TEST ACTIVE PERMIT', '',
+             '1234 TEST-0032                          CITY                                    BC CA')
+;
+INSERT INTO amhrtdb.cmpserno(MANHOMID, CMPSERID, SERIALNO)
+     VALUES (200000045, 1, (SELECT serialno FROM amhrtdb.cmpserno WHERE manhomid = 40865 AND CMPSERID = 1))
+;
+-- Active transport permit registration
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000046', '000931', current timestamp, current timestamp, '103 ', '90499046', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0032                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0032')
+;
+INSERT INTO amhrtdb.location(MANHOMID, LOCATNID, STATUS, REGDOCID, STNUMBER, STNAME, TOWNCITY, PROVINCE, MAHPNAME,
+                             MAHPPAD, PIDNUMB, TAXCERT, TAXDATE)
+     VALUES (200000045, 2, 'A', 'UT000046', '1234', 'TEST-0032', 'CITY', 'BC', '', '', '', 'N',
+             TO_DATE('0001-01-01', 'YYYY-MM-DD'))
+;
+INSERT INTO amhrtdb.mhomnote(MANHOMID, MHNOTEID, MHNOTENO, REGDOCID, CANDOCID, DOCUTYPE, STATUS, DESTROYD, EXPIRYDA, PHONE, NAME, ADDRESS, REMARKS)
+     VALUES (200000045, 1, 1, 'UT000046', '', '103 ', 'A', '', current date + 30 days, '6041234567', 
+             'PERSON GIVING NOTICE', 
+             '1234 TEST-0032                                                                  CITY                                    BC CA                            V8R 3A5', 
+             '')
+;
+UPDATE amhrtdb.location
+   SET status = 'H', candocid = 'UT000046'
+ WHERE regdocid = 'UT000045'
+;

--- a/mhr_api/test_data/postgres_data_files/test0007.sql
+++ b/mhr_api/test_data/postgres_data_files/test0007.sql
@@ -4,6 +4,7 @@
 -- UT-0029 000928 EXEMPT non-residential MH registration
 -- UT-0030 000929 COMMON registration 1 ADMINISTRATOR.
 -- UT-0031 000930 Registration with expired transport permit registration.
+-- UT-0032 000931 Non-manufacturer registration with active transport permit registration.
 
 -- UT-0027 000926 Manufacturer registration with existing transport permit registration.
 INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
@@ -406,6 +407,106 @@ INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_ty
 UPDATE mhr_locations
    SET status_type = 'HISTORICAL', change_registration_id = 200000044
  WHERE id = 200000043
+;
+-- UT-0032 000931 Non-manufacturer registration with active transport permit registration.
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000045, '000931', 'PS12345', 'MHREG', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0032')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000122, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000104, 'SUBMITTING', 'ACTIVE', 200000045, 200000045, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000122, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000123, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_locations(id, location_type, status_type, registration_id, change_registration_id, address_id, ltsa_description, 
+                        additional_description, dealer_name, exception_plan, leave_province, tax_certification, tax_certification_date, 
+                        park_name, park_pad, pid_number, lot, parcel, block, district_lot, part_of, section,
+                        township, range, meridian, land_district, plan)
+    VALUES(200000045, 'OTHER', 'ACTIVE', 200000045, 200000045, 190000123,
+           NULL, 'additional', NULL, NULL, 'N', 'Y', now() at time zone 'UTC', NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+;
+INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_standard, number_of_sections, 
+                          square_feet, year_made, circa, engineer_date, engineer_name, manufacturer_name,
+                          make, model, rebuilt_remarks, other_remarks, change_registration_id)
+    VALUES(200000045, 'ACTIVE', 200000045, '7777700000', '1234', 3, NULL, 2015, 'Y', now() at time zone 'UTC',
+           'engineer name', 'REAL ENGINEERED HOMES INC', 'make', 'model', 'rebuilt', 'other', 200000045)
+;
+INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
+                               width_feet, width_inches, change_registration_id)
+    VALUES(200000043, 200000045, 'ACTIVE', mhr_serial_compressed_key('888888'), '888888', 60, 10, 14, 11,
+           200000045)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000045, 'REG_101', 200000045, 'UT000045', '90499045', 'attn', NULL, NULL, 'Y', null, null, null, 200000045)
+;
+INSERT INTO mhr_owner_groups(id, sequence_number, registration_id, status_type, tenancy_type, interest,
+                             tenancy_specified, interest_numerator, interest_denominator, change_registration_id)
+    VALUES(200000041, 1, 200000045, 'ACTIVE', 'SOLE', NULL, 'Y', NULL, NULL, 200000045)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000124, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000105, 'OWNER_BUS', 'ACTIVE', 200000045, 200000045, null, null, null, 'TEST ACTIVE PERMIT', 
+           mhr_name_compressed_key('TEST ACTIVE PERMIT'), 190000124, null, '6041234567', null, 200000041)
+;
+-- Active transport permit registration
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000046, '000931', 'PS12345', 'PERMIT', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0032')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000125, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000106, 'SUBMITTING', 'ACTIVE', 200000046, 200000046, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000125, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000126, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_locations(id, location_type, status_type, registration_id, change_registration_id, address_id, ltsa_description, 
+                        additional_description, dealer_name, exception_plan, leave_province, tax_certification, tax_certification_date, 
+                        park_name, park_pad, pid_number, lot, parcel, block, district_lot, part_of, section,
+                        township, range, meridian, land_district, plan)
+    VALUES(200000046, 'OTHER', 'ACTIVE', 200000046, 200000046, 190000126,
+           NULL, 'additional', NULL, NULL, 'N', 'Y', now() at time zone 'UTC', NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000046, 'REG_103', 200000046, 'UT000046', '90499046', 'attn', NULL, NULL, 'Y', null, null, null, 200000046)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000127, '1234 TEST-0032', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000107, 'CONTACT', 'ACTIVE', 200000046, 200000046, null, null, null, 'PERSON GIVING NOTICE',
+           mhr_name_compressed_key('PERSON GIVING NOTICE'), 190000127, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_type, remarks, destroyed,
+                      change_registration_id, expiry_date, effective_ts)
+    VALUES(200000033, 'REG_103', 200000046, 200000046, 'ACTIVE', null, 'N', 200000046,
+           (now() at time zone 'UTC') + interval '30 days', now() at time zone 'UTC')
+;
+UPDATE mhr_locations
+   SET status_type = 'HISTORICAL', change_registration_id = 200000046
+ WHERE id = 200000045
 ;
 
 

--- a/mhr_api/tests/unit/api/test_exemptions.py
+++ b/mhr_api/tests/unit/api/test_exemptions.py
@@ -37,24 +37,23 @@ QUALIFIED_USER = [MHR_ROLE, REQUEST_EXEMPTION_NON_RES, REQUEST_EXEMPTION_RES, TR
 DOC_ID_VALID = '63166035'
 # testdata pattern is ({description}, {mhr_num}, {roles}, {status}, {account})
 TEST_CREATE_DATA = [
-    ('Invalid schema validation missing submitting', '000900', [MHR_ROLE, REQUEST_EXEMPTION_RES],
+    ('Invalid schema validation missing submitting', '000916', [MHR_ROLE, REQUEST_EXEMPTION_RES],
      HTTPStatus.BAD_REQUEST, 'PS12345'),
-    ('Missing account', '000900', [MHR_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.BAD_REQUEST, None),
-    ('Staff missing account', '000900', [MHR_ROLE, STAFF_ROLE, REQUEST_EXEMPTION_RES],
+    ('Missing account', '000916', [MHR_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.BAD_REQUEST, None),
+    ('Staff missing account', '000916', [MHR_ROLE, STAFF_ROLE, REQUEST_EXEMPTION_RES],
      HTTPStatus.BAD_REQUEST, None),
-    ('Invalid role product', '000900', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345'),
-    ('Invalid non-exemption role', '000900', [MHR_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345'),
-    ('Valid staff', '000900', [MHR_ROLE, STAFF_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.CREATED, 'PS12345'),
-    ('Valid non-staff legacy', '000900', QUALIFIED_USER, HTTPStatus.CREATED, 'PS12345'),
-    ('Valid non-staff new', '000900', QUALIFIED_USER, HTTPStatus.CREATED, 'PS12345'),
+    ('Invalid role product', '000916', [COLIN_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345'),
+    ('Invalid non-exemption role', '000916', [MHR_ROLE], HTTPStatus.UNAUTHORIZED, 'PS12345'),
+    ('Valid staff', '000916', [MHR_ROLE, STAFF_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.CREATED, 'PS12345'),
+    ('Valid non-staff', '000916', QUALIFIED_USER, HTTPStatus.CREATED, 'PS12345'),
     ('Invalid mhr num', '300655', [MHR_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.UNAUTHORIZED, 'PS12345'),
     ('Invalid exempt', '000912', [MHR_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.BAD_REQUEST, 'PS12345'),
     ('Invalid historical', '000913', [MHR_ROLE, REQUEST_EXEMPTION_RES], HTTPStatus.BAD_REQUEST, 'PS12345'),
-    ('Valid missing note remarks', '000900', [MHR_ROLE, REQUEST_EXEMPTION_NON_RES, REQUEST_EXEMPTION_RES],
+    ('Valid missing note remarks', '000916', [MHR_ROLE, REQUEST_EXEMPTION_NON_RES, REQUEST_EXEMPTION_RES],
      HTTPStatus.CREATED, 'PS12345')
 ]
 TEST_CREATE_DATA_1 = [
-    ('Valid non-staff new', '000900', QUALIFIED_USER, HTTPStatus.CREATED, 'PS12345')
+    ('Valid non-staff new', '000916', QUALIFIED_USER, HTTPStatus.CREATED, 'PS12345')
 ]
 
 

--- a/mhr_api/tests/unit/api/test_permits.py
+++ b/mhr_api/tests/unit/api/test_permits.py
@@ -89,6 +89,7 @@ PERMIT = {
 }
 MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+DOC_ID_VALID = '63166035'
 
 # testdata pattern is ({description}, {mhr_num}, {roles}, {status}, {account})
 TEST_CREATE_DATA = [
@@ -114,7 +115,10 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
     current_app.config.update(AUTH_SVC_URL=MOCK_AUTH_URL)
     headers = None
     json_data = copy.deepcopy(PERMIT)
-    del json_data['documentId']
+    if STAFF_ROLE in roles:
+        json_data['documentId'] = DOC_ID_VALID
+    else:
+        del json_data['documentId']
     json_data['mhrNumber'] = mhr_num
     if desc == 'Invalid schema validation missing submitting':
         del json_data['submittingParty']

--- a/mhr_api/tests/unit/api/test_transfers.py
+++ b/mhr_api/tests/unit/api/test_transfers.py
@@ -41,6 +41,7 @@ from tests.unit.utils.test_transfer_data import (
 
 MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+DOC_ID_VALID = '63166035'
 
 
 # testdata pattern is ({description}, {mhr_num}, {roles}, {status}, {account})
@@ -91,7 +92,10 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
     current_app.config.update(AUTH_SVC_URL=MOCK_AUTH_URL)
     headers = None
     json_data = copy.deepcopy(TRANSFER)
-    del json_data['documentId']
+    if STAFF_ROLE in roles:
+        json_data['documentId'] = DOC_ID_VALID
+    else:
+        del json_data['documentId']
     del json_data['documentDescription']
     del json_data['createDateTime']
     del json_data['payment']
@@ -136,7 +140,10 @@ def test_create_transfer_death(session, client, jwt, desc, mhr_num, roles, statu
     current_app.config.update(AUTH_SVC_URL=MOCK_AUTH_URL)
     headers = None
     json_data = copy.deepcopy(TRANSFER)
-    del json_data['documentId']
+    if STAFF_ROLE in roles:
+        json_data['documentId'] = DOC_ID_VALID
+    else:
+        del json_data['documentId']
     del json_data['documentDescription']
     del json_data['createDateTime']
     del json_data['payment']

--- a/mhr_api/tests/unit/models/test_registration_utils.py
+++ b/mhr_api/tests/unit/models/test_registration_utils.py
@@ -33,6 +33,10 @@ TEST_DATA_MANUFACTURER_MHREG_UPDATE = [
     ('2023-05-25T07:01:00+00:00', '2023-05-26T07:01:00+00:00'),
     (None, None)
 ]
+# testdata pattern is ({description}, {mhr_number}, {ppr_reg_type})
+TEST_DATA_PPR_REG_TYPE = [
+    ('Valid request no lien', '100000', None)
+]
 
 
 @pytest.mark.parametrize('start_ts,end_ts', TEST_DATA_MANUFACTURER_MHREG)
@@ -66,3 +70,9 @@ def test_update_manufacturer_reg_report_batch_url(session, start_ts, end_ts):
         update_count: int = reg_utils.update_reg_report_batch_url(results_json, batch_url)
         assert update_count > 0
 
+
+@pytest.mark.parametrize('desc, mhr_number, ppr_reg_type', TEST_DATA_PPR_REG_TYPE)
+def test_validate_ppr_reg_type(session, desc, mhr_number, ppr_reg_type):
+    """Assert that the PPR reg type query works as expected."""
+    reg_type = reg_utils.get_ppr_registration_type(mhr_number)
+    assert reg_type == ppr_reg_type

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -332,8 +332,9 @@ TEST_LOCATION_DATA = [
 ]
 # test data pattern is ({description}, {valid}, {staff}, {doc_id}, {message_content}, {mhr_num}, {account}, {group})
 TEST_PERMIT_DATA = [
-    (DESC_VALID, True, True, None, None, '000900', 'PS12345', STAFF_ROLE),
+    (DESC_VALID, True, True, DOC_ID_VALID, None, '000900', 'PS12345', STAFF_ROLE),
     ('Valid no doc id not staff', True, False, None, None, '000900', 'PS12345', REQUEST_TRANSPORT_PERMIT),
+    ('Invalid no doc id staff', False, True, None, validator_utils.DOC_ID_REQUIRED, '000900', 'PS12345', STAFF_ROLE),
     ('Invalid FROZEN', False, False, None, validator_utils.STATE_NOT_ALLOWED, '000917', 'PS12345',
      REQUEST_TRANSPORT_PERMIT),
     ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_NOTE, '000914', 'PS12345',
@@ -342,9 +343,9 @@ TEST_PERMIT_DATA = [
      REQUEST_TRANSPORT_PERMIT),
     ('Invalid FROZEN NCON', False, False, None, validator_utils.STATE_FROZEN_NOTE, '000918', 'PS12345',
      REQUEST_TRANSPORT_PERMIT),
-    ('Invalid staff FROZEN', False, True, None, validator_utils.STATE_FROZEN_AFFIDAVIT, '000917', 'PS12345',
-     REQUEST_TRANSPORT_PERMIT),
-    ('Invalid EXEMPT', False, False, None, validator_utils.STATE_NOT_ALLOWED, '000912', 'PS12345', STAFF_ROLE),
+    ('Invalid staff FROZEN', False, True, DOC_ID_VALID, validator_utils.STATE_FROZEN_AFFIDAVIT, '000917', 'PS12345',
+     STAFF_ROLE),
+    ('Invalid EXEMPT', False, False, DOC_ID_VALID, validator_utils.STATE_NOT_ALLOWED, '000912', 'PS12345', STAFF_ROLE),
     ('Invalid CANCELLED', False, False, None, validator_utils.STATE_NOT_ALLOWED, '000913', 'PS12345',
      REQUEST_TRANSPORT_PERMIT)
 ]
@@ -391,9 +392,9 @@ def test_validate_permit(session, desc, valid, staff, doc_id, message_content, m
     """Assert that basic MH transport permit validation works as expected."""
     # setup
     json_data = get_valid_registration()
-    if staff and doc_id:
+    if doc_id:
         json_data['documentId'] = doc_id
-    elif json_data.get('documentId'):
+    else:
         del json_data['documentId']
     # current_app.logger.info(json_data)
     valid_format, errors = schema_utils.validate(json_data, 'permit', 'mhr')
@@ -476,8 +477,6 @@ def test_validate_pid(session, desc, pid, valid, message_content):
     """Assert that basic MH transport permit validation works as expected."""
     # setup
     json_data = get_valid_registration()
-    if json_data.get('documentId'):
-        del json_data['documentId']
     json_data['newLocation'] = copy.deepcopy(LOCATION_PID)
     json_data['newLocation']['pidNumber'] = pid
     # current_app.logger.info(json_data)
@@ -507,4 +506,5 @@ def test_permit_count(session, mhr_number, name, count):
 def get_valid_registration():
     """Build a valid registration"""
     json_data = copy.deepcopy(PERMIT)
+    json_data['documentId'] = DOC_ID_VALID
     return json_data

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -242,23 +242,27 @@ TEST_LOCATION_DATA_OTHER = [
 ]
 # testdata pattern is ({description}, {valid}, {staff}, {doc_id}, {message content}, {account_id}, {mhr_num})
 TEST_EXEMPTION_DATA = [
-    (DESC_VALID, True, True, DOC_ID_VALID, None, 'PS12345', '000900'),
-    ('Valid no doc id not staff', True, False, None, None, 'PS12345', '000900'),
-    ('Valid staff PERMIT', True, True, DOC_ID_VALID, None, 'PS12345', '000926'),
+    (DESC_VALID, True, True, DOC_ID_VALID, None, 'PS12345', '000916'),
+    ('Valid no doc id not staff', True, False, None, None, 'PS12345', '000916'),
+    ('Valid staff PERMIT', True, True, DOC_ID_VALID, None, 'PS12345', '000931'),
+    ('Invalid no doc id staff', False, True, None, validator_utils.DOC_ID_REQUIRED, 'PS12345', '000916'),
     ('Invalid EXEMPT', False, False, None, validator_utils.EXEMPT_EXRS_INVALID, 'PS12345', '000912'),
     ('Invalid CANCELLED', False, False, None, validator_utils.STATE_NOT_ALLOWED, 'PS12345', '000913'),
     ('Invalid note doc type', False, False, None, validator.NOTE_DOC_TYPE_INVALID, 'PS12345', '000900'),
     ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000914'),
     ('Invalid FROZEN NCON', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000918'),
     ('Invalid FROZEN REST', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000915'),
-    ('Invalid FROZEN PERMIT', False, False, None, validator_utils.STATE_FROZEN_PERMIT, 'PS12345', '000926')
+    ('Invalid FROZEN PERMIT', False, False, None, validator_utils.STATE_FROZEN_PERMIT, 'PS12345', '000926'),
+    ('Invalid existing location staff', False, True, DOC_ID_VALID, validator.LOCATION_NOT_ALLOWED, 'PS12345',
+     '000900'),
+    ('Invalid existing location QS', False, False, None, validator.LOCATION_NOT_ALLOWED, 'PS12345', '000900')
 ]
 # test data pattern is ({description}, {valid}, {ts_offset}, {mhr_num}, {account}, {doc_type}, {message_content})
 TEST_EXEMPTION_DATA_DESTROYED = [
-    ('Valid no date EXRS', True, None, '000900', 'PS12345', MhrDocumentTypes.EXRS, None),
-    ('Valid EXNR in the past', True, -1, '000900', 'PS12345', MhrDocumentTypes.EXNR, None),
-    ('Invalid EXRS in the past', False, -1, '000900', 'PS12345', MhrDocumentTypes.EXRS, validator.DESTROYED_EXRS),
-    ('Invalid EXNR future tommorow', False, 1, '000900', 'PS12345', MhrDocumentTypes.EXNR, validator.DESTROYED_FUTURE)
+    ('Valid no date EXRS', True, None, '000916', 'PS12345', MhrDocumentTypes.EXRS, None),
+    ('Valid EXNR in the past', True, -1, '000916', 'PS12345', MhrDocumentTypes.EXNR, None),
+    ('Invalid EXRS in the past', False, -1, '000916', 'PS12345', MhrDocumentTypes.EXRS, validator.DESTROYED_EXRS),
+    ('Invalid EXNR future tommorow', False, 1, '000916', 'PS12345', MhrDocumentTypes.EXNR, validator.DESTROYED_FUTURE)
 ]
 # test data pattern is ({description}, {valid}, {doc_type}, {mhr_num}, {account}, {message_content})
 TEST_EXEMPTION_DATA_EXEMPT = [
@@ -429,7 +433,7 @@ def test_validate_exemption(session, desc, valid, staff, doc_id, message_content
     """Assert that MH exemption validation works as expected."""
     # setup
     json_data = copy.deepcopy(EXEMPTION)
-    if staff and doc_id:
+    if doc_id:
         json_data['documentId'] = doc_id
     elif json_data.get('documentId'):
         del json_data['documentId']


### PR DESCRIPTION

*Description of changes:*
*Issue #:* /bcgov/entity#13890
- request validation changes for existing PPR registrations
- data validation changes for residential exemptions

*Issue #:* /bcgov/entity#17809
- unit note caution expiry date changes, effective timestamp changes. 

*Issue #:* /bcgov/entity#17823
- Doc id required for all staff change registrations. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
