### PR TITLE
Add owner corpNumber, deathCorpnumber

### DIFF
--- a/mhr_api/requirements.txt
+++ b/mhr_api/requirements.txt
@@ -59,4 +59,4 @@ sentry-sdk==1.20.0
 six==1.16.0
 strict-rfc3339==0.7
 urllib3==1.26.11
-git+https://github.com/bcgov/registry-schemas.git@1.8.3#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.8.4#egg=registry_schemas

--- a/mhr_api/requirements/bcregistry-libraries.txt
+++ b/mhr_api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/registry-schemas.git@1.8.3#egg=registry_schemas
+git+https://github.com/bcgov/registry-schemas.git@1.8.4#egg=registry_schemas

--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -108,7 +108,7 @@ SELECT (SELECT COUNT(mr.id)
             AND mr.registration_type IN ('MHREG')),
       (SELECT mlc.registration_type
          FROM mhr_lien_check_vw mlc
-        WHERE mlc.mhr_number = :query_value2 
+        WHERE mlc.mhr_number = :query_value2
      ORDER BY mlc.base_registration_ts DESC
         FETCH FIRST 1 ROWS ONLY)
 """

--- a/mhr_api/src/mhr_api/models/mhr_party.py
+++ b/mhr_api/src/mhr_api/models/mhr_party.py
@@ -49,6 +49,8 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
     description = db.Column('description', db.String(150), nullable=True)
     death_cert_number = db.Column('death_cert_number', db.String(20), nullable=True)
     death_ts = db.Column('death_ts', db.DateTime, nullable=True)
+    corp_number = db.Column('corp_number', db.String(20), nullable=True)
+    death_corp_number = db.Column('death_corp_number', db.String(20), nullable=True)
 
     # parent keys
     address_id = db.Column('address_id', db.Integer, db.ForeignKey('addresses.id'), nullable=True, index=True)
@@ -115,6 +117,8 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
             party['description'] = self.description
         if self.suffix:
             party['suffix'] = self.suffix
+        if self.corp_number:
+            party['corpNumber'] = self.corp_number
         return party
 
     @classmethod
@@ -184,6 +188,8 @@ class MhrParty(db.Model):  # pylint: disable=too-many-instance-attributes
             party.description = json_data['description'].strip().upper()
         if json_data.get('suffix'):
             party.suffix = json_data['suffix'].strip().upper()
+        if json_data.get('corpNumber'):
+            party.corp_number = json_data['corpNumber'].strip()
 
         party.address = Address.create_from_json(json_data['address'])
 

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -28,7 +28,7 @@ from mhr_api.models.type_tables import (
     MhrRegistrationTypes,
     MhrRegistrationStatusTypes
 )
-from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, GENERAL_USER_GROUP, BCOL_HELP
+from mhr_api.services.authz import MANUFACTURER_GROUP, QUALIFIED_USER_GROUP, DEALERSHIP_GROUP, BCOL_HELP
 from mhr_api.services.authz import GOV_ACCOUNT_ROLE
 from mhr_api.models.queries import (
     DOC_ID_COUNT_QUERY,
@@ -267,7 +267,7 @@ def get_generated_values(registration, draft, user_group: str = None):
     gen_doc_id: bool = False
     if draft:
         query = QUERY_PKEYS_NO_DRAFT
-    if user_group and user_group in (QUALIFIED_USER_GROUP, GENERAL_USER_GROUP, BCOL_HELP):
+    if user_group and user_group in (QUALIFIED_USER_GROUP, DEALERSHIP_GROUP, BCOL_HELP):
         query += DOC_ID_QUALIFIED_CLAUSE
         gen_doc_id = True
         current_app.logger.debug('Updating query to generate qualified user document id.')
@@ -304,7 +304,7 @@ def get_change_generated_values(registration, draft, user_group: str = None):
     query = CHANGE_QUERY_PKEYS
     if draft:
         query = CHANGE_QUERY_PKEYS_NO_DRAFT
-    if user_group and user_group in (QUALIFIED_USER_GROUP, GENERAL_USER_GROUP, BCOL_HELP):
+    if user_group and user_group in (QUALIFIED_USER_GROUP, DEALERSHIP_GROUP, BCOL_HELP):
         query += DOC_ID_QUALIFIED_CLAUSE
     elif user_group and user_group == MANUFACTURER_GROUP:
         query += DOC_ID_MANUFACTURER_CLAUSE
@@ -319,8 +319,6 @@ def get_change_generated_values(registration, draft, user_group: str = None):
     if not draft:
         registration.draft_number = str(row[3])
         registration.draft_id = int(row[4])
-    # if user_group and user_group in (QUALIFIED_USER_GROUP, MANUFACTURER_GROUP, GOV_ACCOUNT_ROLE,
-    #                                 GENERAL_USER_GROUP, BCOL_HELP):
     if draft:
         registration.doc_id = str(row[3])
     else:
@@ -351,6 +349,8 @@ def update_deceased(owners_json, owner):
     if match_json:
         if match_json.get('deathCertificateNumber'):
             owner.death_cert_number = str(match_json.get('deathCertificateNumber')).strip()
+        elif match_json.get('deathCorpNumber'):
+            owner.death_corp_number = str(match_json.get('deathCorpNumber')).strip()
         if match_json.get('deathDateTime'):
             owner.death_ts = model_utils.ts_from_iso_format(match_json.get('deathDateTime'))
 

--- a/mhr_api/src/mhr_api/services/authz.py
+++ b/mhr_api/src/mhr_api/services/authz.py
@@ -43,7 +43,7 @@ TRANSFER_DEATH_JT = 'mhr_transfer_death'
 # MH groups from role combinations
 QUALIFIED_USER_GROUP = 'mhr_qualified_user'
 MANUFACTURER_GROUP = 'mhr_manufacturer'
-GENERAL_USER_GROUP = 'mhr_general_user'
+DEALERSHIP_GROUP = 'mhr_dealership'
 SEARCH_USER_GROUP = 'mhr_search_user'
 SBC_STAFF_ACCOUNT = 'SBC_STAFF'
 
@@ -293,5 +293,5 @@ def get_group(jwt: JwtManager) -> str:  # pylint: disable=too-many-return-statem
             not jwt.validate_roles([REGISTER_MH]):
         return QUALIFIED_USER_GROUP
     if jwt.validate_roles([REQUEST_TRANSPORT_PERMIT]):
-        return GENERAL_USER_GROUP
+        return DEALERSHIP_GROUP
     return SEARCH_USER_GROUP

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -76,6 +76,7 @@ TRAN_DEATH_NEW_OWNER = 'The new owners must be individuals or businesses for thi
 TRAN_AFFIDAVIT_NEW_OWNER = 'The new owners must be executors for this registration. '
 TRAN_DEATH_ADD_OWNER = 'Owners cannot be added with this registration. '
 TRAN_DEATH_CERT_MISSING = 'A death certificate number is required with this registration. '
+TRAN_DEATH_CORP_NUM_MISSING = 'A removed business owner corporation number is required with this registration. '
 TRAN_DEATH_DATE_MISSING = 'A death date and time is required with this registration. '
 TRAN_DEATH_DATE_INVALID = 'A death date and time must be in the past. '
 TRAN_AFFIDAVIT_DECLARED_VALUE = 'Declared value must be cannot be greater than 25000 for this registration. '
@@ -351,7 +352,9 @@ def validate_transfer_death_owners(reg_type: str, new_owners, delete_owners):  #
     party_count: int = 0
     for owner_json in delete_owners:
         if not existing_owner_added(new_owners, owner_json) and reg_type == MhrRegistrationTypes.TRAND:
-            if not owner_json.get('deathCertificateNumber'):
+            if owner_json.get('organizationName') and not owner_json.get('deathCorpNumber'):
+                error_msg += TRAN_DEATH_CORP_NUM_MISSING
+            elif not owner_json.get('organizationName') and not owner_json.get('deathCertificateNumber'):
                 error_msg += TRAN_DEATH_CERT_MISSING
             if not owner_json.get('deathDateTime'):
                 error_msg += TRAN_DEATH_DATE_MISSING

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.5.8'  # pylint: disable=invalid-name
+__version__ = '1.5.9'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -130,6 +130,8 @@ TEST_TRANSFER_DATA_TRAND = [
      validator.TRAN_DEATH_ADD_OWNER),
     ('Invalid no cert number', False,  '000920', 'PS12345', TRAND_DELETE_GROUPS, TRAND_ADD_GROUPS,
      validator.TRAN_DEATH_CERT_MISSING),
+    ('Invalid no corp number', False,  '000920', 'PS12345', TRAND_DELETE_GROUPS, TRAND_ADD_GROUPS,
+     validator.TRAN_DEATH_CORP_NUM_MISSING),
     ('Invalid no death ts', False,  '000920', 'PS12345', TRAND_DELETE_GROUPS, TRAND_ADD_GROUPS,
      validator.TRAN_DEATH_DATE_MISSING),
     ('Invalid tenancy type', False,  '000920', 'PS12345', SO_GROUP, TRAND_ADD_GROUPS,
@@ -411,6 +413,11 @@ def test_validate_transfer_trand(session, desc, valid, mhr_num, account_id, dele
         json_data['addOwnerGroups'][0]['owners'].append(ADD_OWNER)
     elif desc == 'Invalid no cert number':
         del json_data['deleteOwnerGroups'][0]['owners'][1]['deathCertificateNumber']
+    elif desc == 'Invalid no corp number':
+        del json_data['deleteOwnerGroups'][0]['owners'][1]['deathCertificateNumber']
+        del json_data['deleteOwnerGroups'][0]['owners'][1]['individualName']
+        json_data['deleteOwnerGroups'][0]['owners'][1]['partyType'] = 'OWNER_BUS'
+        json_data['deleteOwnerGroups'][0]['owners'][1]['organizationName'] = 'TEST BUS NAME'
     elif desc == 'Invalid no death ts':
         del json_data['deleteOwnerGroups'][0]['owners'][1]['deathDateTime']
     elif desc == 'Invalid add 2 groups':


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15704

*Description of changes:*
- Add owner corpNum to capture business owner corp number when available.
- Add owner deathCorpNumber for staff TRAND registration types when removing an owner.

*Issue #:* /bcgov/entity#14563
- Rename keycloak group mhr_general_user to mhr_dealership


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
