### PR TITLE
Add a Manufacturer Registration Success dialog

### DIFF
--- a/ppr-ui/src/components/common/BaseSnackbar.vue
+++ b/ppr-ui/src/components/common/BaseSnackbar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     class="my-reg-snackbar"
-    timeout="4000"
+    timeout="5000"
     transition="fade"
     v-model="showSnackbar"
   >

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -271,7 +271,7 @@ export default defineComponent({
       // Getters
       getRegTableBaseRegs, getRegTableDraftsBaseReg, isMhrRegistration, isMhrManufacturerRegistration,
       getRegTableTotalRowCount, getStateModel, getRegTableDraftsChildReg, hasMorePages, getRegTableNewItem,
-      getRegTableSortOptions, getRegTableSortPage, getUserSettings, getMhRegTableBaseRegs
+      getRegTableSortOptions, getRegTableSortPage, getUserSettings, getMhRegTableBaseRegs, isRoleStaffReg
     } = storeToRefs(useStore())
 
     const {
@@ -1000,7 +1000,7 @@ export default defineComponent({
         // check if success registration dialog for Manufacturers is permanently hidden (via user settings)
         const dialogPermanentlyHidden =
           getUserMiscSettingsByKey(SettingOptions.SUCCESSFUL_REGISTRATION_DIALOG_HIDE) || false
-        localState.manufacturerRegSuccessDialogDisplay = !dialogPermanentlyHidden
+        localState.manufacturerRegSuccessDialogDisplay = !dialogPermanentlyHidden && !isRoleStaffReg.value
 
         // trigger snackbar
         context.emit('snackBarMsg', 'Registration was successfully added to your table.')

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -2,6 +2,14 @@
   <div id="registrations-wrapper">
     <!-- Registration Dialogs -->
     <base-dialog
+      id="manufacturerRegSuccessDialog"
+      :setDisplay="manufacturerRegSuccessDialogDisplay"
+      :setOptions="manufacturerRegSuccessDialogOptions"
+      @proceed="manufacturerRegSuccessDialogDisplay = false"
+      showDismissDialogCheckbox
+    />
+
+    <base-dialog
       id="myRegAddDialog"
       :setDisplay="myRegAddDialogDisplay"
       :setOptions="myRegAddDialog"
@@ -202,6 +210,7 @@ import {
 import {
   amendConfirmationDialog,
   dischargeConfirmationDialog,
+  manufacturerRegSuccessDialogOptions,
   mhRegistrationFoundDialog,
   mhrTableRemoveDialog,
   registrationAddErrorDialog,
@@ -256,7 +265,7 @@ export default defineComponent({
       setAddCollateral, setAddSecuredPartiesAndDebtors, setUnsavedChanges, setRegTableDraftsBaseReg,
       setRegTableDraftsChildReg, setRegTableTotalRowCount, setRegTableBaseRegs, setRegTableSortPage,
       setRegTableSortHasMorePages, setRegTableSortOptions, setUserSettings, resetRegTableData, setMhrInformation,
-      setMhrTableHistory, setEmptyMhr
+      setMhrTableHistory, setEmptyMhr, getUserMiscSettingsByKey
     } = useStore()
     const {
       // Getters
@@ -282,6 +291,8 @@ export default defineComponent({
       myRegActionRoute: null as RouteNames,
       myRegAddDialog: null as DialogOptionsIF,
       myRegAddDialogError: null as StatusCodes,
+      manufacturerRegSuccessDialogDisplay: false,
+      manufacturerRegSuccessDialogOptions: manufacturerRegSuccessDialogOptions,
       myRegAddDialogDisplay: false,
       myRegActionDialogDisplay: false,
       myRegDeleteDialogDisplay: false,
@@ -985,6 +996,12 @@ export default defineComponent({
         }
 
         localState.myRegDataAdding = false
+
+        // check if success registration dialog for Manufacturers is permanently hidden (via user settings)
+        const dialogPermanentlyHidden =
+          getUserMiscSettingsByKey(SettingOptions.SUCCESSFUL_REGISTRATION_DIALOG_HIDE) || false
+        localState.manufacturerRegSuccessDialogDisplay = !dialogPermanentlyHidden
+
         // trigger snackbar
         context.emit('snackBarMsg', 'Registration was successfully added to your table.')
         // set to empty strings after 6 seconds

--- a/ppr-ui/src/components/dialogs/BaseDialog.vue
+++ b/ppr-ui/src/components/dialogs/BaseDialog.vue
@@ -21,6 +21,22 @@
           </v-btn>
         </v-col>
       </v-row>
+      <v-row v-if="showDismissDialogCheckbox">
+        <v-col>
+          <v-checkbox
+          id="dismiss-dialog"
+          class="ma-0 pt-4"
+          hide-details
+          v-model="isDismissDialogChecked"
+        >
+          <template v-slot:label>
+            <p class="ma-0">
+              Do not show this message again.
+            </p>
+          </template>
+        </v-checkbox>
+        </v-col>
+      </v-row>
       <div class="mt-10 action-buttons">
         <!-- can be replaced with <template v-slot:buttons> -->
         <slot name="buttons">
@@ -42,13 +58,16 @@ import {
   computed,
   defineComponent,
   reactive,
-  toRefs
+  toRefs,
+  watch
 } from 'vue-demi'
 // local components
 import DialogButtons from './common/DialogButtons.vue'
 import DialogContent from './common/DialogContent.vue'
 // local types/helpers/etc.
 import { DialogOptionsIF } from '@/interfaces' // eslint-disable-line
+import { SettingOptions } from '@/enums'
+import { useUserAccess } from '@/composables'
 
 export default defineComponent({
   name: 'BaseDialog',
@@ -65,6 +84,10 @@ export default defineComponent({
     reverseActionButtons: {
       type: Boolean,
       default: false
+    },
+    showDismissDialogCheckbox: { // display the checkbox to dismiss dialog for all future sessions
+      type: Boolean,
+      default: false
     }
   },
   emits: ['proceed'],
@@ -78,12 +101,20 @@ export default defineComponent({
       }),
       options: computed(() => {
         return props.setOptions
-      })
+      }),
+      isDismissDialogChecked: false
     })
 
     const proceed = (val: boolean) => {
       emit('proceed', val)
     }
+
+    watch(
+      () => localState.isDismissDialogChecked,
+      async (val: boolean) => {
+        await useUserAccess().updateUserMiscSettings(SettingOptions.SUCCESSFUL_REGISTRATION_DIALOG_HIDE, val)
+      }
+    )
 
     return {
       proceed,

--- a/ppr-ui/src/components/dialogs/BaseDialog.vue
+++ b/ppr-ui/src/components/dialogs/BaseDialog.vue
@@ -24,7 +24,7 @@
       <v-row v-if="showDismissDialogCheckbox">
         <v-col>
           <v-checkbox
-          id="dismiss-dialog"
+          id="dismiss-dialog-checkbox"
           class="ma-0 pt-4"
           hide-details
           v-model="isDismissDialogChecked"

--- a/ppr-ui/src/composables/userAccess/useUserAccess.ts
+++ b/ppr-ui/src/composables/userAccess/useUserAccess.ts
@@ -210,18 +210,23 @@ export const useUserAccess = () => {
 
   /** Update Qualified Supplier status message - locally and user settings **/
   const hideStatusMsg = async (hideMsg: boolean): Promise<void> => {
-    let msgSettings = getUserSettings.value[SettingOptions.MISCELLANEOUS_PREFERENCES] || []
+    await updateUserMiscSettings(SettingOptions.QS_STATUS_MSG_HIDE, hideMsg)
+  }
+
+  /** Update Misc Preference in User Profile by specifying key and value to update **/
+  const updateUserMiscSettings = async (settingKey: SettingOptions, settingValue: string | boolean) => {
+    let miscSettings = getUserSettings.value[SettingOptions.MISCELLANEOUS_PREFERENCES] || []
 
     // Update existing account setting if it exists, otherwise create new misc setting for account.
-    if (msgSettings?.find(setting => setting.accountId === getAccountId.value)) {
-      msgSettings = msgSettings.map(pref => pref.accountId === getAccountId.value
-        ? { ...pref, [SettingOptions.QS_STATUS_MSG_HIDE]: hideMsg }
+    if (miscSettings?.find(setting => setting.accountId === getAccountId.value)) {
+      miscSettings = miscSettings.map(pref => pref.accountId === getAccountId.value
+        ? { ...pref, [settingKey]: settingValue }
         : pref
       )
-    } else msgSettings.push({ accountId: getAccountId.value, [SettingOptions.QS_STATUS_MSG_HIDE]: hideMsg })
+    } else miscSettings.push({ accountId: getAccountId.value, [SettingOptions.QS_STATUS_MSG_HIDE]: settingValue })
 
-    await updateUserSettings(SettingOptions.MISCELLANEOUS_PREFERENCES, msgSettings)
-    await setUserSettings({ ...getUserSettings.value, [SettingOptions.MISCELLANEOUS_PREFERENCES]: msgSettings })
+    await updateUserSettings(SettingOptions.MISCELLANEOUS_PREFERENCES, miscSettings)
+    await setUserSettings({ ...getUserSettings.value, [SettingOptions.MISCELLANEOUS_PREFERENCES]: miscSettings })
   }
 
   /** Download QS Service Agreement via user browser **/
@@ -292,6 +297,7 @@ export const useUserAccess = () => {
     goToUserAccess,
     qsMsgContent,
     hideStatusMsg,
+    updateUserMiscSettings,
     isQsAccessEnabled,
     hasPendingQsAccess,
     hasRejectedQsAccess,

--- a/ppr-ui/src/enums/settingOptions.ts
+++ b/ppr-ui/src/enums/settingOptions.ts
@@ -4,4 +4,6 @@ export enum SettingOptions {
   REGISTRATION_TABLE = 'registrationsTable',
   MISCELLANEOUS_PREFERENCES = 'miscellaneousPreferences',
   QS_STATUS_MSG_HIDE = 'qsStatusMsgHide', // miscellaneousPreferences: Boolean - User has hidden the Qs status msg
+  // eslint-disable-next-line
+  SUCCESSFUL_REGISTRATION_DIALOG_HIDE = 'successfulRegDialogHide' // miscellaneousPreferences: Boolean to disable Registration Successful dialog for future sessions
 }

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -83,6 +83,17 @@ export const confirmQsProductChangeDialog: DialogOptionsIF = {
   acceptText: 'Change Access Type',
   cancelText: 'Cancel',
   title: 'Change Access type',
-  text: `Changing the Access Type will delete any application information you have entered and return you to the 
+  text: `Changing the Access Type will delete any application information you have entered and return you to the
     original state. `
+}
+
+export const manufacturerRegSuccessDialogOptions: DialogOptionsIF = {
+  acceptText: 'OK',
+  cancelText: '',
+  title: 'Registration Successful',
+  text: `This home is now included in the Manufactured Home Registry.<br><br>
+    The verification statement and registration decals displaying the Manufactured Home Registration Number
+    will be mailed to the Submitting Party.<br><br>
+    <b>Note: The registration decals must be affixed to the home, according to the instructions on the
+    decal envelope.</b>`
 }

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { stateModel } from '@/store/state'
+import { find } from 'lodash'
 import {
   AccountInformationIF,
   AccountModelIF,
@@ -58,6 +59,7 @@ import {
   ProductCode,
   RegistrationFlowType,
   RouteNames,
+  SettingOptions,
   UnitNoteDocTypes
 } from '@/enums'
 import { computed, ComputedRef, ref, set, toRefs } from 'vue-demi'
@@ -320,6 +322,11 @@ export const useStore = defineStore('assetsStore', () => {
   const getUserSettings = computed<UserSettingsIF>(() => {
     return state.value.userInfo?.settings
   })
+  // Get a specific User Profile preference from Misc Preferences array
+  const getUserMiscSettingsByKey = (settingKey: SettingOptions) => {
+    return find(state.value.userInfo?.settings?.miscellaneousPreferences,
+      { accountId: getAccountId.value })?.[settingKey] || null
+  }
   const getUserUsername = computed<string>(() => {
     return state.value.userInfo?.username || ''
   })
@@ -1228,6 +1235,7 @@ export const useStore = defineStore('assetsStore', () => {
     getUserUsername,
     getUserServiceFee,
     getUserSettings,
+    getUserMiscSettingsByKey,
 
     // Account-related getters
     getAccountId,

--- a/ppr-ui/tests/unit/BaseDialog.spec.ts
+++ b/ppr-ui/tests/unit/BaseDialog.spec.ts
@@ -1,4 +1,4 @@
-import Vue, { nextTick } from 'vue'
+import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { useStore } from '@/store/store'
 import { createPinia, setActivePinia } from 'pinia'
@@ -17,7 +17,8 @@ import {
   registrationRestrictedDialog,
   tableDeleteDialog,
   tableRemoveDialog,
-  unsavedChangesDialog
+  unsavedChangesDialog,
+  manufacturerRegSuccessDialogOptions
 } from '@/resources/dialogOptions'
 import { getLastEvent } from './utils'
 
@@ -49,7 +50,8 @@ describe('Base Dialog tests', () => {
     { ...registrationRestrictedDialog },
     { ...unsavedChangesDialog },
     { ...tableDeleteDialog },
-    { ...tableRemoveDialog }
+    { ...tableRemoveDialog },
+    { ...manufacturerRegSuccessDialogOptions }
   ]
 
   beforeEach(async () => {
@@ -118,6 +120,18 @@ describe('Base Dialog tests', () => {
       expect(wrapper.findComponent(DialogButtons).vm.$props.setAcceptText).toBe(options.acceptText)
       expect(wrapper.findComponent(DialogButtons).vm.$props.setCancelText).toBe(options.cancelText)
     }
+  })
+
+  it('renders base dialog with a dismiss checkbox', async () => {
+    await wrapper.setProps({
+      setAttach: '',
+      setDisplay: true,
+      setOptions: manufacturerRegSuccessDialogOptions,
+      showDismissDialogCheckbox: true
+    })
+
+    expect(wrapper.findComponent(BaseDialog).isVisible()).toBe(true)
+    expect(wrapper.find('#dismiss-dialog-checkbox').isVisible()).toBe(true)
   })
 
   it('Emits the button actions', async () => {

--- a/ppr-ui/tests/unit/test-data/mock-user-profile-responses.ts
+++ b/ppr-ui/tests/unit/test-data/mock-user-profile-responses.ts
@@ -6,7 +6,14 @@ export const mockedDefaultUserSettingsResponse: UserSettingsIF = {
   [SettingOptions.PAYMENT_CONFIRMATION_DIALOG]: true,
   [SettingOptions.SELECT_CONFIRMATION_DIALOG]: true,
   defaultDropDowns: true,
-  defaultTableFilters: true
+  defaultTableFilters: true,
+  miscellaneousPreferences: [
+    {
+      accountId: 1,
+      qsStatusMsgHide: true,
+      successfulRegDialogHide: false
+    }
+  ]
 }
 
 export const mockedDisablePayUserSettingsResponse: UserSettingsIF = {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#17783

*Description of changes:*
- Add a Success Registration dialog for Manufacturer Registration
- Add a permanently hide dialog option by extending functionality of a base dialog
- Add unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
