### PR TITLE
LandLease Hotfix

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.27",
+  "version": "2.1.27a",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "2.1.27",
+      "version": "2.1.27a",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.7",
         "@bcrs-shared-components/enums": "^1.0.19",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "2.1.27",
+  "version": "2.1.27a",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLandOwnership.vue
@@ -120,7 +120,7 @@ export default defineComponent({
 
     watch(() => localState.isValidHomeLandOwnership, async (val: boolean) => {
       setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LAND_DETAILS_VALID, val)
-    })
+    }, { immediate: true })
 
     watch(() => props.validate, () => {
       validateForm()

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -287,11 +287,13 @@ export const useNewMhrRegistration = () => {
 
   const buildApiData = (): NewMhrRegistrationApiIF => {
     const data: NewMhrRegistrationApiIF = {
-      ownLand: getMhrRegistrationOwnLand.value,
       submittingParty: parseSubmittingParty(),
       ownerGroups: parseOwnerGroups(),
       location: parseLocation(),
       description: parseDescription(),
+      ...(!isMhrManufacturerRegistration.value && {
+        ownLand: getMhrRegistrationOwnLand.value
+      }),
       ...(isRoleStaffReg.value && !!getStaffPayment.value && {
         clientReferenceId: getStaffPayment.value.folioNumber
       }),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19025

*Description of changes:*
* only include `ownLand` in payload for Staff registrations to unblock Manufacturer Registrations.
* Validate LandLease immediately to handle resuming draft scenarios, was causing a validation failure when it mounted as true, the watcher couldn't trigger.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
