### PR TITLE
Home Owners styling and Transfer Bugs

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "dependencies": {
         "@lemoncode/fonk": "^1.5.1",
         "@lemoncode/fonk-range-number-validator": "^1.1.0",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "serve": "vite preview --port 8080",
+    "preview": "vite preview --port 8080",
     "lint": "eslint . --ext .js,.ts,.vue",
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -212,6 +212,10 @@ a {
 .group-header, .group-header:hover {
   font-weight: bold;
 }
+.v-table:not(#registration-table) > .v-table__wrapper  {
+  max-width: 100%;
+  overflow-x: hidden;
+}
 
 // Actions Table Header and Action Cell Override Styling
 .v-table.v-table--fixed-header > .v-table__wrapper > table > thead > tr > th.registration-action,
@@ -227,6 +231,11 @@ a {
 
 .actions-width {
   width: 0;
+}
+
+.actions {
+  padding-right: 28px!important;
+  width: 100%!important;
 }
 
 .smaller-actions {

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -233,11 +233,6 @@ a {
   width: 0;
 }
 
-.actions {
-  padding-right: 28px!important;
-  width: 100%!important;
-}
-
 .smaller-actions {
   margin-left: -12px;
 }

--- a/ppr-ui/src/assets/styles/layout.scss
+++ b/ppr-ui/src/assets/styles/layout.scss
@@ -69,6 +69,3 @@ aside {
   min-width: 5rem;
   width: 5rem;
 }
-th:first-child, td:first-child:not(.text-center) {
-  padding-left: 24px!important;
-}

--- a/ppr-ui/src/assets/styles/overrides.scss
+++ b/ppr-ui/src/assets/styles/overrides.scss
@@ -144,7 +144,13 @@
   font-size: .875rem;
   text-align: left;
   padding-top: 16px;
-  padding-bottom: 16px
+  padding-bottom: 16px;
+}
+
+.v-table > .v-table__wrapper {
+  .text-right {
+    padding-top: 6px;
+  }
 }
 
 // Generic Overlay

--- a/ppr-ui/src/assets/styles/overrides.scss
+++ b/ppr-ui/src/assets/styles/overrides.scss
@@ -148,6 +148,10 @@
 }
 
 .v-table > .v-table__wrapper {
+  .actions {
+    padding-right: 28px;
+    width: 100%;
+  }
   .text-right {
     padding-top: 6px;
   }

--- a/ppr-ui/src/components/common/CautionBox.vue
+++ b/ppr-ui/src/components/common/CautionBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="caution-box px-4 py-3 fs-14"
+    class="caution-box px-4 pt-4 pb-1 fs-14"
     :class="{ 'alert-box': setAlert }"
   >
     <slot name="prependSLot" />

--- a/ppr-ui/src/components/common/CautionBox.vue
+++ b/ppr-ui/src/components/common/CautionBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="caution-box px-4 pt-4 pb-1 fs-14"
+    class="caution-box px-4 py-4 fs-14"
     :class="{ 'alert-box': setAlert }"
   >
     <slot name="prependSLot" />

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -1099,14 +1099,14 @@ export default defineComponent({
 
     thead.simple {
 
-      th {
-        padding: 16px;
+      th:not(:first-child) {
+        padding-left: 0
       }
     }
 
     tbody > tr > td > div > tr > td,
     tbody > tr > td {
-      padding: 20px 16px;
+      padding: 16px 0;
       border-radius: 0 !important;
     }
 
@@ -1115,18 +1115,8 @@ export default defineComponent({
       border-bottom: thin solid rgba(0, 0, 0, 0.12);
     }
 
-    th:first-child,
-    td:last-child {
-      padding-right: 30px;
-      padding-top: 8px;
-    }
-
     td:first-child {
-      padding-left: 0 !important;
-    }
-
-    td.owner-name {
-      padding-left: 24px !important;
+      padding-left: 16px;
     }
 
     tbody > tr.v-row-group__header,
@@ -1183,7 +1173,8 @@ export default defineComponent({
 }
 
 .home-owners-table:not(.review-mode) .group-header-slot {
-  padding: 0 28px;
+  padding-left: 20px;
+  padding-right: 12px;
 }
 
 .v-menu__content {

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/TableGroupHeader.vue
@@ -70,7 +70,6 @@
       <!-- Default Actions -->
       <div
         v-show="showEditActions && !isMhrTransfer"
-        class="mr-n4"
       >
         <v-btn
           variant="text"
@@ -129,7 +128,6 @@
       <!-- Mhr Transfer Actions -->
       <div
         v-if="showEditActions && isMhrTransfer && !isRemovedHomeOwnerGroup(group) && !isChangedOwnerGroup(group)"
-        class="mr-n4"
       >
         <v-btn
           variant="text"
@@ -193,7 +191,6 @@
           <v-btn
             variant="text"
             color="primary"
-            class="pr-0"
             :ripple="false"
             :disabled="isGlobalEditingMode"
             data-test-id="group-header-undo-btn"
@@ -264,7 +261,6 @@
           v-else
           variant="text"
           color="primary"
-          class="pr-0"
           :ripple="false"
           :disabled="isGlobalEditingMode"
           data-test-id="group-header-undo-btn"
@@ -305,7 +301,7 @@
       </v-row>
       <v-row>
         <v-col>
-          <div class="form__row form__btns">
+          <div class="form__row form__btns float-right">
             <v-btn
               color="primary"
               class="ml-auto mx-2"
@@ -396,6 +392,7 @@ export default defineComponent({
     } = useHomeOwners(props.isMhrTransfer)
     const {
       isSOorJT,
+      groupHasAllAddedOwners,
       hasCurrentGroupChanges,
       isAddedHomeOwnerGroup,
       isRemovedHomeOwnerGroup,
@@ -470,7 +467,10 @@ export default defineComponent({
     // Close Delete Group dialog or proceed to deleting a Group
     const cancelOrProceed = (proceed: boolean, groupId: number): void => {
       if (proceed) {
-        if (props.isMhrTransfer && localState.group?.action !== ActionTypes.ADDED) {
+        // Delete the group entirely if it contained ONLY newly added owners
+        if (props.isMhrTransfer &&
+          (localState.group?.action !== ActionTypes.ADDED && !groupHasAllAddedOwners(localState.group))
+        ) {
           markGroupForRemoval(groupId)
         } else deleteGroup(groupId)
 

--- a/ppr-ui/src/components/tables/mhr/HomeSectionsTable.vue
+++ b/ppr-ui/src/components/tables/mhr/HomeSectionsTable.vue
@@ -16,7 +16,7 @@
             <th
               v-for="header in headers"
               :key="header.value"
-              :class="header.class"
+              :class="[header.class, (isReviewMode && header == headers[0]) ? 'pl-0' : '']"
             >
               {{ header.text }}
             </th>

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -649,6 +649,12 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     }
     updatedGroups.unshift(previousOwnersGroup)
 
+    // When a user edits the current group before removing all current owners - update the action to ADDED
+    const updatedGroup = updatedGroups.find(updatedGroup => updatedGroup.groupId === group.groupId + 1)
+    if (groupHasAllAddedOwners(updatedGroup) && updatedGroup.action === ActionTypes.CHANGED) {
+      updatedGroup.action = ActionTypes.ADDED
+    }
+
     // Set new ownership structure to store
     await setMhrTransferHomeOwnerGroups(updatedGroups)
   }
@@ -715,6 +721,11 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
       )
   }
 
+  /** Return true if all owners in the group have been added **/
+  const groupHasAllAddedOwners = (group: MhrHomeOwnerGroupIF) => {
+    return group?.owners?.every(owner => owner.action === ActionTypes.ADDED)
+  }
+
   return {
     isAddedHomeOwnerGroup,
     isRemovedHomeOwnerGroup,
@@ -748,6 +759,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     disableNameFields,
     isJointTenancyStructure,
     getCurrentOwnerStateById,
+    groupHasAllAddedOwners,
     groupHasRemovedAllCurrentOwners,
     getCurrentOwnerGroupIdByOwnerId,
     hasCurrentOwnerChanges,

--- a/ppr-ui/src/resources/tableHeaders.ts
+++ b/ppr-ui/src/resources/tableHeaders.ts
@@ -876,26 +876,26 @@ export const homeSectionsReviewTableHeaders: Array<BaseHeaderIF> = [
 
 export const homeOwnersTableHeaders: Array<BaseHeaderIF> = [
   {
-    class: 'column-width-lg',
+    class: 'column-xl',
     sortable: false,
     text: 'Name',
     value: 'fullName'
   },
   {
-    class: 'column-width-xl',
+    class: 'column-xl',
     sortable: false,
     text: 'Mailing Address',
     value: 'mailingAddress'
   },
   {
-    class: 'column-width-lg',
+    class: 'column-lg',
     sortable: false,
     text: 'Phone Number',
     value: 'phoneNumber',
     width: '10rem'
   },
   {
-    class: 'actions column-width-md',
+    class: 'actions column-md',
     sortable: false,
     text: '',
     value: 'actions'

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -153,7 +153,10 @@
                   <label class="font-weight-bold pl-2">Ownership Transfer or Change</label>
                 </header>
 
-                <section id="owners-review">
+                <section
+                  id="owners-review"
+                  class="mt-9"
+                >
                   <HomeOwners
                     isMhrTransfer
                     isReadonlyTable

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -718,5 +718,6 @@ span:not(.generic-label)  {
 .review-table {
   margin-top: -40px !important;
   padding-top: 0 !important;
+  border-radius: unset;
 }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17754  /bcgov/entity#18197

*Description of changes:*
* Fix to remove groups that had only added owners after a 'previous' owner mark for removal
* Fix for owner group if it was edited before removing current owners, will now convert to an added group
* Styling changes to Home Owners to restore spacing and appearances

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
