### PR TITLE
Pre-select only one Owner role for Sale Transfers

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -750,7 +750,6 @@ export default defineComponent({
       isTransferDueToDeath,
       disableNameFields,
       HomeOwnerPartyTypes,
-      getMhrTransferType,
       transfersContent,
       isFrozenMhr,
       customRules,
@@ -821,6 +820,10 @@ export default defineComponent({
 
     label {
       color: $gray7;
+      opacity: .4;
+    }
+
+    i {
       opacity: .4;
     }
   }

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
@@ -64,6 +64,7 @@ export default defineComponent({
       disableNameFields,
       isTransferDueToDeath,
       isTransferToAdminNoWill,
+      isTransferDueToSaleOrGift,
       isTransferToExecutorProbateWill,
       isTransferToExecutorUnder25Will,
       isTransferToSurvivingJointTenant
@@ -84,12 +85,13 @@ export default defineComponent({
           return isTransferToExecutorProbateWill.value || isTransferToExecutorUnder25Will.value ||
             isTransferToAdminNoWill.value || isTransferToSurvivingJointTenant.value
         case HomeOwnerPartyTypes.EXECUTOR:
-          return disableNameFields.value || isTransferToAdminNoWill.value || isFrozenMhrDueToUnitNote.value
+          return disableNameFields.value || isTransferToAdminNoWill.value || isTransferDueToSaleOrGift.value ||
+            isFrozenMhrDueToUnitNote.value
         case HomeOwnerPartyTypes.ADMINISTRATOR:
           return isTransferToSurvivingJointTenant.value || isTransferToExecutorUnder25Will.value ||
-            isTransferToExecutorProbateWill.value || isFrozenMhrDueToUnitNote.value
+            isTransferToExecutorProbateWill.value || isTransferDueToSaleOrGift.value || isFrozenMhrDueToUnitNote.value
         case HomeOwnerPartyTypes.TRUSTEE:
-          return isTransferDueToDeath.value || isFrozenMhrDueToUnitNote.value
+          return isTransferDueToDeath.value || isTransferDueToSaleOrGift.value || isFrozenMhrDueToUnitNote.value
       }
     }
 

--- a/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrRegistrationHomeOwners.spec.ts
@@ -588,11 +588,11 @@ describe('Home Owners', () => {
     await nextTick()
 
     const HomeOwnerRolesComponent = wrapper.findComponent(HomeOwnerRoles)
-    const radioButtons = HomeOwnerRolesComponent.findAll('input[type="radio"]')
     expect(HomeOwnerRolesComponent.exists()).toBeTruthy()
+    const radioButtons = HomeOwnerRolesComponent.findAll('input[type="radio"]')
     expect(radioButtons).toHaveLength(4)
     radioButtons.wrappers.forEach(radioButton => {
-      expect(radioButton.attributes('disabled')).toBeFalsy()
+      expect(radioButton.attributes('disabled')).toBe(undefined)
     })
   })
 })

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -9,7 +9,8 @@ import {
   AddEditHomeOwner,
   HomeOwnersTable,
   HomeOwnerGroups,
-  TableGroupHeader
+  TableGroupHeader,
+  HomeOwnerRoles
 } from '@/components/mhrRegistration/HomeOwners'
 import { InfoChip, SharedDatePicker, SimpleHelpToggle } from '@/components/common'
 import {
@@ -29,7 +30,6 @@ import {
 } from './test-data'
 import { getTestId } from './utils'
 import {
-  MhrHomeOwnerGroupIF,
   MhrRegistrationHomeOwnerGroupIF,
   MhrRegistrationHomeOwnerIF,
   TransferTypeSelectIF
@@ -451,6 +451,28 @@ describe('Home Owners', () => {
     expect(homeOwners.text()).not.toContain('Group 1')
     expect(homeOwners.find(getTestId('invalid-group-msg')).exists()).toBeFalsy()
     expect(homeOwners.find(getTestId('no-data-msg')).exists()).toBeFalsy()
+  })
+
+  it('TRANS SALE GIFT: only one role (Owner) should be active when adding/editing an owner', async () => {
+    const homeOwnerGroup: MhrRegistrationHomeOwnerGroupIF[] = [{ groupId: 1, owners: [mockedPerson], type: '' }]
+
+    await store.setMhrTransferCurrentHomeOwnerGroups(homeOwnerGroup)
+    await store.setMhrTransferHomeOwnerGroups(homeOwnerGroup)
+
+    expect(wrapper.findComponent(AddEditHomeOwner).exists()).toBeFalsy()
+    openAddPerson()
+    await Vue.nextTick()
+    expect(wrapper.findComponent(AddEditHomeOwner).exists()).toBeTruthy()
+
+    const HomeOwnerRolesComponent = wrapper.findComponent(AddEditHomeOwner).findComponent(HomeOwnerRoles)
+    const radioButtons = HomeOwnerRolesComponent.findAll('input[type="radio"]')
+    expect(radioButtons).toHaveLength(4)
+
+    // role 'Owner' should be enabled while others disabled
+    expect(radioButtons.at(0).attributes('disabled')).toBe(undefined)
+    expect(radioButtons.at(1).attributes('disabled')).toBe('disabled')
+    expect(radioButtons.at(2).attributes('disabled')).toBe('disabled')
+    expect(radioButtons.at(3).attributes('disabled')).toBe('disabled')
   })
 
   it('TRANS WILL: display Supporting Document component for deleted sole Owner and add Executor', async () => {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#15852

*Description of changes:*
- For Transfer Due to Sale/Gift only: one role (Owner) should be active when adding/editing Home Owners
- Update tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
