### PR TITLE
Fix/transfer ownership group modal typo hairline

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -39,6 +39,7 @@
               <div class="pa-6 fs-14 text-center no-owners-head-row" data-test-id="no-data-msg">
                 No owners added yet.
               </div>
+              <v-divider class="horizontal-divider pb-1" />
             </div>
 
             <div
@@ -1063,5 +1064,10 @@ export default defineComponent({
     margin-left: 20px !important;
     padding-left: 20px !important;
   }
+
+  .horizontal-divider {
+  border-color: $gray7;
+  max-width: 4px;
+}
 }
 </style>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -1065,7 +1065,7 @@ export default defineComponent({
     padding-left: 20px !important;
   }
 
-  .horizontal-divider {
+.horizontal-divider {
   border-color: $gray7;
   max-width: 4px;
 }

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -9,7 +9,7 @@
           'Deleting a group also deletes all of the owners in the group. ' +
           'All subsequent groups will be re-numbered.' +
           '<br><br>' +
-          'If there are any newly added owerns in the group that you wish to keep, move those ' +
+          'If there are any newly added owners in the group that you wish to keep, move those ' +
           'owners to a different group prior to deletion.',
         acceptText: 'Delete Group',
         cancelText: 'Cancel'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17651

*Description of changes:*

1. added a divider below the message 'no owner added yet', when all owners are removed
2. fixed a typo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
