### PR TITLE
missing hint of declared value for mhr transfer

### DIFF
--- a/ppr-ui/src/components/mhrTransfers/TransferType.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferType.vue
@@ -111,7 +111,7 @@
                 :disabled="disableSelect"
                 :rules="declaredValueRules"
                 :hint="declaredHomeValueHint"
-                :persistent-hint="isDeclaredHitPersistent"
+                persistent-hint="true"
                 data-test-id="declared-value"
               />
               <span class="mt-4">.00</span>
@@ -186,10 +186,6 @@ export default defineComponent({
           required('Enter declared value of home'))
       }),
       showFormError: computed(() => props.validate && !localState.isValid),
-      isDeclaredHitPersistent: computed(() =>
-        [ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL,
-          ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL].includes(getMhrTransferType.value?.transferType)
-      ),
       declaredHomeValueHint: computed(() =>
         transfersContent.declaredHomeValueHint[getMhrTransferType.value?.transferType]
       ),

--- a/ppr-ui/src/resources/mhr-transfers/transfers-content.ts
+++ b/ppr-ui/src/resources/mhr-transfers/transfers-content.ts
@@ -2,11 +2,15 @@ import { ApiTransferTypes } from '@/enums'
 
 export const transfersContent = {
   declaredHomeValueHint: {
+    [ApiTransferTypes.SALE_OR_GIFT]:
+      'Must be the current market value of the home',
+    [ApiTransferTypes.SURVIVING_JOINT_TENANT]:
+      'Must be the current market value of the home',
     [ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL]:
-      'Must match the declared value at death as recorded on the list of Assets and Liabilities',
+      'Must match the declared value at death, as recorded on the list of Assets and Liabilities',
     [ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL]:
-      'Must match the declared value at death as recorded on the list of Assets and Liabilities',
+      'Must match the declared value at death, as recorded on the list of Assets and Liabilities',
     [ApiTransferTypes.TO_ADMIN_NO_WILL]:
-      'Must match the declared value at death as recorded on the list of Assets and Liabilities'
+      'Must match the declared value at death, as recorded on the list of Assets and Liabilities'
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17647

*Description of changes:*

Added some hints for all types of mhr transfer, declared value. And made the hints always show.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
