### PR TITLE
Code cleanup for Unit Tests

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",
@@ -24593,7 +24593,7 @@
         "@vue/cli-shared-utils": "^5.0.8",
         "babel-loader": "^8.2.2",
         "thread-loader": "^3.0.0",
-        "webpack": "^5.54.0"
+        "webpack": "5.78"
       }
     },
     "@vue/cli-plugin-eslint": {
@@ -24605,7 +24605,7 @@
         "@vue/cli-shared-utils": "^5.0.8",
         "eslint-webpack-plugin": "^3.1.0",
         "globby": "^11.0.2",
-        "webpack": "^5.54.0",
+        "webpack": "5.78",
         "yorkie": "^2.0.0"
       },
       "dependencies": {
@@ -24712,7 +24712,7 @@
         "globby": "^11.0.2",
         "thread-loader": "^3.0.0",
         "ts-loader": "^9.2.5",
-        "webpack": "^5.54.0"
+        "webpack": "5.78"
       }
     },
     "@vue/cli-plugin-unit-jest": {
@@ -24794,7 +24794,7 @@
         "thread-loader": "^3.0.0",
         "vue-loader": "^17.0.0",
         "vue-style-loader": "^4.1.3",
-        "webpack": "^5.54.0",
+        "webpack": "5.78",
         "webpack-bundle-analyzer": "^4.4.0",
         "webpack-chain": "^6.5.1",
         "webpack-dev-server": "^4.7.3",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/CertifyInformation.vue
+++ b/ppr-ui/src/components/common/CertifyInformation.vue
@@ -194,7 +194,7 @@ export default defineComponent({
         } else {
           try {
             const token = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
-            const decodedToken = JSON.parse(atob(token.split('.')[1]))
+            const decodedToken = JSON.parse(atob(token?.split('.')[1]))
             if (decodedToken.firstname && decodedToken.lastname) {
               certifyInfo.legalName = decodedToken.firstname + ' ' + decodedToken.lastname
             } else if (decodedToken.name) {

--- a/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReviewDetailsTable.vue
@@ -43,7 +43,7 @@
       <template v-else>
         <h3>{{ contactInfoTitle }}</h3>
 
-        <v-simple-table class="giving-notice-party-table" data-test-id="party-info-table">
+        <v-simple-table v-if="givingNoticeParty" class="giving-notice-party-table" data-test-id="party-info-table">
           <template v-slot:default>
             <thead>
               <tr>
@@ -124,7 +124,9 @@ export default defineComponent({
           : props.unitNote.remarks
       ),
       displayFullOrBusinessName: computed((): string => {
-        if (localState.givingNoticeParty?.businessName.length > 0) { return localState.givingNoticeParty.businessName }
+        if (localState.givingNoticeParty?.businessName?.length > 0) {
+          return localState.givingNoticeParty?.businessName
+        }
         const { first, middle, last } = localState.givingNoticeParty.personName
         return [first, middle, last].filter(Boolean).join(' ')
       }),

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -116,7 +116,7 @@ export const useMhrInformation = () => {
     const { data } = await fetchMhRegistration(getMhrInformation.value.mhrNumber)
 
     // Assign frozen state when the base registration is frozen (for drafts)
-    if (data.status === MhApiStatusTypes.FROZEN) {
+    if (data?.status === MhApiStatusTypes.FROZEN) {
       await setMhrStatusType(MhApiStatusTypes.FROZEN)
     }
 

--- a/ppr-ui/src/composables/useParty.ts
+++ b/ppr-ui/src/composables/useParty.ts
@@ -62,7 +62,7 @@ export const useParty = () => {
     const isSecuredPartiesRestricted = SecuredPartyRestrictedList.includes(regType)
     const securedPartyValid = isSecuredPartiesRestricted ? securedPartyCount === 1 : securedPartyCount >= 1
 
-    const debtorValid = parties.debtors.some((debtor) => debtor.action !== ActionTypes.REMOVED)
+    const debtorValid = parties.debtors?.some((debtor) => debtor.action !== ActionTypes.REMOVED)
     const registeringPartyValid = !!parties.registeringParty
 
     return debtorValid && securedPartyValid && registeringPartyValid

--- a/ppr-ui/src/composables/useRegisteringParty.ts
+++ b/ppr-ui/src/composables/useRegisteringParty.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@/store/store'
 import { useParty } from './useParty'
 import { AddPartiesIF } from '@/interfaces'
-import { getStaffegisteringParty, getRegisteringPartyFromAuth } from '@/utils'
+import { getStaffRegisteringParty, getRegisteringPartyFromAuth } from '@/utils'
 import { storeToRefs } from 'pinia'
 
 export const useRegisteringParty = () => {
@@ -23,7 +23,7 @@ export const useRegisteringParty = () => {
     let regParty = null
     const parties: AddPartiesIF = getAddSecuredPartiesAndDebtors.value
     if (isRoleStaffBcol.value || isRoleStaffReg.value) {
-      regParty = await getStaffegisteringParty(isRoleStaffBcol.value)
+      regParty = await getStaffRegisteringParty(isRoleStaffBcol.value)
     } else if (isRoleStaffSbc.value) {
       // do nothing (keep regParty null)
     } else {

--- a/ppr-ui/src/utils/auth-helper.ts
+++ b/ppr-ui/src/utils/auth-helper.ts
@@ -51,7 +51,7 @@ export function getKeycloakRoles (): Array<string> {
   throw new Error('Error getting Keycloak roles')
 }
 
-export async function getStaffegisteringParty (isBcOnline: boolean): Promise<PartyIF> {
+export async function getStaffRegisteringParty (isBcOnline: boolean): Promise<PartyIF> {
   let partyCode = sessionStorage.getItem('PPR_STAFF_PARTY_CODE')
   if (isBcOnline) {
     partyCode = sessionStorage.getItem('BCOL_STAFF_PARTY_CODE')
@@ -74,9 +74,9 @@ export async function getStaffegisteringParty (isBcOnline: boolean): Promise<Par
 
 // Get Account Info from from auth api /api/v1/orgs/{org_id}
 export async function getAccountInfoFromAuth (): Promise<AccountInfoIF> {
-  const url = sessionStorage.getItem('AUTH_API_URL')
+  const url = sessionStorage.getItem(SessionStorageKeys.AuthApiUrl)
   const currentAccount = sessionStorage.getItem(SessionStorageKeys.CurrentAccount)
-  const accountId = JSON.parse(currentAccount).id
+  const accountId = JSON.parse(currentAccount)?.id
 
   const config = { baseURL: url, headers: { Accept: 'application/json' } }
 

--- a/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
@@ -157,19 +157,19 @@ export default defineComponent({
     CautionBox
 },
   setup () {
-    const { 
-      setStaffPayment, 
-      setMhrAttentionReference, 
-      setFolioOrReferenceNumber, 
-      setMhrRegistrationSubmittingParty 
+    const {
+      setStaffPayment,
+      setMhrAttentionReference,
+      setFolioOrReferenceNumber,
+      setMhrRegistrationSubmittingParty
     } = useStore()
-    const { 
+    const {
       getFolioOrReferenceNumber,
       getMhrAttentionReference,
-      getMhrRegistrationValidationModel, 
+      getMhrRegistrationValidationModel,
       isRoleStaffReg,
       getMhrSteps,
-      isMhrManufacturerRegistration 
+      isMhrManufacturerRegistration
     } = storeToRefs(useStore())
     const route = useRoute()
     const {

--- a/ppr-ui/tests/unit/AddCollateral.spec.ts
+++ b/ppr-ui/tests/unit/AddCollateral.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
@@ -15,7 +15,7 @@ import ButtonFooter from '@/components/common/ButtonFooter.vue'
 import AddCollateral from '@/views/newRegistration/AddCollateral.vue'
 // Local types/helpers
 import { FeeSummaryTypes } from '@/composables/fees/enums'
-import { RegistrationFlowType, RouteNames, StatementTypes, UIRegistrationTypes } from '@/enums'
+import { RegistrationFlowType, RouteNames, UIRegistrationTypes } from '@/enums'
 import { RegistrationTypes } from '@/resources'
 import { LengthTrustIF } from '@/interfaces'
 // unit test helpers/data

--- a/ppr-ui/tests/unit/AmendRegistration.spec.ts
+++ b/ppr-ui/tests/unit/AmendRegistration.spec.ts
@@ -71,7 +71,7 @@ describe('Amendment registration component', () => {
       name: RouteNames.AMEND_REGISTRATION,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((AmendRegistration as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(AmendRegistration as any, { localVue, store, router, stubs: { Affix: true }, vuetify })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })
@@ -124,13 +124,13 @@ describe('Amendment registration component', () => {
   it('processes cancel button action', async () => {
     await store.setUnsavedChanges(false)
     await nextTick()
-    await wrapper.find(StickyContainer).vm.$emit('cancel', true)
+    await wrapper.findComponent(StickyContainer).vm.$emit('cancel', true)
     expect(wrapper.vm.$route.name).toBe(RouteNames.DASHBOARD)
   })
 
   it('doesnt proceed if validation errors', async () => {
     wrapper.vm.setValidDebtor(false)
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.showInvalid).toBe(true)
   })
@@ -138,7 +138,7 @@ describe('Amendment registration component', () => {
   it('goes to the confirmation page', async () => {
     wrapper.vm.courtOrderValid = true
     await store.setAmendmentDescription('test12')
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.CONFIRM_AMENDMENT)
   })
@@ -146,13 +146,13 @@ describe('Amendment registration component', () => {
   it('does not go to the confirmation page if component open', async () => {
     wrapper.vm.debtorOpen = true
     await nextTick()
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.AMEND_REGISTRATION)
   })
 
   it('saves the draft and redirects to dashboard', async () => {
-    wrapper.find(StickyContainer).vm.$emit('back', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('back', true)
     await nextTick()
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.DASHBOARD)
@@ -170,7 +170,7 @@ describe('Amendment registration component', () => {
       action: ActionTypes.EDITED
     })
     wrapper.vm.courtOrderValid = true
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.CONFIRM_AMENDMENT)
   })

--- a/ppr-ui/tests/unit/Attention.spec.ts
+++ b/ppr-ui/tests/unit/Attention.spec.ts
@@ -1,7 +1,6 @@
 // Libraries
 import Vue, { nextTick } from 'vue'
 import Vuetify from 'vuetify'
-import { Wrapper } from '@vue/test-utils'
 
 // Components
 import { Attention, FormField } from '@/components/common'

--- a/ppr-ui/tests/unit/ButtonsStacked.spec.ts
+++ b/ppr-ui/tests/unit/ButtonsStacked.spec.ts
@@ -1,7 +1,6 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
-import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
@@ -10,7 +9,6 @@ import flushPromises from 'flush-promises'
 // Components
 import { ButtonsStacked } from '@/components/common'
 // Other
-import { RouteNames } from '@/enums'
 // unit test stuff
 import { getLastEvent } from './utils'
 

--- a/ppr-ui/tests/unit/ConfirmAmendment.spec.ts
+++ b/ppr-ui/tests/unit/ConfirmAmendment.spec.ts
@@ -51,7 +51,7 @@ describe('Confirm Amendment registration component', () => {
   sessionStorage.setItem('KEYCLOAK_TOKEN', 'token')
 
   beforeAll(async () => {
-    // Mimicks loading the data in the store in the previous step.
+    // Mimics loading the data in the store in the previous step.
     const financingStatement = mockedFinancingStatementAll
     financingStatement.baseRegistrationNumber = '123456B'
     initPprUpdateFilling(financingStatement, RegistrationFlowType.AMENDMENT)
@@ -105,7 +105,7 @@ describe('Confirm Amendment registration component', () => {
       name: RouteNames.CONFIRM_AMENDMENT,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((ConfirmAmendment as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount((ConfirmAmendment as any), { localVue, store, router, stubs: { Affix: true }, vuetify })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })

--- a/ppr-ui/tests/unit/ConfirmDischarge.spec.ts
+++ b/ppr-ui/tests/unit/ConfirmDischarge.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
@@ -22,7 +22,6 @@ import { RegisteringPartyChange } from '@/components/parties/party'
 // ppr enums/utils/etc.
 import { RegistrationFlowType, RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
-import { StateModelIF } from '@/interfaces'
 import { axios } from '@/utils/axios-ppr'
 // test mocks/data
 import mockRouter from './MockRouter'
@@ -78,7 +77,7 @@ describe('ConfirmDischarge registration view', () => {
       name: RouteNames.CONFIRM_DISCHARGE,
       query: { 'reg-num': regNum }
     })
-    wrapper = shallowMount((ConfirmDischarge as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount((ConfirmDischarge as any), { localVue, store, router, stubs: { Affix: true }, vuetify })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })

--- a/ppr-ui/tests/unit/ConfirmMHRSearch.spec.ts
+++ b/ppr-ui/tests/unit/ConfirmMHRSearch.spec.ts
@@ -1,12 +1,11 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
 
 import { createLocalVue, shallowMount } from '@vue/test-utils'
-import sinon from 'sinon'
 import flushPromises from 'flush-promises'
 // Components
 import { ConfirmMHRSearch } from '@/views'
@@ -18,7 +17,6 @@ import { BaseDialog } from '@/components/dialogs'
 // ppr enums/utils/etc.
 import { RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
-import { StateModelIF } from '@/interfaces'
 // test mocks/data
 import mockRouter from './MockRouter'
 import { SearchedResultMhr } from '@/components/tables'
@@ -48,7 +46,13 @@ describe('Confirm MHRSearch view', () => {
     await router.push({
       name: RouteNames.MHRSEARCH_CONFIRM
     })
-    wrapper = shallowMount((ConfirmMHRSearch as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(ConfirmMHRSearch as any, {
+      localVue,
+      store,
+      router,
+      stubs: { Affix: true },
+      vuetify
+    })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })

--- a/ppr-ui/tests/unit/ConfirmRenewal.spec.ts
+++ b/ppr-ui/tests/unit/ConfirmRenewal.spec.ts
@@ -24,7 +24,7 @@ import { RegistrationLengthTrustSummary } from '@/components/registration'
 // Other
 import mockRouter from './MockRouter'
 import { RegistrationFlowType, RouteNames } from '@/enums'
-import { FinancingStatementIF, StateModelIF } from '@/interfaces'
+import { StateModelIF } from '@/interfaces'
 import flushPromises from 'flush-promises'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import { RegisteringPartyChange } from '@/components/parties/party'
@@ -79,7 +79,13 @@ describe('Confirm Renewal new registration component', () => {
       name: RouteNames.CONFIRM_RENEWAL,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((ConfirmRenewal as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(ConfirmRenewal as any, {
+      localVue,
+      store,
+      router,
+      stubs: { Affix: true },
+      vuetify
+    })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })

--- a/ppr-ui/tests/unit/CourtOrder.spec.ts
+++ b/ppr-ui/tests/unit/CourtOrder.spec.ts
@@ -87,7 +87,6 @@ describe('Court Order component', () => {
     wrapper.find('#effect-of-order').setValue(invalidLengthTxt)
     await nextTick()
     const messages = wrapper.findAll('.v-messages__message')
-    console.log(messages)
     expect(messages.length).toBe(4)
     expect(messages.at(0).text()).toBe('Maximum 256 characters')
     expect(messages.at(1).text()).toBe('Maximum 64 characters')

--- a/ppr-ui/tests/unit/Dashboard.spec.ts
+++ b/ppr-ui/tests/unit/Dashboard.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
@@ -7,8 +7,6 @@ import { useStore } from '../../src/store/store'
 import { createLocalVue, Wrapper, mount, shallowMount } from '@vue/test-utils'
 import flushPromises from 'flush-promises'
 import sinon from 'sinon'
-import { StatusCodes } from 'http-status-codes'
-import { cloneDeep } from 'lodash'
 // local components
 import { Dashboard } from '@/views'
 import { BaseSnackbar } from '@/components/common'
@@ -17,17 +15,12 @@ import { SearchBar } from '@/components/search'
 import { RegistrationTable, SearchHistory } from '@/components/tables'
 import { RegistrationBar } from '@/components/registration'
 // local types/helpers, etc.
-import { AuthRoles, ProductCode, RouteNames, SettingOptions, TableActions, UISearchTypes } from '@/enums'
-import { DraftResultIF, RegistrationSummaryIF, RegTableNewItemI } from '@/interfaces'
-import { registrationTableHeaders } from '@/resources'
+import { AuthRoles, ProductCode, RouteNames, TableActions, UISearchTypes } from '@/enums'
+import { RegistrationSummaryIF } from '@/interfaces'
 import {
   amendConfirmationDialog,
   dischargeConfirmationDialog,
-  registrationFoundDialog,
-  renewConfirmationDialog,
-  tableDeleteDialog,
-  tableRemoveDialog
-} from '@/resources/dialogOptions'
+  renewConfirmationDialog } from '@/resources/dialogOptions'
 import { axios } from '@/utils/axios-ppr'
 // unit test data, etc.
 import mockRouter from './MockRouter'
@@ -36,11 +29,9 @@ import {
   mockedSearchHistory,
   mockedSelectSecurityAgreement,
   mockedRegistration1,
-  mockedDraft1,
   mockedFinancingStatementComplete,
   mockedDraftFinancingStatementAll,
   mockedDebtorNames,
-  mockedDraftAmend,
   mockedRegistration2,
   mockedUpdateRegTableUserSettingsResponse,
   mockedManufacturerAuthRoles

--- a/ppr-ui/tests/unit/DischargeRegistration.spec.ts
+++ b/ppr-ui/tests/unit/DischargeRegistration.spec.ts
@@ -21,7 +21,6 @@ import {
 // ppr enums/utils/etc.
 import { RouteNames } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
-import { StateModelIF } from '@/interfaces'
 import { axios } from '@/utils/axios-ppr'
 // test mocks/data
 import mockRouter from './MockRouter'
@@ -61,7 +60,13 @@ describe('ReviewConfirm new registration component', () => {
       name: RouteNames.REVIEW_DISCHARGE,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((DischargeRegistration as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(DischargeRegistration as any, {
+      localVue,
+      store,
+      router,
+      stubs: { Affix: true },
+      vuetify
+    })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })
@@ -112,17 +117,17 @@ describe('ReviewConfirm new registration component', () => {
   })
 
   it('processes cancel button action', async () => {
-    wrapper.find(StickyContainer).vm.$emit('cancel', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('cancel', true)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.REVIEW_DISCHARGE)
-    expect(wrapper.find(BaseDialog).exists()).toBe(true)
-    wrapper.find(BaseDialog).vm.$emit('proceed', false)
+    expect(wrapper.findComponent(BaseDialog).exists()).toBe(true)
+    wrapper.findComponent(BaseDialog).vm.$emit('proceed', false)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.DASHBOARD)
   })
 
   it('processes submit button action', async () => {
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.CONFIRM_DISCHARGE)
   })

--- a/ppr-ui/tests/unit/GeneralCollateral.spec.ts
+++ b/ppr-ui/tests/unit/GeneralCollateral.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
@@ -11,7 +11,6 @@ import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 import { GenColEdit, GenColSummary, GeneralCollateral, GenColAmend } from '@/components/collateral'
 // local types/helpers/etc.
 import { RegistrationFlowType } from '@/enums'
-import { getLastEvent } from './utils'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})

--- a/ppr-ui/tests/unit/LengthTrust.spec.ts
+++ b/ppr-ui/tests/unit/LengthTrust.spec.ts
@@ -52,6 +52,7 @@ function createComponent (): Wrapper<any> {
       isJestRunning: true
     },
     router,
+    stubs: { Affix: true },
     store,
     vuetify
   })

--- a/ppr-ui/tests/unit/MHRSearch.spec.ts
+++ b/ppr-ui/tests/unit/MHRSearch.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
@@ -14,7 +14,6 @@ import { MHRSearch } from '@/views'
 import mockRouter from './MockRouter'
 import { mockedMHRSearchResponse } from './test-data'
 import { UIMHRSearchTypes } from '@/enums'
-import { MHRSearchTypes } from '@/resources'
 
 Vue.use(Vuetify)
 

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -75,6 +75,7 @@ function createComponent (): Wrapper<any> {
       isMhrTransfer: true
     },
     vuetify,
+    stubs: { Affix: true },
     router
   })
 }
@@ -274,7 +275,7 @@ describe('Mhr Information', () => {
     wrapper.vm.dataLoaded = true
     await nextTick()
 
-    const homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson] }]
+    const homeOwnerGroup = [{ groupId: 1, owners: [mockedPerson], type: '' }]
     const homeOwnersComponent = wrapper.findComponent(HomeOwners) as Wrapper<any>
 
     expect(homeOwnersComponent.vm.getHomeOwners.length).toBe(1)
@@ -300,7 +301,7 @@ describe('Mhr Information', () => {
     ).toBe(HomeTenancyTypes.JOINT)
 
     // Enable Groups
-    homeOwnerGroup.push({ groupId: 2, owners: [mockedPerson] })
+    homeOwnerGroup.push({ groupId: 2, owners: [mockedPerson], type: '' })
     await nextTick()
 
     expect(
@@ -957,10 +958,10 @@ describe('Mhr Information', () => {
     expect(store.getMhrTransferDate).toBe(null)
   })
 
-  it('should hides the Transfer Change button when the feature flag is false', async () => {
+  it('should hide the Transfer Change button when the feature flag is false', async () => {
     defaultFlagSet['mhr-transfer-enabled'] = false
     await nextTick()
-    const wrapper = createComponent()
+    wrapper = createComponent()
 
     setupCurrentHomeOwners()
     wrapper.vm.dataLoaded = true
@@ -978,7 +979,7 @@ describe('Mhr Information', () => {
     await store.setMhrUnitNotes(mockedUnitNotes5)
 
     await nextTick()
-    const wrapper = await createComponent()
+    wrapper = await createComponent()
     await store.setMhrInformation(mockedLockedMhRegistration)
     await store.setMhrFrozenDocumentType(UnitNoteDocTypes.NOTICE_OF_TAX_SALE)
 

--- a/ppr-ui/tests/unit/MhrRegistration.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistration.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
@@ -14,7 +14,6 @@ import { MhrRegistrationType } from '@/resources'
 import { defaultFlagSet } from '@/utils'
 import mockRouter from './MockRouter'
 import { RouteNames } from '@/enums'
-import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { mockedManufacturerAuthRoles } from './test-data'
 
 Vue.use(Vuetify)
@@ -45,6 +44,7 @@ function createComponent (): Wrapper<any> {
       appReady: true
     },
     vuetify,
+    stubs: { Affix: true },
     router
   })
 }

--- a/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/MhrReviewConfirm.spec.ts
@@ -18,7 +18,6 @@ import { mockedFractionalOwnership, mockedPerson } from './test-data/mock-mhr-re
 import { MhrRegistrationHomeOwnerGroupIF, MhrRegistrationHomeOwnerIF } from '@/interfaces/mhr-registration-interfaces'
 import { getTestId } from './utils'
 import { HomeOwnersTable } from '@/components/mhrRegistration/HomeOwners'
-import { MhrCompVal, MhrSectVal } from '../../src/composables/mhrRegistration/enums'
 import { MhrRegistrationType } from '@/resources'
 import { mockedAccountInfo, mockedManufacturerAuthRoles } from './test-data'
 import { defaultFlagSet } from '@/utils'
@@ -248,7 +247,7 @@ describe('Mhr Manufacturer Registration Review and Confirm', () => {
     await nextTick()
     const attention = wrapper.findComponent(Attention)
     const folio = wrapper.findComponent(FolioOrReferenceNumber)
-    expect((attention.find(FormField) as Wrapper<any>).vm.inputModel).toBe('TEST 123')
-    expect((folio.find(FormField) as Wrapper<any>).vm.inputModel).toBe('TEST 245')
+    expect((attention.findComponent(FormField) as Wrapper<any>).vm.inputModel).toBe('TEST 123')
+    expect((folio.findComponent(FormField) as Wrapper<any>).vm.inputModel).toBe('TEST 245')
   })
 })

--- a/ppr-ui/tests/unit/MhrUnitNote.spec.ts
+++ b/ppr-ui/tests/unit/MhrUnitNote.spec.ts
@@ -50,6 +50,7 @@ function createComponent (): Wrapper<any> {
   return mount(MhrUnitNote as any, {
     localVue,
     router,
+    stubs: { Affix: true },
     vuetify
   })
 }
@@ -375,15 +376,15 @@ describe('MHR Unit Note Filing', () => {
     expect(UnitNoteReviewComponent.find(getTestId('cancel-note-info')).exists()).toBeTruthy()
 
     // Effective Date should not existing for Cancel Note
-    expect(UnitNoteReviewComponent.find(EffectiveDate).exists()).toBeFalsy()
+    expect(UnitNoteReviewComponent.findComponent(EffectiveDate).exists()).toBeFalsy()
 
-    expect(UnitNoteReviewComponent.find(ContactInformation).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(ContactInformation).find('h2').text()).toBe(
+    expect(UnitNoteReviewComponent.findComponent(ContactInformation).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(ContactInformation).find('h2').text()).toBe(
       submittingPartyChangeContent.title
     )
-    expect(UnitNoteReviewComponent.find(Attention).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(CertifyInformation).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(StaffPayment).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(Attention).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(CertifyInformation).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(StaffPayment).exists()).toBeTruthy()
   })
 
   it('Notice of Redemption (NRED): renders Landing & Review pages', async () => {
@@ -414,15 +415,15 @@ describe('MHR Unit Note Filing', () => {
     expect(UnitNoteReviewComponent.find(getTestId('redemption-note-info')).exists()).toBeTruthy()
 
     // Effective Date should not existing for Cancel Note
-    expect(UnitNoteReviewComponent.find(EffectiveDate).exists()).toBeFalsy()
+    expect(UnitNoteReviewComponent.findComponent(EffectiveDate).exists()).toBeFalsy()
 
-    expect(UnitNoteReviewComponent.find(ContactInformation).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(ContactInformation).find('h2').text()).toBe(
+    expect(UnitNoteReviewComponent.findComponent(ContactInformation).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(ContactInformation).find('h2').text()).toBe(
       submittingPartyRegistrationContent.title
     )
-    expect(UnitNoteReviewComponent.find(Attention).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(CertifyInformation).exists()).toBeTruthy()
-    expect(UnitNoteReviewComponent.find(StaffPayment).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(Attention).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(CertifyInformation).exists()).toBeTruthy()
+    expect(UnitNoteReviewComponent.findComponent(StaffPayment).exists()).toBeTruthy()
   })
 
   it('Additional Remarks checkbox should not be included for REST, NCON and NPUB Unit Notes', async () => {

--- a/ppr-ui/tests/unit/Parties.spec.ts
+++ b/ppr-ui/tests/unit/Parties.spec.ts
@@ -1,14 +1,12 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
 import flushPromises from 'flush-promises'
 import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
 import {
-  mockedDebtors1,
   mockedRegisteringParty1,
-  mockedSecuredParties1,
   mockedSelectSecurityAgreement
 } from './test-data'
 

--- a/ppr-ui/tests/unit/PartySearch.spec.ts
+++ b/ppr-ui/tests/unit/PartySearch.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { Wrapper } from '@vue/test-utils'
 

--- a/ppr-ui/tests/unit/RegisteringParty.spec.ts
+++ b/ppr-ui/tests/unit/RegisteringParty.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'

--- a/ppr-ui/tests/unit/RegisteringPartyChange.spec.ts
+++ b/ppr-ui/tests/unit/RegisteringPartyChange.spec.ts
@@ -14,9 +14,7 @@ import {
 } from './test-data'
 
 // Components
-import PartySummary from '@/components/parties/PartySummary.vue' // need to import like this
 import { EditParty, PartySearch, RegisteringParty, RegisteringPartyChange } from '@/components/parties/party'
-import { CautionBox } from '@/components/common'
 
 Vue.use(Vuetify)
 

--- a/ppr-ui/tests/unit/RegistrationBar.spec.ts
+++ b/ppr-ui/tests/unit/RegistrationBar.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'

--- a/ppr-ui/tests/unit/RegistrationDialog.spec.ts
+++ b/ppr-ui/tests/unit/RegistrationDialog.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'

--- a/ppr-ui/tests/unit/RenewRegistration.spec.ts
+++ b/ppr-ui/tests/unit/RenewRegistration.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '@/components/parties/summaries'
 // ppr enums/utils/etc.
 import { RouteNames } from '@/enums'
-import { StateModelIF } from '@/interfaces'
 import { axios } from '@/utils/axios-ppr'
 // test mocks/data
 import mockRouter from './MockRouter'
@@ -61,7 +60,13 @@ describe('Renew registration component', () => {
       name: RouteNames.RENEW_REGISTRATION,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((RenewRegistration as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(RenewRegistration as any, {
+      localVue,
+      store,
+      router,
+      stubs: { Affix: true },
+      vuetify
+    })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })
@@ -115,10 +120,10 @@ describe('Renew registration component', () => {
   })
 
   it('processes cancel button action', async () => {
-    await wrapper.find(StickyContainer).vm.$emit('cancel', true)
+    await wrapper.findComponent(StickyContainer).vm.$emit('cancel', true)
     expect(wrapper.vm.$route.name).toBe(RouteNames.RENEW_REGISTRATION)
-    expect(wrapper.find(BaseDialog).exists()).toBe(true)
-    wrapper.find(BaseDialog).vm.$emit('proceed', false)
+    expect(wrapper.findComponent(BaseDialog).exists()).toBe(true)
+    wrapper.findComponent(BaseDialog).vm.$emit('proceed', false)
     await flushPromises()
     expect(wrapper.vm.$route.name).toBe(RouteNames.DASHBOARD)
   })
@@ -132,7 +137,7 @@ describe('Renew registration component', () => {
       showInvalid: false
     })
     wrapper.vm.registrationValid = true
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
 
     expect(wrapper.vm.$route.name).toBe(RouteNames.CONFIRM_RENEWAL)
@@ -140,7 +145,7 @@ describe('Renew registration component', () => {
 
   it('doesnt proceed if validation errors', async () => {
     wrapper.vm.registrationValid = false
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.showInvalid).toBe(true)
   })
@@ -169,7 +174,7 @@ describe('Renew registration component for repairers lien', () => {
       name: RouteNames.RENEW_REGISTRATION,
       query: { 'reg-num': '123456B' }
     })
-    wrapper = shallowMount((RenewRegistration as any), { localVue, store, router, vuetify })
+    wrapper = shallowMount(RenewRegistration as any, { localVue, store, router, stubs: { Affix: true }, vuetify })
     wrapper.setProps({ appReady: true })
     await flushPromises()
   })
@@ -195,14 +200,14 @@ describe('Renew registration component for repairers lien', () => {
   })
 
   it('proceeds if valid court order', async () => {
-    wrapper.find(CourtOrder).vm.$emit('setCourtOrderValid', true)
+    wrapper.findComponent(CourtOrder).vm.$emit('setCourtOrderValid', true)
     await flushPromises()
     expect(wrapper.vm.registrationValid).toBe(true)
   })
 
   it('doesnt proceed if validation errors', async () => {
-    wrapper.find(CourtOrder).vm.$emit('setCourtOrderValid', false)
-    wrapper.find(StickyContainer).vm.$emit('submit', true)
+    wrapper.findComponent(CourtOrder).vm.$emit('setCourtOrderValid', false)
+    wrapper.findComponent(StickyContainer).vm.$emit('submit', true)
     await flushPromises()
     expect(wrapper.vm.showInvalid).toBe(true)
   })

--- a/ppr-ui/tests/unit/ReviewConfirm.spec.ts
+++ b/ppr-ui/tests/unit/ReviewConfirm.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
@@ -19,7 +19,6 @@ import { FeeSummaryTypes } from '@/composables/fees/enums'
 import {
   RegistrationFlowType,
   RouteNames,
-  StatementTypes,
   UIRegistrationTypes
 } from '@/enums'
 import { LengthTrustIF } from '@/interfaces'

--- a/ppr-ui/tests/unit/SecuredParties.spec.ts
+++ b/ppr-ui/tests/unit/SecuredParties.spec.ts
@@ -123,14 +123,14 @@ describe('Secured Party Other registration type tests', () => {
     expect(wrapper.find(partyAutoComplete).exists()).toBeTruthy()
 
     // should have the dialog
-    expect(wrapper.find(ChangeSecuredPartyDialog).exists()).toBeTruthy()
+    expect(wrapper.findComponent(ChangeSecuredPartyDialog).exists()).toBeTruthy()
   })
 
   it('shows the dialog with a secured party code change', async () => {
     expect(wrapper.findComponent(SecuredParties).exists()).toBe(true)
 
     // should have the dialog
-    expect(wrapper.find(ChangeSecuredPartyDialog).exists()).toBeTruthy()
+    expect(wrapper.findComponent(ChangeSecuredPartyDialog).exists()).toBeTruthy()
 
     expect(wrapper.find('#secured-party-autocomplete').exists()).toBeTruthy()
 
@@ -140,7 +140,7 @@ describe('Secured Party Other registration type tests', () => {
     // change the party code and then the dialog should show
     wrapper.vm.selectResult({ code: 123, businessName: 'Forrest Gump' })
 
-    expect(wrapper.find(ChangeSecuredPartyDialog).isVisible()).toBeTruthy()
+    expect(wrapper.findComponent(ChangeSecuredPartyDialog).isVisible()).toBeTruthy()
   })
 
   it('is not valid if you remove the secured party for amendment', async () => {

--- a/ppr-ui/tests/unit/Signout.spec.ts
+++ b/ppr-ui/tests/unit/Signout.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'

--- a/ppr-ui/tests/unit/Stepper.spec.ts
+++ b/ppr-ui/tests/unit/Stepper.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick, toRefs } from 'vue'
+import Vue, { } from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
@@ -19,7 +19,6 @@ import { mockedManufacturerAuthRoles } from './test-data'
 // Others
 import { MhrRegistrationType } from '@/resources'
 import { getTestId } from './utils'
-import { useMhrValidations } from '@/composables'
 import { StepIF } from '@/interfaces'
 
 Vue.use(Vuetify)

--- a/ppr-ui/tests/unit/UnitNotePanels.spec.ts
+++ b/ppr-ui/tests/unit/UnitNotePanels.spec.ts
@@ -289,8 +289,8 @@ describe('UnitNotePanels', () => {
           if ([UnitNoteDocTypes.CONTINUED_NOTE_OF_CAUTION, UnitNoteDocTypes.EXTENSION_TO_NOTICE_OF_CAUTION]
             .includes(additionalNote.documentType)) {
             additionalNoteIdx.push(i)
-            const additionalHeader = panel.findAll(UnitNoteHeaderInfo).at(additionalNotePos)
-            const additionalContent = panel.findAll(UnitNoteContentInfo).at(additionalNotePos)
+            const additionalHeader = panel.findAllComponents(UnitNoteHeaderInfo).at(additionalNotePos)
+            const additionalContent = panel.findAllComponents(UnitNoteContentInfo).at(additionalNotePos)
 
             verifyHeaderContent(additionalNote, additionalHeader)
             verifyBodyContent(additionalNote, additionalContent)
@@ -303,8 +303,8 @@ describe('UnitNotePanels', () => {
         // Verify the notice of caution data
         additionalNoteIdx.push(i)
         const noticeOfCautionNote = mockUnitNotes[i]
-        const noticeOfCautionHeader = panel.findAll(UnitNoteHeaderInfo).at(additionalNotePos)
-        const noticeOfCautionContent = panel.findAll(UnitNoteContentInfo).at(additionalNotePos)
+        const noticeOfCautionHeader = panel.findAllComponents(UnitNoteHeaderInfo).at(additionalNotePos)
+        const noticeOfCautionContent = panel.findAllComponents(UnitNoteContentInfo).at(additionalNotePos)
 
         verifyHeaderContent(noticeOfCautionNote, noticeOfCautionHeader)
         verifyBodyContent(noticeOfCautionNote, noticeOfCautionContent)

--- a/ppr-ui/tests/unit/YourHome.spec.ts
+++ b/ppr-ui/tests/unit/YourHome.spec.ts
@@ -1,5 +1,5 @@
 // Libraries
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '../../src/store/store'
@@ -122,7 +122,9 @@ describe('Your Home - Manufacturer', () => {
 
   it('renders and displays the correct headers and sub components', async () => {
     expect(wrapper.find('#mhr-make-model h2').text()).toBe('Manufacturer, Make, and Model')
-    expect(wrapper.find(getTestId('make-model-prompt')).text()).toContain('Enter the Year of Manufacture (not the model year)')
+    expect(wrapper.find(getTestId('make-model-prompt')).text()).toContain(
+      'Enter the Year of Manufacture (not the model year)'
+    )
     expect(wrapper.findComponent(ManufacturerMakeModel).exists()).toBe(true)
     expect(wrapper.findComponent(SimpleHelpToggle).exists()).toBe(true)
     expect(wrapper.find('#mhr-home-sections h2').text()).toBe('Home Sections')


### PR DESCRIPTION
*Description of changes:*
- When running unit tests with console output (silent: false), a large number of error messages are printed out
- This PR is an attempt to clean up the code and fix the errors
- Fix deprecated methods (find -> findComponent, etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
