### PR TITLE
Remove Expiry Time from Unit Note Panels

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteContentInfo.vue
@@ -19,11 +19,11 @@
 
     <v-row v-if="isNoticeOfCautionOrRelatedDocType(note)" no-gutters class="my-6">
       <v-col cols="3">
-        <h3 class="fs-14">Expiry Date and Time</h3>
+        <h3 class="fs-14">Expiry Date</h3>
       </v-col>
       <v-col cols="9">
         <span v-if="note.expiryDateTime" class="info-text fs-14">
-          {{ pacificDate(note.expiryDateTime, true) }}
+          {{ shortPacificDate(note.expiryDateTime) }}
         </span>
         <span v-else id="no-expiry" class="info-text fs-14">
           N/A

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -898,8 +898,8 @@ export default defineComponent({
       localState.showTransferType = !localState.showTransferType
     }
 
-    const handleDocumentIdUpdate = async (documentId: string) => {
-      await setMhrTransferDocumentId(documentId)
+    const handleDocumentIdUpdate = (documentId: string) => {
+      setMhrTransferDocumentId(documentId)
     }
 
     const handleTransferTypeChange = async (transferTypeSelect: TransferTypeSelectIF): Promise<void> => {

--- a/ppr-ui/tests/unit/UnitNotePanels.spec.ts
+++ b/ppr-ui/tests/unit/UnitNotePanels.spec.ts
@@ -93,8 +93,8 @@ const verifyBodyContent = (note: UnitNotePanelIF, content: Wrapper<any>, cancelN
   if (note.expiryDateTime) {
     const expiryDate = content.findAll('h3').at(headerIndex).text()
     const expiryDateTime = content.findAll('.info-text.fs-14').at(headerIndex).text()
-    expect(expiryDate).toBe('Expiry Date and Time')
-    expect(expiryDateTime).toBe(pacificDate(note.expiryDateTime, true))
+    expect(expiryDate).toBe('Expiry Date')
+    expect(expiryDateTime).toBe(shortPacificDate(note.expiryDateTime))
     headerIndex++
   }
 


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#17898

*Description of changes:*
- Only Expiry Time is removed from the Unit Note Panels (date is till there)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
