### PR TITLE
Transport permit report template and generation setup.

### DIFF
--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -97,16 +97,19 @@
           {{ documentDescription }}
         {% endif %}        
       </div>
-      <div class="cover-data"><span class="cover-data-bold">Document Registration Number:</span>
+      <div class="cover-data"><span class="cover-data-bold">
+        {% if registrationType is defined and registrationType == 'PERMIT' %}Transport Permit Number:{% else %}Document Registration Number:{% endif %}
+        </span>
         {% if documentRegistrationNumber is defined and documentRegistrationNumber != '' %}
          {{ documentRegistrationNumber }}
-        {% elif note is defined and note.documentRegistrationNumber is defined and note.documentRegistrationNumber != '' %}
-          {{ note.documentRegistrationNumber }}
         {% else %}
           N/A
         {% endif %}
       </div>
-      <div class="cover-data"><span class="cover-data-bold">Document Registration Date and Time:</span> {{ createDateTime }}</div>
+      <div class="cover-data"><span class="cover-data-bold">
+        {% if registrationType is defined and registrationType == 'PERMIT' %}Date of Issue:{% else %}Document Registration Date and Time:{% endif %}
+        </span> {{ createDateTime }}
+      </div>
       <div class="cover-data mt-4"><span class="cover-data-bold">Toll-Free Phone:</span> 1-877-526-1526</div>
     </div>
   </div>

--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -1,6 +1,8 @@
 {% if location is defined %}
 <div class="no-page-break">
-    {% if registrationType not in ('EXEMPTION_RES', 'EXEMPTION_NON_RES') %}
+    {% if registrationType == 'PERMIT' %}
+        <div class="section-title mt-5">New Registered Location</div>
+    {% elif registrationType not in ('EXEMPTION_RES', 'EXEMPTION_NON_RES') %}
         <div class="separator mt-5"></div>
         <div class="section-title mt-3">Registered Location</div>
     {% endif %}

--- a/mhr_api/report-templates/template-parts/registration/submittingParty.html
+++ b/mhr_api/report-templates/template-parts/registration/submittingParty.html
@@ -1,7 +1,9 @@
 {% if submittingParty is defined  %}
 <div class="no-page-break">
     {% if not (registrationType == 'EXEMPTION_RES' and usergroup is defined and usergroup != 'ppr_staff') %}
-        <div class="separator mt-5"></div>
+        {% if registrationType != 'PERMIT' %}
+            <div class="separator mt-5"></div>
+        {% endif %}
     {% endif %}
     <div class="section-title mt-3">Submitting Party Information</div>
     <table class="section-data section-data-table-new mt-4" role="presentation">

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -673,6 +673,21 @@
 		padding-right: 25px;
 	}
 
+	.section-data-table-base {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.section-data-table-base td {
+		vertical-align: top;
+		overflow-wrap: break-word;
+  		word-wrap: break-word;
+	}
+
+	.section-data-table-base td:nth-child(1) {
+		padding-left: 8px;
+	}
+
 	.cover-data-table {
 		width: 100%;
 		margin: 0px;

--- a/mhr_api/report-templates/transportPermitV2.html
+++ b/mhr_api/report-templates/transportPermitV2.html
@@ -21,12 +21,16 @@
         <td>{{status|title}}</td>
       </tr>
       <tr>
-        <td>Document Registration Number:</td>
+        <td>Transport Permit Number:</td>
         <td>{{documentRegistrationNumber}}</td>
       </tr>
       <tr>
-        <td>Document Registration Date and Time:</td>
+        <td>Date of Issue:</td>
         <td>{{createDateTime}}</td>
+      </tr>
+      <tr>
+        <td>Expiry Date:</td>
+        <td>{% if note is defined and note.expiryDateTime is defined %} {{note.expiryDateTime}} {% endif %}</td>
       </tr>
       <tr>
         <td>Folio Number:</td>
@@ -42,39 +46,61 @@
   </div>
 
   <div class="container pt-4">
+    <div class="section-data mt-1">
+      Under section 17 of the Manufactured Home Act, the Registrar hereby permits the movement of the manufactured home registered 
+      under {{mhrNumber}} with Serial Number(s)
+      {% if description is defined and description.sections is defined %}
+        {% for section in description.sections %}{{section.serialNumber}}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      to:
+    </div>
+  
     [[registration/location.html]]
 
-    {% if note is defined %}
-      <div class="no-page-break">
-        <div class="separator-header mt-6"></div>
-        <div class="section-title-centre mt-2">UNIT NOTE</div>
-        <div class="separator-header mt-0"></div>
-      </div>
-      <table class="no-page-break section-data details-table mt-4" role="presentation">
-        <tr>
-            <td class="section-sub-title">Expired Date:</td>
-            <td>{% if note.expiryDate is defined and note.expiryDate != '' %} 
-                    {{note.expiryDate}}
-                {% else %}
-                    N/A
-                {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td class="section-sub-title">Remarks:</td>
-            <td>
-              {% if note.remarks is defined and note.remarks != '' %} 
-                  {{note.remarks}}
-              {% else %}
-                  N/A
-              {% endif %}
-            </td>
-        </tr>
-      </table>
-
-    {% endif %}
+    <div class="separator mt-5"></div>
+    <div class="section-title mt-5">Transport Permit Conditions</div>
+    <table class="no-page-break section-data section-data-table-base mt-2" role="presentation">
+      <tr>
+        <td>1.</td>
+        <td class="pl-2">
+          <div>If the manufactured home is permanently placed on a location other than specifically described on the transport permit, 
+          the owner must advise the Registrar and provide full details of the location either</div>
+          <div>(a) within 3 days after the manufactured home was transported to the new location</div>
+          <div>or</div>
+          <div>(b) within 3 days after the expiration of the transport permit which ever occurs first.</div>
+        </td>
+      </tr>
+      <tr>
+        <td class="pt-2">2.</td>
+        <td class="pl-2 pt-2">
+          This permit expires 30 days after the date of issue. If the manufactured home is NOT MOVED within this time,
+          you must report the physical location of the manufactured home within 3 days after the expiration of the permit.
+        </td>
+      </tr>
+      <tr>
+        <td class="pt-2">3.</td>
+        <td class="pl-2 pt-2">
+          This permit may be used for one (1) move only. A new permit must be obtained for subsequent moves.
+        </td>
+      </tr>
+      <tr>
+        <td class="pt-2">4.</td>
+        <td class="pl-2 pt-2">
+          Upon leaving British Columbia, this home is Exempted from the Manufactured Home Act. The home is required to be
+          re-registered under the same number if it re-enters the Province of British Columbia.
+        </td>
+      </tr>
+    </table>
 
     [[registration/submittingParty.html]]
+
+    <div class="separator mt-5"></div>
+
+    {% if status == 'EXEMPT' %}
+      <div class="section-data mt-5">
+        Upon leaving British Columbia, this home is Exempted from the Manufactured Home Act. The home is required to be re-registered under the same number if it re-enters the Province of British Columbia.
+      </div>
+    {% endif %}
   </div>
   <p class="last-page"></p>
   </body>

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -643,6 +643,10 @@ def __build_summary(row, add_in_user_list: bool = True, mhr_list=None):
         summary = __get_cancel_info(summary, row)
     elif summary['documentType'] in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE):
         summary = __get_caution_info(summary, row)
+    elif summary['documentType'] in (Db2Document.DocumentTypes.PERMIT,
+                                     Db2Document.DocumentTypes.PERMIT_TRIM) and row[12]:
+        expiry = row[12]
+        summary['expireDays'] = model_utils.expiry_date_days(expiry)
     summary = __set_frozen_status(summary, row)
     return summary
 

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -693,6 +693,9 @@ def __build_summary(row, account_id: str, staff: bool, add_in_user_list: bool = 
         summary = __get_cancel_info(summary, row)
     elif doc_type in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE):
         summary = __get_caution_info(summary, row, doc_type)
+    elif doc_type == MhrDocumentTypes.REG_103 and row[12]:
+        expiry = row[12]
+        summary['expireDays'] = model_utils.expiry_date_days(expiry.date())
     summary = __set_frozen_status(summary, row, staff)
     return summary
 

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -177,6 +177,8 @@ class Report:  # pylint: disable=too-few-public-methods
         elif self._report_data.get('registrationType', '') in (MhrRegistrationTypes.EXEMPTION_RES,
                                                                MhrRegistrationTypes.EXEMPTION_NON_RES):
             self._report_key = ReportTypes.MHR_EXEMPTION
+        elif self._report_data.get('registrationType', '') == MhrRegistrationTypes.PERMIT:
+            self._report_key = ReportTypes.MHR_TRANSPORT_PERMIT
         elif self._report_data.get('registrationType', '') == MhrRegistrationTypes.REG_NOTE:
             if self._report_data.get('documentType'):
                 self._report_key = ReportTypes.MHR_ADMIN_REGISTRATION
@@ -390,8 +392,7 @@ class Report:  # pylint: disable=too-few-public-methods
             self._set_addresses()
             self._set_owner_groups()
             if self._report_key not in (ReportTypes.MHR_REGISTRATION,
-                                        ReportTypes.MHR_TRANSFER,
-                                        ReportTypes.MHR_TRANSPORT_PERMIT):
+                                        ReportTypes.MHR_TRANSFER):
                 self._set_notes()
             if self._report_key == ReportTypes.SEARCH_DETAIL_REPORT:
                 self._set_selected()

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -569,7 +569,7 @@ class Report:  # pylint: disable=too-few-public-methods
                             message = {
                                 'messageType': note.get('documentType'),
                                 'messageId': note.get('documentRegistrationNumber', ''),
-                                'messageDate': Report._to_report_datetime(note['createDateTime'], False)
+                                'messageDate': Report._to_report_datetime(note['createDateTime'], True)
                             }
                             messages.append(message)
                 if not has_exempt_note and detail.get('status') == 'EXEMPT':

--- a/mhr_api/tests/unit/api/test_permits.py
+++ b/mhr_api/tests/unit/api/test_permits.py
@@ -139,6 +139,8 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
     else:
         assert response.status_code == status
     if response.status_code == HTTPStatus.CREATED:
+        resp_json = response.json
+        assert resp_json.get('description')
         registration: MhrRegistration = MhrRegistration.find_by_mhr_number(response.json['mhrNumber'],
                                                                            account)
         assert registration

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -206,6 +206,8 @@ def test_find_account_registrations(session, account_id, has_results):
                         desc: str = reg['registrationDescription']
                         if reg.get('registrationType') == MhrRegistrationTypes.REG_NOTE and desc.find('CAUTION') > 0:
                             assert reg.get('expireDays')
+                        elif reg.get('registrationType') == MhrRegistrationTypes.PERMIT:
+                            assert reg.get('expireDays')
         else:
             assert not reg_list
 

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -444,6 +444,8 @@ def test_find_account_registrations(session, account_id, has_results):
                     desc: str = reg['registrationDescription']
                     if reg.get('registrationType') == MhrRegistrationTypes.REG_NOTE and desc.find('CAUTION') > 0:
                         assert reg.get('expireDays')
+                    elif reg.get('registrationType') == MhrRegistrationTypes.PERMIT:
+                        assert reg.get('expireDays')
     else:
         assert not reg_list
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18348

*Description of changes:*
- Transport permit registration report staff and non-staff.
- Update API set up for report generation.

*Issue #:* /bcgov/entity#18346
- For account registration summary return expireDays for PERMIT registrations.
- Example response in the ticket.

*Issue #:* /bcgov/entity#18310
- Search exempt status message include time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
