### PR TITLE
Model changes to save BCA batch registration data.

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_registration_report.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration_report.py
@@ -32,6 +32,8 @@ class MhrRegistrationReport(db.Model):
     report_type = db.Column('report_type', db.String(30), nullable=False)
     doc_storage_url = db.Column('doc_storage_url', db.String(1000), nullable=True)
     batch_report_data = db.Column('batch_report_data', db.JSON, nullable=True)
+    # BC Assessment version of the registration.
+    batch_registration_data = db.Column('batch_registration_data', db.JSON, nullable=True)
 
     # parent keys
     registration_id = db.Column('registration_id', db.Integer, db.ForeignKey('mhr_registrations.id'), nullable=False,

--- a/mhr_api/src/mhr_api/resources/v1/exemptions.py
+++ b/mhr_api/src/mhr_api/resources/v1/exemptions.py
@@ -115,12 +115,18 @@ def submit_exemption(current_reg: MhrRegistration,  # pylint: disable=too-many-b
         response_json['usergroup'] = group
         if is_staff(j_token):
             response_json['username'] = reg_utils.get_affirmby(g.jwt_oidc_token_info)
-            reg_utils.enqueue_registration_report(registration, response_json, ReportTypes.MHR_REGISTRATION_STAFF)
+            reg_utils.enqueue_registration_report(registration,
+                                                  response_json,
+                                                  ReportTypes.MHR_REGISTRATION_STAFF,
+                                                  current_json)
             del response_json['username']
         else:
             if not response_json.get('affirmbyName'):
                 response_json['affirmByName'] = reg_utils.get_affirmby(g.jwt_oidc_token_info)
-            reg_utils.enqueue_registration_report(registration, response_json, ReportTypes.MHR_EXEMPTION)
+            reg_utils.enqueue_registration_report(registration,
+                                                  response_json,
+                                                  ReportTypes.MHR_EXEMPTION,
+                                                  current_json)
         del response_json['usergroup']
         return jsonify(response_json), HTTPStatus.CREATED
     except DatabaseException as db_exception:

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.6.5'  # pylint: disable=invalid-name
+__version__ = '1.6.6'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -23,7 +23,7 @@ import pytest
 from flask import current_app
 from registry_schemas.example_data.mhr import REGISTRATION
 
-from mhr_api.models import MhrRegistration, registration_utils as reg_utils, utils as model_utils
+from mhr_api.models import MhrRegistration, registration_utils as reg_utils, utils as model_utils, MhrRegistrationReport
 from mhr_api.models.type_tables import MhrDocumentTypes, MhrRegistrationTypes
 from mhr_api.resources.registration_utils import (
     notify_man_reg_config,
@@ -306,6 +306,9 @@ def test_create(session, client, jwt, desc, has_submitting, roles, status, has_a
         registration: MhrRegistration = MhrRegistration.find_by_mhr_number(response_json.get('mhrNumber'),
                                                                            'PS12345')
         assert registration
+        reg_report: MhrRegistrationReport = MhrRegistrationReport.find_by_registration_id(registration.id)
+        assert reg_report
+        assert reg_report.batch_registration_data
 
 
 @pytest.mark.parametrize('desc,year_offset,status,account_id', TEST_CREATE_MANUFACTURER_DATA)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19074

*Description of changes:*
- Add new column to mhr_registration_reports table.
- Conditionally save batch version of registration JSON to new column as a last step in the api call. 
- Batch version includes current description, location, and owner groups. It conditionally includes previous location and previous owner groups.
- Update unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
