### PR TITLE
InputField DatePicker: Update min/max defaults

### DIFF
--- a/ppr-ui/src/components/common/InputFieldDatePicker.vue
+++ b/ppr-ui/src/components/common/InputFieldDatePicker.vue
@@ -39,8 +39,8 @@
         <BaseDatePicker
           id="date-picker-calendar"
           :defaultSelectedDate="defaultDate"
-          :setMinDate="new Date(minDate)"
-          :setMaxDate="new Date(maxDate)"
+          :setMinDate="minDate ? new Date(minDate) : null"
+          :setMaxDate="maxDate ? new Date(maxDate): null"
           @selected-date="dateHandler"
         />
 
@@ -86,10 +86,6 @@ export default defineComponent({
     initialValue: { type: String, default: '' },
     minDate: { type: String, default: '' },
     maxDate: { type: String, default: '' },
-    nudgeTop: { type: String, default: null },
-    nudgeBottom: { type: String, default: null },
-    nudgeRight: { type: String, default: null },
-    nudgeLeft: { type: String, default: null },
     hint: { type: String, default: '' },
     persistentHint: { type: Boolean, default: false },
     clearable: { type: Boolean, default: false }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16986

*Description of changes:*
* Don't set date defaults when no min or max props dates are passed. (ie no range restriction)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
