### PR TITLE
Allow NCON, NCAN, NRED in exempt state.

### DIFF
--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -744,7 +744,9 @@ def __collapse_results(results):
         has_caution: bool = False
         changes = []
         for result in results:
-            if result['mhrNumber'] == reg['mhrNumber'] and result['registrationType'] != MhrRegistrationTypes.MHREG:
+            if result['mhrNumber'] == reg['mhrNumber'] and \
+                    result['registrationType'] not in (MhrRegistrationTypes.MHREG,
+                                                       MhrRegistrationTypes.MHREG_CONVERSION):
                 if result.get('expireDays') and result.get('expireDays') >= 0:
                     has_caution = True
                 changes.append(result)

--- a/mhr_api/src/mhr_api/utils/admin_validator.py
+++ b/mhr_api/src/mhr_api/utils/admin_validator.py
@@ -18,7 +18,7 @@ Validation includes verifying the data combination for various registration docu
 from flask import current_app
 
 from mhr_api.models import MhrRegistration, utils as model_utils, registration_utils as reg_utils
-from mhr_api.models.type_tables import MhrDocumentTypes, MhrNoteStatusTypes
+from mhr_api.models.type_tables import MhrDocumentTypes, MhrNoteStatusTypes, MhrRegistrationTypes
 from mhr_api.models.db2.mhomnote import FROM_LEGACY_STATUS
 from mhr_api.models.db2.utils import FROM_LEGACY_DOC_TYPE
 from mhr_api.utils import validator_utils
@@ -55,7 +55,10 @@ def validate_admin_reg(registration: MhrRegistration, json_data) -> str:
         doc_type: str = json_data.get('documentType', '')
         if not doc_type and json_data.get('note') and json_data['note'].get('documentType'):
             doc_type = json_data['note'].get('documentType')
-        error_msg += validator_utils.validate_registration_state(registration, True, doc_type)
+        error_msg += validator_utils.validate_registration_state(registration,
+                                                                 True,
+                                                                 MhrRegistrationTypes.REG_STAFF_ADMIN,
+                                                                 doc_type)
         error_msg += validate_giving_notice(json_data, doc_type)
         if doc_type and doc_type == MhrDocumentTypes.NRED:
             error_msg += validate_nred(registration, json_data)

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -507,7 +507,7 @@ def validate_owner_groups(groups,
             error_msg += validate_owner(owner)
     if so_count > 1 or (so_count == 1 and len(groups) > 1):
         error_msg += ADD_SOLE_OWNER_INVALID
-    if not new and active_count == 1 and tenancy_type in (MhrTenancyTypes.COMMON, MhrTenancyTypes.NA):
+    if not new and active_count == 1 and tenancy_type == MhrTenancyTypes.COMMON:
         error_msg += GROUP_COMMON_INVALID
     return error_msg
 

--- a/mhr_api/src/mhr_api/utils/validator_utils.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils.py
@@ -132,7 +132,7 @@ def validate_registration_state(registration: MhrRegistration, staff: bool, reg_
         return error_msg
     if is_legacy():
         return validator_utils_legacy.validate_registration_state(registration, staff, reg_type, doc_type)
-    if reg_type and reg_type == MhrDocumentTypes.EXRE:
+    if doc_type and doc_type == MhrDocumentTypes.EXRE:
         return validate_registration_state_exre(registration)
     if reg_type and reg_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
         return validate_registration_state_exemption(registration, reg_type, staff)
@@ -140,7 +140,8 @@ def validate_registration_state(registration: MhrRegistration, staff: bool, reg_
         if registration.status_type != MhrRegistrationStatusTypes.ACTIVE:
             if registration.status_type == MhrRegistrationStatusTypes.CANCELLED or \
                     doc_type is None or \
-                    doc_type != MhrDocumentTypes.NPUB:
+                    doc_type not in (MhrDocumentTypes.NPUB, MhrDocumentTypes.NCON,
+                                     MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED):
                 error_msg += STATE_NOT_ALLOWED
         elif registration.change_registrations:
             last_reg: MhrRegistration = registration.change_registrations[-1]

--- a/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
@@ -43,14 +43,15 @@ def validate_registration_state(registration, staff: bool, reg_type: str, doc_ty
     if not registration or not registration.manuhome:
         return error_msg
     manuhome: Db2Manuhome = registration.manuhome
-    if reg_type and reg_type == MhrDocumentTypes.EXRE:
+    if doc_type and doc_type == MhrDocumentTypes.EXRE:
         return validate_registration_state_exre(manuhome)
     if reg_type and reg_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
         return validate_registration_state_exemption(manuhome, reg_type, staff)
     if manuhome.mh_status != manuhome.StatusTypes.REGISTERED:
         if manuhome.mh_status == manuhome.StatusTypes.CANCELLED or \
                 doc_type is None or \
-                doc_type != MhrDocumentTypes.NPUB:
+                doc_type not in (MhrDocumentTypes.NPUB, MhrDocumentTypes.NCON,
+                                 MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED):
             error_msg += STATE_NOT_ALLOWED
     elif manuhome.reg_documents:
         last_doc: Db2Document = manuhome.reg_documents[-1]

--- a/mhr_api/test_data/db2_data_files/test0006.sql
+++ b/mhr_api/test_data/db2_data_files/test0006.sql
@@ -1,0 +1,71 @@
+-- UT-0033 000932 MHREG EXEMPT with NCON, TAXN notes.
+INSERT INTO amhrtdb.manuhome(MANHOMID, MHREGNUM, MHSTATUS, REGDOCID, UPDATECT, UPDATEID, UPDATEDA, UPDATETI)
+     VALUES (200000047, '000932', 'E', 'UT000047', 1, 'PS12345 ', current date, current time)
+;
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000047', '000932', current timestamp, current timestamp, '101 ', '90499047', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0033')
+;
+INSERT INTO amhrtdb.descript(MANHOMID, DESCRNID, STATUS, REGDOCID, CSANUMBR, CSASTAND, NUMBSECT, YEARMADE,
+                             SERNUMB1, LENGTH1, LENGIN1, WIDTH1, WIDIN1,
+                             MANUNAME, MAKEMODL, REBUILTR, OTHERREM, ENGIDATE)
+     VALUES (200000047, 1, 'A', 'UT000047', '77777', '1234', 1, '2000', '888888', 60, 10, 14, 11,
+             'MANUFACTURER', 'make model', 'rebuilt', 'other', TO_DATE('0001-01-01', 'YYYY-MM-DD'))
+;
+INSERT INTO amhrtdb.location(MANHOMID, LOCATNID, STATUS, REGDOCID, STNUMBER, STNAME, TOWNCITY, PROVINCE, MAHPNAME,
+                             MAHPPAD, PIDNUMB, TAXCERT, TAXDATE, MHDEALER, ADDDESC)
+     VALUES (200000047, 1, 'A', 'UT000047', '1234', 'TEST-0033', 'CITY', 'BC', '', '', '005509807', 'N',
+             TO_DATE('0001-01-01', 'YYYY-MM-DD'), '', 'additional')
+;
+INSERT INTO amhrtdb.owngroup(MANHOMID, OWNGRPID, COPGRPID, GRPSEQNO, STATUS, REGDOCID, TENYTYPE, INTEREST, INTNUMER, TENYSPEC)
+     VALUES (200000047, 1, 0, 1, '3', 'UT000047', 'SO', '', 0, 'Y')
+;
+INSERT INTO amhrtdb.owner(MANHOMID, OWNGRPID, OWNERID, OWNSEQNO, VERIFIED, OWNRTYPE, COMPNAME, OWNRFONE, OWNRPOCO, OWNRNAME, OWNRSUFF, OWNRADDR)
+     VALUES (200000047, 1, 1, 1, ' ', 'B', 'TESTEXRSACTIVE', '6041234567', 'V8R 3A5', 'TTEST EXRS ACTIVE', '',
+             '1234 TEST-0033                          CITY                                    BC CA')
+;
+INSERT INTO amhrtdb.cmpserno(MANHOMID, CMPSERID, SERIALNO)
+     VALUES (200000047, 1, (SELECT serialno FROM amhrtdb.cmpserno WHERE manhomid = 40865 AND CMPSERID = 1))
+;
+-- UT-0033 000932 NCON note registration
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000048', '000932', current timestamp, current timestamp, 'NCON', '90499048', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0033')
+;
+INSERT INTO amhrtdb.mhomnote(MANHOMID, MHNOTEID, MHNOTENO, REGDOCID, CANDOCID, DOCUTYPE, STATUS, DESTROYD, EXPIRYDA, PHONE, NAME, ADDRESS, REMARKS)
+     VALUES (200000047, 1, 1, 'UT000048', '', 'NCON', 'A', '', TO_DATE('0001-01-01', 'YYYY-MM-DD'), '6041234567', 
+             'PERSON GIVING NOTICE', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'NCON NOTE REMARKS')
+;
+-- UT-0033 000932 TAXN note registration
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000049', '000932', current timestamp, current timestamp, 'TAXN', '90499049', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0033')
+;
+INSERT INTO amhrtdb.mhomnote(MANHOMID, MHNOTEID, MHNOTENO, REGDOCID, CANDOCID, DOCUTYPE, STATUS, DESTROYD, EXPIRYDA, PHONE, NAME, ADDRESS, REMARKS)
+     VALUES (200000047, 2, 2, 'UT000049', '', 'TAXN', 'A', '', TO_DATE('0001-01-01', 'YYYY-MM-DD'), '6041234567', 
+             'PERSON GIVING NOTICE', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TAXN NOTE REMARKS')
+;
+-- UT-0033 000932 EXRS registration
+INSERT INTO amhrtdb.document(DOCUMTID, MHREGNUM, DRAFDATE, REGIDATE, DOCUTYPE, DOCUREGI, OWNLAND, UPDATEID, PHONE, NAME, ADDRESS, AFFIRMBY, OLBCFOLI)
+     VALUES ('UT000050', '000932', current timestamp, current timestamp, 'EXRS', '90499050', 'N', 'PS12345 ', '6041234567', 
+             'SUBMITTING', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'TEST USER', 'UT-0033')
+;
+INSERT INTO amhrtdb.mhomnote(MANHOMID, MHNOTEID, MHNOTENO, REGDOCID, CANDOCID, DOCUTYPE, STATUS, DESTROYD, EXPIRYDA, PHONE, NAME, ADDRESS, REMARKS)
+     VALUES (200000047, 3, 3, 'UT000050', '', 'EXRS', 'A', '', TO_DATE('0001-01-01', 'YYYY-MM-DD'), '6041234567', 
+             'PERSON GIVING NOTICE', 
+             '1234 TEST-0033                                                                  CITY                                    BC CA                            V8R 3A5', 
+             'RESIDENTIAL REMARKS')
+;
+

--- a/mhr_api/test_data/postgres_data_files/test0008.sql
+++ b/mhr_api/test_data/postgres_data_files/test0008.sql
@@ -1,0 +1,135 @@
+-- UT-0033 000932 MHREG EXEMPT with NCON, TAXN notes.
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000047, '000932', 'PS12345', 'MHREG', now() at time zone 'UTC', 'EXEMPT', 200000001, null, null, 'TESTUSER', 'UT-0033')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000128, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000108, 'SUBMITTING', 'ACTIVE', 200000047, 200000047, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000128, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000129, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_locations(id, location_type, status_type, registration_id, change_registration_id, address_id, ltsa_description, 
+                        additional_description, dealer_name, exception_plan, leave_province, tax_certification, tax_certification_date, 
+                        park_name, park_pad, pid_number, lot, parcel, block, district_lot, part_of, section,
+                        township, range, meridian, land_district, plan)
+    VALUES(200000047, 'OTHER', 'ACTIVE', 200000047, 200000047, 190000129,
+           'LOT 24 DISTRICT LOT 497 KAMLOOPS DIVISION YALE DISTRICT PLAN 25437',
+           'additional', NULL, NULL, 'N', 'Y', now() at time zone 'UTC', NULL, NULL, '005509807', NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+;
+INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_standard, number_of_sections, 
+                          square_feet, year_made, circa, engineer_date, engineer_name, manufacturer_name,
+                          make, model, rebuilt_remarks, other_remarks, change_registration_id)
+    VALUES(200000047, 'ACTIVE', 200000047, '7777700000', '1234', 3, NULL, 2015, 'Y', now() at time zone 'UTC',
+           'engineer name', 'manufacturer', 'make', 'model', 'rebuilt', 'other', 200000047)
+;
+INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
+                               width_feet, width_inches, change_registration_id)
+    VALUES(200000044, 200000047, 'ACTIVE', mhr_serial_compressed_key('888888'), '888888', 60, 10, 14, 11,
+           200000047)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000047, 'REG_101', 200000047, 'UT000047', '90499047', 'attn', NULL, NULL, 'Y', null, null, null, 200000047)
+;
+INSERT INTO mhr_owner_groups(id, sequence_number, registration_id, status_type, tenancy_type, interest,
+                             tenancy_specified, interest_numerator, interest_denominator, change_registration_id)
+    VALUES(200000042, 1, 200000047, 'ACTIVE', 'SOLE', NULL, 'Y', NULL, NULL, 200000047)
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000130, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000109, 'OWNER_BUS', 'ACTIVE', 200000047, 200000047, null, null, null, 'TEST EXRS ACTIVE', 
+           mhr_name_compressed_key('TEST EXRS ACTIVE'), 190000130, null, NULL, null, 200000042)
+;
+-- UT-0033 000932 NCON note registration
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000048, '000932', 'PS12345', 'REG_STAFF_ADMIN', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0033')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000131, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000110, 'SUBMITTING', 'ACTIVE', 200000048, 200000048, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000131, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000111, 'CONTACT', 'ACTIVE', 200000048, 200000048, null, null, null, 'PERSON GIVING NOTICE',
+           mhr_name_compressed_key('PERSON GIVING NOTICE'), 190000131, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000048, 'NCON', 200000048, 'UT000048', '90499048', 'attn', NULL, NULL, 'Y', null, null, null, 200000048)
+;
+INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_type, remarks, destroyed,
+                      change_registration_id, expiry_date, effective_ts)
+    VALUES(200000034, 'NCON', 200000048, 200000048, 'ACTIVE', 'NCON NOTE REMARKS', 'N', 200000048,
+           null, now() at time zone 'UTC')
+;
+-- UT-0033 000932 TAXN note registration
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000049, '000932', 'PS12345', 'REG_STAFF_ADMIN', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0033')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000132, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000112, 'SUBMITTING', 'ACTIVE', 200000049, 200000049, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000132, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000113, 'CONTACT', 'ACTIVE', 200000049, 200000049, null, null, null, 'PERSON GIVING NOTICE',
+           mhr_name_compressed_key('PERSON GIVING NOTICE'), 190000132, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000049, 'TAXN', 200000049, 'UT000049', '90499049', 'attn', NULL, NULL, 'Y', null, null, null, 200000049)
+;
+INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_type, remarks, destroyed,
+                      change_registration_id, expiry_date, effective_ts)
+    VALUES(200000035, 'TAXN', 200000049, 200000049, 'ACTIVE', 'TAXN NOTE REMARKS', 'N', 200000049,
+           null, now() at time zone 'UTC')
+;
+-- UT-0033 000932 residential exemption registration
+INSERT INTO mhr_registrations (id, mhr_number, account_id, registration_type, registration_ts, status_type, draft_id, 
+                               pay_invoice_id, pay_path, user_id, client_reference_id)
+     VALUES (200000050, '000932', 'PS12345', 'EXEMPTION_RES', now() at time zone 'UTC', 'ACTIVE', 200000001, null, null, 'TESTUSER', 'UT-0033')
+;
+INSERT INTO addresses(id, street, street_additional, city, region, postal_code, country)
+  VALUES(190000133, '1234 TEST-0033', NULL, 'CITY', 'BC', 'V8R 3A5', 'CA')
+;
+INSERT INTO mhr_parties(id, party_type, status_type, registration_id, change_registration_id, first_name, middle_name, 
+                        last_name, business_name, compressed_name, address_id, email_address, phone_number, phone_extension, 
+                        owner_group_id)
+    VALUES(200000114, 'SUBMITTING', 'ACTIVE', 200000050, 200000050, null, null, null, 'SUBMITTING',
+           mhr_name_compressed_key('SUBMITTING'), 190000133, 'test@gmail.com', '6041234567', null, null)
+;
+INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
+                          declared_value, consideration_value, own_land, transfer_date, consent, owner_x_reference, change_registration_id)
+    VALUES(200000050, 'EXRS', 200000050, 'UT000050', '90499050', 'attn', NULL, NULL, 'Y', null, null, null, 200000050)
+;
+INSERT INTO mhr_notes(id, document_type, registration_id, document_id, status_type, remarks, destroyed,
+                      change_registration_id, expiry_date, effective_ts)
+    VALUES(200000036, 'EXRS', 200000050, 200000050, 'ACTIVE', 'RESIDENTIAL REMARKS', 'N', 200000050,
+           null, now() at time zone 'UTC')
+;

--- a/mhr_api/tests/unit/utils/test_admin_validator.py
+++ b/mhr_api/tests/unit/utils/test_admin_validator.py
@@ -92,7 +92,7 @@ TEST_REG_DATA = [
     ('Invalid missing submitting party', False, 'NRED', DOC_ID_VALID, '000914', 'PS12345',
      validator_utils.SUBMITTING_REQUIRED),
     ('Invalid FROZEN', False, 'NRED', DOC_ID_VALID, '000917', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Invalid EXEMPT', False, 'NRED', DOC_ID_VALID, '000912', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
+    ('Invalid EXEMPT', False, 'REST', DOC_ID_VALID, '000912', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
     ('Invalid CANCELLED', False, 'NRED', DOC_ID_VALID, '000913', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
     ('Invalid missing doc id', False, 'NRED', None, '000914', 'PS12345', validator.DOC_ID_REQUIRED),
     ('Invalid doc id checksum', False, 'NRED', DOC_ID_INVALID_CHECKSUM, '000914', 'PS12345',
@@ -104,6 +104,7 @@ TEST_REG_DATA = [
 # test data pattern is ({description}, {valid}, {update_doc_id}, {mhr_num}, {account}, {message_content})
 TEST_NOTE_DATA_NRED = [
     ('Valid TAXN', True, 'UT000020', '000914', 'PS12345', None),
+    ('Valid TAXN EXEMPT', True, 'UT000049', '000932', 'PS12345', None),
     ('Invalid no doc id', False, None, '000914', 'PS12345', validator.UPDATE_DOCUMENT_ID_REQUIRED),
     ('Invalid status', False, 'UT000014', '000910', 'PS12345', validator.UPDATE_DOCUMENT_ID_STATUS),
     ('Invalid doc type REST', False, 'UT000022', '000915', 'PS12345', validator.NRED_INVALID_TYPE)
@@ -128,6 +129,7 @@ TEST_DATA_EXRE = [
 # test data pattern is ({description}, {valid}, {update_doc_id}, {mhr_num}, {account}, {message_content})
 TEST_NOTE_DATA_NCAN = [
     ('Valid REST', True, 'UT000022', '000915', 'PS12345', None),
+    ('Valid NCON EXEMPT', True, 'UT000048', '000932', 'PS12345', None),
     ('Invalid no doc id', False, None, '000915', 'PS12345', validator.NCAN_DOCUMENT_ID_REQUIRED),
     ('Invalid status', False, 'UT000011', '000909', 'PS12345', validator.NCAN_DOCUMENT_ID_STATUS),
     ('Invalid doc type TAXN', False, 'UT000020', '000914', 'PS12345', validator.NCAN_NOT_ALLOWED)

--- a/mhr_api/tests/unit/utils/test_note_validator.py
+++ b/mhr_api/tests/unit/utils/test_note_validator.py
@@ -139,6 +139,7 @@ TEST_NOTE_DATA_NOTICE = [
 TEST_NOTE_DATA_STATE = [
     ('Valid', True, 'CAUC', '000916', 'PS12345', None),
     ('Valid exempt NPUB', True, 'NPUB', '000912', 'PS12345', None),
+    ('Valid exempt NCON', True, 'NCON', '000912', 'PS12345', None),
     ('Invalid exempt not NPUB', False, 'CAU', '000912', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
     ('Invalid cancelled', False, 'CAU', '000913', 'PS12345', validator_utils.STATE_NOT_ALLOWED)
  ]

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -241,7 +241,7 @@ TEST_TRANSFER_DATA_TC = [
     ('Valid unchanged exec', True, True, 'COMMON', '000924', TRANS_TC_5, None),
     ('Valid split exec', True, True, 'COMMON', '000924', TRANS_TC_6, None),
     ('Invalid add TC type', False, True, 'COMMON', '000900', TRANS_TC_3, validator.GROUP_COMMON_INVALID),
-    ('Invalid add NA type', False, True, 'NA', '000900', TRANS_TC_3, validator.GROUP_COMMON_INVALID),
+    ('Invalid add NA type', False, True, 'NA', '000900', TRANS_TC_3, validator.TENANCY_TYPE_NA_INVALID),
     ('Invalid add exec', False, True, 'COMMON', '000924', TRANS_TC_5, validator.TRANSFER_PARTY_TYPE_INVALID)
 ]
 # testdata pattern is ({desc}, {valid}, {doc_type}, {reg_type}, {message content})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18285

*Description of changes:*
- Staff allow NCON, NCAN, and NRED registrations when MH status is EXEMPT.
- Update post-migration account registration summary to collapse converted registrations correctly.

*Issue #:* /bcgov/entity#18290
- bug fix allow transfer from SOLE to JOINT with ADMIN/EXEC/TRUSTEE and tenancy type of NA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
