### PR TITLE
Fix/transfer to surviving jt deactivate groups have eta

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -299,9 +299,9 @@
                   <template v-else-if="enableTransferOwnerActions(item)">
                     <v-btn
                       v-if="!isRemovedHomeOwner(item) &&
-                            !isChangedOwner(item) &&
-                            !isDisabledForSoGChanges(item) &&
-                            !(!isPartyTypeNotEAT(item) && isTransferToSurvivingJointTenant)"
+                        !isChangedOwner(item) &&
+                        !isDisabledForSoGChanges(item) &&
+                        !(!isPartyTypeNotEAT(item) && isTransferToSurvivingJointTenant)"
                       variant="text"
                       color="primary"
                       class="mr-n4"

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -298,7 +298,10 @@
                   <!-- Existing Owner Actions -->
                   <template v-else-if="enableTransferOwnerActions(item)">
                     <v-btn
-                      v-if="!isRemovedHomeOwner(item) && !isChangedOwner(item) && !isDisabledForSoGChanges(item)"
+                      v-if="!isRemovedHomeOwner(item) &&
+                            !isChangedOwner(item) &&
+                            !isDisabledForSoGChanges(item) &&
+                            !(!isPartyTypeNotEAT(item) && isTransferToSurvivingJointTenant)"
                       variant="text"
                       color="primary"
                       class="mr-n4"

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -995,7 +995,8 @@ export default defineComponent({
       if (isExpired(item) || isDischarged(item)) return '—'
 
       const days = item.expireDays
-      if (days === null || days === undefined) {
+      // -9999 indicates the notice of caution has been cancelled
+      if (days === null || days === undefined || days === -9999) {
         return 'N/A'
       }
       if (days === -99) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17065

*Description of changes:*
1. fixed bug - Transfer to Surviving Joint Tenants - deactivate Groups that have execs/admins/trustees
2. minor bug fixed for ticket #18071

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
