### PR TITLE
Fix for search report with 1000s of collateral not generating.

### DIFF
--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -650,7 +650,7 @@ def email_batch_location_data(config: dict, report_url: str) -> dict:
     rep_date: str = now_local.strftime('%B %-d, %Y')
     rep_filename = config.get('filename')
     rep_filename = rep_filename.format(rep_date=rep_date)
-    subject = config.get('subject')
+    subject = config.get('subject') if report_url else config.get('subjectNone')
     subject = subject.format(rep_date=rep_date)
     if report_url:
         body += EMAIL_DOWNLOAD_LOCATION.format(rep_filename, report_url)

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -545,6 +545,7 @@ def test_batch_location_notify_config(session, client, jwt):
     assert config.get('url')
     assert config.get('recipients')
     assert config.get('subject')
+    assert config.get('subjectNone')
     assert config.get('body')
     assert config.get('bodyNone')
     assert config.get('filename')

--- a/ppr-api/report-templates/template-parts/search-result/vehicleCollateral.html
+++ b/ppr-api/report-templates/template-parts/search-result/vehicleCollateral.html
@@ -19,6 +19,7 @@
             <td class="top-align">MHR Number</td>
          {% endif %}
       </tr>
+{% if detail.financingStatement.vehicleCollateral|length < 500 %} 
       {% for collateral in detail.financingStatement.vehicleCollateral %}
          {% if detail.financingStatement.mhCollateralCount is defined and detail.financingStatement.mhCollateralCount > 0 %}
             <tr>
@@ -44,6 +45,23 @@
          </tr>
       {% endfor %}
    </table>
+{% else %}   
+   <tr><td colspan="4">
+      {% for collateral in detail.financingStatement.vehicleCollateral %}
+         {% if loop.index % 50 == 0 %}
+            </td></tr><tr><td colspan="4">
+         {% endif %}
+         {{collateral.type}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+         {{collateral.year}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+         {{collateral.make}}{% if collateral.model is defined %} / {{collateral.model}}{% endif %}
+         &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{collateral.serialNumber}}
+         {% if collateral.manufacturedHomeRegistrationNumber is defined %}&nbsp;&nbsp;&nbsp;{{collateral.manufacturedHomeRegistrationNumber}}{% endif %}
+         <br>
+      {% endfor %}
+   </td></tr>
+   </table>
+{% endif %}         
+
 {% elif change is defined and (change.addVehicleCollateral is defined or change.deleteVehicleCollateral is defined) %}
    {% if change.mhCollateralCount is defined and change.mhCollateralCount > 0 %}
          <table class="vehicle-collateral-table-mh mt-4" role="presentation">

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.7'  # pylint: disable=invalid-name
+__version__ = '1.1.8'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18945

*Description of changes:*
- Search report fix to generate when registrations contain 1000's of serial collateral records.
- MHR staff notify noc location email allow custom subject when no registrations.
- Remove unintentionally added (prematurely) endpoint code for the custom BCA endpoint. 
- Example attached to ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
