### PR TITLE
Update PPR lien check logic for restricting non-staff registrations

### DIFF
--- a/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
+++ b/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
@@ -62,7 +62,9 @@ SELECT r.mhr_number, r.status_type, r.registration_ts,
       (SELECT CASE WHEN r.registration_type != 'MHREG' THEN ''
             ELSE (SELECT lcv.registration_type
                     FROM mhr_lien_check_vw lcv
-                   WHERE lcv.mhr_number = r.mhr_number) END) AS ppr_lien_type,
+                   WHERE lcv.mhr_number = r.mhr_number
+                ORDER BY lcv.base_registration_ts
+                FETCH FIRST 1 ROWS ONLY) END) AS ppr_lien_type,
        d.document_type,
        r.id AS registration_id,
        (SELECT mrr.doc_storage_url
@@ -72,4 +74,3 @@ SELECT r.mhr_number, r.status_type, r.registration_ts,
  WHERE r.id = d.registration_id
    AND d.document_type = dt.document_type
 ;
- 

--- a/mhr_api/src/database/postgres_views/mhr_lien_check_vw.sql
+++ b/mhr_api/src/database/postgres_views/mhr_lien_check_vw.sql
@@ -1,26 +1,99 @@
 -- 14527 view to check if there is an outstanding PPR lien on a manufactured home searching by MHR number.
+-- 17853 updated.
 CREATE OR REPLACE VIEW public.mhr_lien_check_vw AS
 SELECT sc.mhr_number, r.registration_type, r.registration_ts AS base_registration_ts,
-       r.registration_number AS base_registration_num,
-       cc.id AS client_code_id, cc.name AS secured_party_name
-  FROM registrations r, financing_statements fs, serial_collateral sc, parties p, client_codes cc
+       r.registration_number AS base_registration_num
+  FROM registrations r, financing_statements fs, serial_collateral sc
  WHERE r.financing_id = fs.id
    AND r.registration_type_cl IN ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
-   AND r.registration_type IN ('SG', 'SA', 'LT', 'FR', 'MH')
-   AND (fs.expire_date IS NULL OR fs.expire_date > ((now() at time zone 'utc') - interval '30 days'))
+   AND r.registration_type NOT IN ('SA', 'TA', 'TM')
+   AND (fs.expire_date IS NULL OR fs.expire_date > (now() at time zone 'utc'))
    AND NOT EXISTS (SELECT r3.id 
                      FROM registrations r3
                     WHERE r3.financing_id = fs.id
                       AND r3.registration_type_cl = 'DISCHARGE'
-                      AND r3.registration_ts < ((now() at time zone 'utc') - interval '30 days'))
+                      AND r3.registration_ts < (now() at time zone 'utc'))
    AND sc.financing_id = fs.id
    AND sc.registration_id_end IS NULL
    AND sc.mhr_number IS NOT NULL
    AND sc.mhr_number != 'NR'
-   AND p.financing_id = fs.id
-   AND p.party_type = 'SP'
-   AND p.registration_id_end IS NULL
-   AND p.branch_id IS NOT NULL
-   AND p.branch_id = cc.id
-   AND (cc.name like 'HER MAJESTY%' OR cc.name like '%TAX DEFERME%')
+UNION (
+SELECT sc.mhr_number, r.registration_type || '_TAX', r.registration_ts AS base_registration_ts,
+       r.registration_number AS base_registration_num
+  FROM registrations r, financing_statements fs, serial_collateral sc
+ WHERE r.financing_id = fs.id
+   AND r.registration_type_cl = 'PPSALIEN'
+   AND r.registration_type IN ('SA', 'TA', 'TM')
+   AND (fs.expire_date IS NULL OR fs.expire_date > (now() at time zone 'utc'))
+   AND NOT EXISTS (SELECT r3.id 
+                     FROM registrations r3
+                    WHERE r3.financing_id = fs.id
+                      AND r3.registration_type_cl = 'DISCHARGE'
+                      AND r3.registration_ts < (now() at time zone 'utc'))
+   AND sc.financing_id = fs.id
+   AND sc.registration_id_end IS NULL
+   AND sc.mhr_number IS NOT NULL
+   AND sc.mhr_number != 'NR'
+   AND EXISTS (SELECT p.id
+                 FROM parties p, client_codes cc
+                WHERE p.financing_id = fs.id
+                  AND p.party_type = 'SP'
+                  AND p.registration_id_end IS NULL
+                  AND p.branch_id IS NOT NULL
+                  AND p.branch_id = cc.id
+                  AND cc.name like '%TAX DEFERME%')
+)
+UNION (
+SELECT sc.mhr_number, r.registration_type || '_GOV', r.registration_ts AS base_registration_ts,
+       r.registration_number AS base_registration_num
+  FROM registrations r, financing_statements fs, serial_collateral sc
+ WHERE r.financing_id = fs.id
+   AND r.registration_type_cl = 'PPSALIEN'
+   AND r.registration_type IN ('SA', 'TA', 'TM')
+   AND r.registration_ts <= TO_DATE('2004-03-31', 'YYYY-MM-DD')
+   AND (fs.expire_date IS NULL OR fs.expire_date > (now() at time zone 'utc'))
+   AND NOT EXISTS (SELECT r3.id 
+                     FROM registrations r3
+                    WHERE r3.financing_id = fs.id
+                      AND r3.registration_type_cl = 'DISCHARGE'
+                      AND r3.registration_ts < (now() at time zone 'utc'))
+   AND sc.financing_id = fs.id
+   AND sc.registration_id_end IS NULL
+   AND sc.mhr_number IS NOT NULL
+   AND sc.mhr_number != 'NR'
+   AND EXISTS (SELECT p.id
+                 FROM parties p, client_codes cc
+                WHERE p.financing_id = fs.id
+                  AND p.party_type = 'SP'
+                  AND p.registration_id_end IS NULL
+                  AND p.branch_id IS NOT NULL
+                  AND p.branch_id = cc.id
+                  AND cc.name like 'HER MAJESTY%')
+)
+UNION (
+SELECT sc.mhr_number, r.registration_type, r.registration_ts AS base_registration_ts,
+       r.registration_number AS base_registration_num
+  FROM registrations r, financing_statements fs, serial_collateral sc
+ WHERE r.financing_id = fs.id
+   AND r.registration_type_cl = 'PPSALIEN'
+   AND r.registration_type IN ('SA', 'TA', 'TM')
+   AND (fs.expire_date IS NULL OR fs.expire_date > (now() at time zone 'utc'))
+   AND NOT EXISTS (SELECT r3.id 
+                     FROM registrations r3
+                    WHERE r3.financing_id = fs.id
+                      AND r3.registration_type_cl = 'DISCHARGE'
+                      AND r3.registration_ts < (now() at time zone 'utc'))
+   AND sc.financing_id = fs.id
+   AND sc.registration_id_end IS NULL
+   AND sc.mhr_number IS NOT NULL
+   AND sc.mhr_number != 'NR'
+   AND NOT EXISTS (SELECT p.id
+                     FROM parties p, client_codes cc
+                    WHERE p.financing_id = fs.id
+                      AND p.party_type = 'SP'
+                      AND p.registration_id_end IS NULL
+                      AND p.branch_id IS NOT NULL
+                      AND p.branch_id = cc.id
+                      AND (cc.name like 'HER MAJESTY%' OR cc.name like '%TAX DEFERME%'))
+)
 ;

--- a/mhr_api/src/mhr_api/models/db2/owngroup.py
+++ b/mhr_api/src/mhr_api/models/db2/owngroup.py
@@ -253,14 +253,14 @@ class Db2Owngroup(db.Model):
         return owngroup
 
     @staticmethod
-    def create_from_registration(registration, new_info, group_id: int):
+    def create_from_registration(registration, new_info, group_id: int, sequence_num: int = 1):
         """Create a new owner group object from a new MH registration."""
         # current_app.logger.info('group group id=' + str(group_id))
         # current_app.logger.info(new_info)
         tenancy: str = new_info.get('type', Db2Owngroup.TenancyTypes.SOLE)
         tenancy_type: str = NEW_TENANCY_LEGACY.get(tenancy)
         if tenancy == MhrTenancyTypes.NA and len(new_info.get('owners')) > 1:
-            tenancy_type = Db2Owngroup.TenancyTypes.JOINT.value
+            tenancy_type = Db2Owngroup.TenancyTypes.JOINT
         interest: str = new_info.get('interest', '')
         if tenancy_type == Db2Owngroup.TenancyTypes.COMMON or \
                 (tenancy_type == Db2Owngroup.TenancyTypes.JOINT and new_info.get('interestDenominator') and
@@ -272,7 +272,7 @@ class Db2Owngroup(db.Model):
         owngroup = Db2Owngroup(manuhome_id=registration.id,
                                group_id=group_id,
                                copy_id=0,
-                               sequence_number=1,
+                               sequence_number=sequence_num if sequence_num > 0 else 1,
                                status=Db2Owngroup.StatusTypes.ACTIVE,
                                pending_flag='',
                                reg_document_id=new_info.get('documentId', ''),

--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -35,7 +35,9 @@ QUERY_ACCOUNT_MHR_LEGACY = """
 SELECT DISTINCT mer.mhr_number, 'N' AS account_reg,
                 (SELECT mlc.registration_type
                    FROM mhr_lien_check_vw mlc
-                  WHERE mlc.mhr_number = mer.mhr_number) AS lien_registration_type
+                  WHERE mlc.mhr_number = mer.mhr_number
+                ORDER BY mlc.base_registration_ts DESC
+                FETCH FIRST 1 ROWS ONLY) AS lien_registration_type
  FROM mhr_extra_registrations mer
 WHERE account_id = :query_value
   AND (removed_ind IS NULL OR removed_ind != 'Y')
@@ -43,7 +45,9 @@ UNION (
 SELECT DISTINCT mr.mhr_number, 'Y' AS account_reg,
                 (SELECT mlc.registration_type
                    FROM mhr_lien_check_vw mlc
-                  WHERE mlc.mhr_number = mr.mhr_number) AS lien_registration_type
+                  WHERE mlc.mhr_number = mr.mhr_number
+                ORDER BY mlc.base_registration_ts DESC
+                FETCH FIRST 1 ROWS ONLY) AS lien_registration_type
   FROM mhr_registrations mr
 WHERE account_id = :query_value
   AND mr.registration_type = 'MHREG'
@@ -104,7 +108,9 @@ SELECT (SELECT COUNT(mr.id)
             AND mr.registration_type IN ('MHREG')),
       (SELECT mlc.registration_type
          FROM mhr_lien_check_vw mlc
-        WHERE mlc.mhr_number = :query_value2)
+        WHERE mlc.mhr_number = :query_value2 
+     ORDER BY mlc.base_registration_ts DESC
+        FETCH FIRST 1 ROWS ONLY)
 """
 DOC_ID_COUNT_QUERY = """
 SELECT COUNT(documtid)

--- a/mhr_api/src/mhr_api/models/db2/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/registration_utils.py
@@ -1,0 +1,260 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds miscellaneous legacy registration utility functions."""
+from flask import current_app
+
+from mhr_api.models import utils as model_utils
+from mhr_api.models.type_tables import (
+    MhrDocumentTypes,
+    MhrNoteStatusTypes,
+    MhrPartyTypes,
+    MhrStatusTypes,
+    MhrTenancyTypes
+)
+
+from .document import Db2Document
+from .mhomnote import Db2Mhomnote
+from .owngroup import Db2Owngroup
+
+
+def update_note_json(registration, note_json: dict) -> dict:
+    """Conditionally update the note json with new registration data if available."""
+    if not registration.change_registrations:
+        return note_json
+    for reg in registration.change_registrations:
+        if reg.notes:
+            doc = reg.documents[0]
+            if doc.document_id == note_json.get('documentId'):
+                note_json['createDateTime'] = model_utils.format_ts(reg.registration_ts)
+                note = reg.notes[0]
+                if note.expiry_date:
+                    note_json['expiryDateTime'] = model_utils.format_ts(note.expiry_date)
+                if note.effective_ts:
+                    note_json['effectiveDateTime'] = model_utils.format_ts(note.effective_ts)
+                if note.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE):
+                    note_json['remarks'] = note.remarks
+                # Use modernized person giving notice data if available.
+                notice_party = note.get_giving_notice()
+                if notice_party:
+                    note_json['givingNoticeParty'] = notice_party.json
+    return note_json
+
+
+def update_location_json(registration, reg_json: dict) -> dict:
+    """Conditionally update the location json with the modernized registration data if available."""
+    if not registration.locations:
+        return reg_json
+    active_loc = registration.locations[0]
+    active_doc_id = registration.documents[0].document_id
+    if active_loc.status_type != MhrStatusTypes.ACTIVE and registration.change_registrations:
+        for reg in registration.change_registrations:
+            if reg.locations and reg.locations[0].status_type == MhrStatusTypes.ACTIVE:
+                active_loc = reg.locations[0]
+                active_doc_id = reg.documents[0].document_id
+    if active_loc.status_type == MhrStatusTypes.ACTIVE and active_doc_id:
+        legacy_loc = registration.manuhome.reg_location
+        for doc in registration.manuhome.reg_documents:
+            if legacy_loc.reg_document_id == doc.id:
+                current_app.logger.info(f'Comparing modern doc_id={active_doc_id} to legacy id={doc.id}')
+                if active_doc_id == legacy_loc.reg_document_id:
+                    current_app.logger.debug('Using modernized location data')
+                    reg_json['location'] = active_loc.json
+    return reg_json
+
+
+def update_description_json(registration, reg_json: dict) -> dict:
+    """Conditionally update the description json with the modernized registration data if available."""
+    if not registration.descriptions:
+        return reg_json
+    active_desc = registration.descriptions[0]
+    active_doc_id = registration.documents[0].document_id
+    if active_desc.status_type != MhrStatusTypes.ACTIVE and registration.change_registrations:
+        for reg in registration.change_registrations:
+            if reg.descriptions and reg.descriptions[0].status_type == MhrStatusTypes.ACTIVE:
+                active_desc = reg.descriptions[0]
+                active_doc_id = reg.documents[0].document_id
+    if active_desc.status_type == MhrStatusTypes.ACTIVE and active_doc_id:
+        legacy_desc = registration.manuhome.reg_descript
+        for doc in registration.manuhome.reg_documents:
+            if legacy_desc.reg_document_id == doc.id:
+                current_app.logger.info(f'Comparing modern doc_id={active_doc_id} to legacy id={doc.id}')
+                if active_doc_id == legacy_desc.reg_document_id:
+                    current_app.logger.debug('Using modernized description data')
+                    desc_json = active_desc.json
+                    desc_json['sections'] = reg_json['description'].get('sections')
+                    reg_json['description'] = desc_json
+    return reg_json
+
+
+def set_owner_sequence_num(owner_groups) -> int:
+    """Get the next owner group sequence number."""
+    sequence_num: int = 1
+    if owner_groups:
+        for group in owner_groups:
+            if group.status in (Db2Owngroup.StatusTypes.ACTIVE, Db2Owngroup.StatusTypes.EXEMPT):
+                group.sequence_number = sequence_num
+                sequence_num += 1
+
+
+def update_group_type(groups, existing_count: int = 0):
+    """Set type if multiple active owner groups and a trustee, admin, executor exists."""
+    if not groups or ((len(groups) + existing_count) == 1 and groups[0].get('type') == MhrTenancyTypes.SOLE):
+        return groups
+    for group in groups:
+        for owner in group.get('owners'):
+            if owner.get('partyType') and owner['partyType'] in (MhrPartyTypes.ADMINISTRATOR,
+                                                                 MhrPartyTypes.EXECUTOR,
+                                                                 MhrPartyTypes.TRUSTEE):
+                group['type'] = MhrTenancyTypes.NA
+                break
+    return groups
+
+
+def adjust_group_interest(groups, new: bool):
+    """For TC and optionally JT groups adjust group interest value."""
+    tc_count: int = 0
+    for group in groups:
+        if group.tenancy_type != Db2Owngroup.TenancyTypes.SOLE and \
+                group.status == Db2Owngroup.StatusTypes.ACTIVE and \
+                group.interest_numerator and group.interest_denominator and \
+                group.interest_numerator > 0 and group.interest_denominator > 0:
+            tc_count += 1
+    if tc_count > 0:
+        for group in groups:
+            if new or (group.modified and group.status == Db2Owngroup.StatusTypes.ACTIVE):
+                fraction: str = str(group.interest_numerator) + '/' + str(group.interest_denominator)
+                if len(fraction) > 10:
+                    group.interest = ''
+                elif group.interest.upper().startswith(model_utils.OWNER_INTEREST_UNDIVIDED):
+                    group.interest = model_utils.OWNER_INTEREST_UNDIVIDED + ' '
+                else:
+                    group.interest = ''
+                group.interest += fraction
+                current_app.logger.debug('Updating group interest to: ' + group.interest)
+
+
+def get_next_note_id(reg_notes) -> int:
+    """Get the next mhomnote.note_id value: part of the composite key."""
+    note_id: int = 1
+    if reg_notes:
+        for note in reg_notes:
+            if note.note_id >= note_id:
+                note_id = note.note_id + 1
+    return note_id
+
+
+def set_caution(notes) -> bool:
+    """Check if an active caution exists on the MH registration: exists and not cancelled or expired."""
+    has_caution: bool = False
+    if not notes:
+        return has_caution
+    for note in notes:
+        if note.document_type in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE) and \
+                note.status == Db2Mhomnote.StatusTypes.ACTIVE:
+            if (not note.expiry_date or note.expiry_date.isoformat() == '0001-01-01') and \
+                    note.document_type == MhrDocumentTypes.CAUC:
+                has_caution = True
+            elif note.expiry_date:
+                now_ts = model_utils.now_ts()
+                has_caution = note.expiry_date > now_ts.date()
+                break
+    return has_caution
+
+
+def cancel_note(manuhome, reg_json, doc_type: str, doc_id: int):
+    """Update status, candocid for a registration that cancels a unit note."""
+    if not reg_json.get('cancelDocumentId') and not reg_json.get('updateDocumentId'):
+        return
+    cancel_doc_type: str = None
+    cancel_doc_id: str = reg_json.get('cancelDocumentId')
+    if not cancel_doc_id:
+        cancel_doc_id: str = reg_json.get('updateDocumentId')
+    for note in manuhome.reg_notes:
+        if note.reg_document_id == cancel_doc_id:
+            note.can_document_id = doc_id
+            note.status = Db2Mhomnote.StatusTypes.CANCELLED
+            cancel_doc_type = note.document_type
+            break
+    if doc_type == MhrDocumentTypes.NCAN and cancel_doc_type in (MhrDocumentTypes.CAU,
+                                                                 Db2Document.DocumentTypes.CAUTION,
+                                                                 Db2Document.DocumentTypes.CONTINUE_CAUTION,
+                                                                 Db2Document.DocumentTypes.EXTEND_CAUTION):
+        for note in manuhome.reg_notes:
+            if note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
+                    note.document_type in (MhrDocumentTypes.CAU, Db2Document.DocumentTypes.CAUTION,
+                                           Db2Document.DocumentTypes.CONTINUE_CAUTION,
+                                           Db2Document.DocumentTypes.EXTEND_CAUTION):
+                note.can_document_id = doc_id
+                note.status = Db2Mhomnote.StatusTypes.CANCELLED
+    elif doc_type == MhrDocumentTypes.EXRE and cancel_doc_type in (MhrDocumentTypes.EXNR,
+                                                                   MhrDocumentTypes.EXRS,
+                                                                   MhrDocumentTypes.EXMN):
+        for note in manuhome.reg_notes:
+            if note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
+                    note.document_type in (MhrDocumentTypes.EXNR, MhrDocumentTypes.EXRS, MhrDocumentTypes.EXMN):
+                note.can_document_id = doc_id
+                note.status = Db2Mhomnote.StatusTypes.CANCELLED
+
+
+def get_note_doc_reg_num(reg_documents, doc_id: str) -> str:
+    """Get the document registration number matching the doc_id from document."""
+    reg_num: str = ''
+    if doc_id and reg_documents:
+        for doc in reg_documents:
+            if doc.id == doc_id:
+                return doc.document_reg_id
+    return reg_num
+
+
+def sort_key_notes_ts(item):
+    """Sort the notes registration timestamp."""
+    return item.get('createDateTime', '')
+
+
+def sort_notes(notes):
+    """Sort notes by registration timesamp."""
+    notes.sort(key=sort_key_notes_ts, reverse=True)
+    return notes
+
+
+def get_notes_json(reg_notes, reg_documents):
+    """Get the unit notes json sorted in descending order by timestamp (most recent first)."""
+    notes = []
+    if not reg_notes or not reg_documents:
+        return notes
+    for note in reg_notes:
+        note_json = note.registration_json
+        note_json['documentRegistrationNumber'] = get_note_doc_reg_num(reg_documents, note.reg_document_id)
+        notes.append(note_json)
+    # Add any NCAN registration using the cancelled note as a base.
+    for doc in reg_documents:
+        if doc.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE):
+            for note in reg_notes:
+                if doc.id == note.can_document_id:
+                    cancel_json = note.registration_json
+                    note_json = {
+                        'cancelledDocumentType': cancel_json.get('documentType'),
+                        'cancelledDocumentRegistrationNumber': get_note_doc_reg_num(reg_documents,
+                                                                                    note.reg_document_id),
+                        'documentType': doc.document_type.strip(),
+                        'documentId': doc.id,
+                        'documentRegistrationNumber': doc.document_reg_id,
+                        'status': MhrNoteStatusTypes.ACTIVE.value,
+                        'createDateTime':  model_utils.format_local_ts(doc.registration_ts),
+                        'remarks': cancel_json.get('remarks'),
+                        'givingNoticeParty': cancel_json.get('givingNoticeParty')
+                    }
+                    notes.append(note_json)
+    # Now sort in descending timestamp order.
+    return sort_notes(notes)

--- a/mhr_api/src/mhr_api/utils/note_validator.py
+++ b/mhr_api/src/mhr_api/utils/note_validator.py
@@ -48,7 +48,9 @@ def validate_note(registration: MhrRegistration, json_data, staff: bool = False,
     try:
         current_app.logger.info(f'Validating unit note registration staff={staff}, group={group_name}')
         if not staff and registration:
-            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
+            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number,
+                                                           MhrRegistrationTypes.REG_NOTE,
+                                                           staff)
         error_msg += validate_doc_id(json_data)
         error_msg += validator_utils.validate_submitting_party(json_data)
         doc_type: str = None

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -139,7 +139,7 @@ def validate_transfer(registration: MhrRegistration,  # pylint: disable=too-many
         if staff:
             error_msg += validator_utils.validate_doc_id(json_data, True)
         elif registration:
-            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
+            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number, MhrRegistrationTypes.TRANS, staff)
         active_group_count: int = get_active_group_count(json_data, registration)
         error_msg += validator_utils.validate_submitting_party(json_data)
         error_msg += validate_owner_groups(json_data.get('addOwnerGroups'),
@@ -190,10 +190,9 @@ def validate_exemption(registration: MhrRegistration,  # pylint: disable=too-man
         if staff:
             error_msg += validator_utils.validate_doc_id(json_data)
         elif registration:
-            reg_type = reg_utils.get_ppr_registration_type(registration.mhr_number)
-            current_app.logger.debug(f'Checking PPR reg type {reg_type}')
-            if reg_type and PPR_SECURITY_AGREEMENT.find(reg_type) < 0:
-                error_msg += validator_utils.PPR_LIEN_EXISTS
+            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number,
+                                                           MhrRegistrationTypes.EXEMPTION_RES,
+                                                           staff)
         location = validator_utils.get_existing_location(registration)
         if location and (location.get('parkName') or location.get('dealerName')):
             error_msg += LOCATION_NOT_ALLOWED
@@ -238,7 +237,7 @@ def validate_permit(registration: MhrRegistration, json_data, staff: bool = Fals
         if staff:
             error_msg += validator_utils.validate_doc_id(json_data, True)
         elif registration:
-            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number)
+            error_msg += validator_utils.validate_ppr_lien(registration.mhr_number, MhrRegistrationTypes.PERMIT, staff)
         current_location = validator_utils.get_existing_location(registration)
         if registration and group_name and group_name == MANUFACTURER_GROUP:
             error_msg += validate_manufacturer_permit(registration.mhr_number, json_data.get('submittingParty'),

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -27,6 +27,7 @@ from mhr_api.exceptions import BusinessException
 from mhr_api.models import Db2Document, Db2Manuhome, Db2Mhomnote, Db2Owngroup, MhrRegistration, Db2Location
 from mhr_api.models import utils as model_utils
 from mhr_api.models.db2.manuhome import LEGACY_STATUS_DESCRIPTION
+from mhr_api.models.db2.registration_utils import adjust_group_interest
 from mhr_api.models.type_tables import MhrPartyTypes, MhrTenancyTypes, MhrDocumentTypes
 from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GOV_ACCOUNT_ROLE, STAFF_ROLE
 
@@ -435,7 +436,7 @@ def test_adjust_group_interest_new(session, interest, numerator, denominator, ne
                                         interest_numerator=numerator,
                                         interest_denominator=denominator)
         groups.append(group)
-        Db2Manuhome.adjust_group_interest(groups, True)
+        adjust_group_interest(groups, True)
         assert groups[0].interest == new_interest
 
 
@@ -450,7 +451,7 @@ def test_adjust_group_interest_2(session, group1, group2, group3, interest1, int
             groups.append(group2)
         if group3:
             groups.append(group3)
-        Db2Manuhome.adjust_group_interest(groups, True)
+        adjust_group_interest(groups, True)
         for group in groups:
             if group.group_id == 1:
                 assert group.interest == interest1

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -21,7 +21,7 @@ from registry_schemas.example_data.mhr import REGISTRATION, TRANSFER, EXEMPTION
 
 from mhr_api.utils import registration_validator as validator, manufacturer_validator as man_validator, validator_utils
 from mhr_api.models import MhrRegistration, MhrManufacturer, utils as model_utils
-from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrTenancyTypes, MhrDocumentTypes
+from mhr_api.models.type_tables import MhrRegistrationTypes, MhrTenancyTypes, MhrDocumentTypes
 from mhr_api.models.utils import is_legacy, now_ts
 from mhr_api.services.authz import QUALIFIED_USER_GROUP
 from tests.unit.utils.test_registration_data import (
@@ -681,7 +681,7 @@ def get_valid_registration(o_type):
 @pytest.mark.parametrize('desc, mhr_number, message_content', TEST_DATA_LIEN_COUNT)
 def test_validate_ppr_lien(session, desc, mhr_number, message_content):
     """Assert that the PPR lien check validation works as expected."""
-    error_msg = validator_utils.validate_ppr_lien(mhr_number)
+    error_msg = validator_utils.validate_ppr_lien(mhr_number, MhrRegistrationTypes.TRANS, False)
     assert error_msg == message_content
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17853

*Description of changes:*
- Update rules for restricting non-staff registrations when a PPR registration exists on a MH.

*Issue #:* /bcgov/entity#18043
- Fix saving tenants in common DB2 owngroup.grpseqno value to match legacy application value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
