### PR TITLE
Fix to display pre-selected Business type in HomeOwnerRoles

### DIFF
--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnerRoles.vue
@@ -72,7 +72,9 @@ export default defineComponent({
     } = useTransferOwners()
 
     const localState = reactive({
-      selectedPartyType: props.partyType
+      selectedPartyType:
+        // treat BUS type as IND to properly display selected role
+        props.partyType === HomeOwnerPartyTypes.OWNER_BUS ? HomeOwnerPartyTypes.OWNER_IND : props.partyType
     })
 
     /**


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#16140

*Description of changes:*
- Treat Business owner type as Individual to properly display pre-selected role in HomeOwnerRoles component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
