### PR TITLE
User Access + Global Address Fixes

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.21",
+  "version": "3.0.22",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -233,13 +233,21 @@ export default defineComponent({
           }
         }
 
-        // When we are authenticated, allow time for session storage propagation from auth, then initialize application
-        // (since we won't get the event from Signin component)
-        if (isAuthenticated.value) {
-          setTimeout(() => { onProfileReady(true) }, 1000)
-        }
+        authVerificationHandler()
       }
     })
+
+    /**
+     * When we are authenticated, allow time for session storage propagation from auth, then initialize application
+     * (since we won't get the event from signin component)
+     */
+    const authVerificationHandler = () => {
+      setTimeout(() => {
+        isAuthenticated.value && !!sessionStorage.getItem(SessionStorageKeys.CurrentAccount)
+          ? onProfileReady(true)
+          : authVerificationHandler()
+      }, 2000)
+    }
 
     const payErrorDialogHandler = (confirmed: boolean) => {
       const flowType = getRegistrationFlowType.value
@@ -663,7 +671,12 @@ export default defineComponent({
 
     /** Called when profile is ready -- we can now init app. */
     watch(() => localState.profileReady, async (val: boolean) => {
+      console.log(sessionStorage.getItem(SessionStorageKeys.CurrentAccount))
       await onProfileReady(val)
+    })
+
+    watch(() => sessionStorage.getItem(SessionStorageKeys.CurrentAccount), async (val: object) => {
+      console.log(val)
     })
 
     return {

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -671,12 +671,7 @@ export default defineComponent({
 
     /** Called when profile is ready -- we can now init app. */
     watch(() => localState.profileReady, async (val: boolean) => {
-      console.log(sessionStorage.getItem(SessionStorageKeys.CurrentAccount))
       await onProfileReady(val)
-    })
-
-    watch(() => sessionStorage.getItem(SessionStorageKeys.CurrentAccount), async (val: object) => {
-      console.log(val)
     })
 
     return {

--- a/ppr-ui/src/components/common/OrgNameLookup.vue
+++ b/ppr-ui/src/components/common/OrgNameLookup.vue
@@ -80,9 +80,7 @@ export default defineComponent({
       localState.autoCompleteIsActive = false
     }
 
-    /**
-     * Clear search values if manual entry is disabled and a selection has already been made
-     **/
+    /** Clear search values if manual entry is disabled and a selection has already been made **/
     const manualEntryHandler = () => {
       if (props.disableManualEntry && localState.lookupResultSelected) {
         localState.searchValue = ''

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeCivicAddress.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeCivicAddress.vue
@@ -60,9 +60,8 @@
               variant="filled"
               color="primary"
               label="Street Address (Number and Name)"
-              hint="Required if location has a street address"
               persistentHint
-              :rules="[...CivicAddressSchema.street]"
+              :rules="[...schema.street]"
               @keypress.once="enableAddressComplete()"
               @click="enableAddressComplete()"
             />
@@ -78,7 +77,7 @@
                   color="primary"
                   class="item address-city"
                   label="City"
-                  :rules="[...CivicAddressSchema.city]"
+                  :rules="[...schema.city]"
                 />
               </v-col>
               <v-col>
@@ -94,7 +93,7 @@
                   :items="provinceOptions"
                   itemTitle="name"
                   itemValue="value"
-                  :rules="[...CivicAddressSchema.region]"
+                  :rules="[...schema.region]"
                 >
                   <template #item="{item, props}">
                     <v-divider v-if="item.value === 'divider'" />
@@ -102,6 +101,11 @@
                       v-else
                       v-bind="props"
                     />
+                  </template>
+                  <template #no-data>
+                    <v-list-item>
+                      <p>Select a country first</p>
+                    </v-list-item>
                   </template>
                 </v-select>
               </v-col>
@@ -115,7 +119,6 @@
 
 <script lang="ts">
 import { computed, defineComponent, reactive, ref, toRefs, watch } from 'vue'
-import { CivicAddressSchema } from '@/schemas/civic-address'
 import { useStore } from '@/store/store'
 import {
   useAddress,
@@ -123,6 +126,7 @@ import {
   useCountriesProvinces
 } from '@/composables/address/factories'
 import { AddressIF, FormIF } from '@/interfaces'
+import { SchemaIF } from '@/composables/address/interfaces'
 
 export default defineComponent({
   name: 'HomeCivicAddress',
@@ -132,11 +136,15 @@ export default defineComponent({
       default: () => ({
         street: '',
         city: '',
-        region: '',
+        region: null,
         postalCode: '',
-        country: '',
+        country: null,
         deliveryInstructions: ''
       })
+    },
+    schema: {
+      type: Object as () => SchemaIF,
+      default: null
     },
     stateKey: {
       type: String,
@@ -157,7 +165,7 @@ export default defineComponent({
       schemaLocal,
       isSchemaRequired,
       labels
-    } = useAddress(toRefs(props).value, CivicAddressSchema)
+    } = useAddress(toRefs(props).value, props.schema)
     const { enableAddressComplete, uniqueIds } = useAddressComplete(addressLocal)
     const addressForm = ref(null) as FormIF
 
@@ -221,7 +229,6 @@ export default defineComponent({
 
     return {
       addressForm,
-      CivicAddressSchema,
       addressLocal,
       country,
       schemaLocal,

--- a/ppr-ui/src/components/mhrTransfers/TransferType.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferType.vue
@@ -40,7 +40,6 @@
               :rules="transferTypeRules"
               :disabled="disableSelect"
               returnObject
-              :menu="true"
             >
               <template #item="{ props, item }">
                 <!-- Type Header -->
@@ -230,7 +229,6 @@ export default defineComponent({
     }
 
     const handleTypeChange = async (item: TransferTypeSelectIF): Promise<void> => {
-      console.log(item)
       if (item.transferType !== localState.previousType?.transferType &&
         (hasUnsavedChanges.value || !!getMhrTransferDeclaredValue.value)) {
         localState.showTransferChangeDialog = true

--- a/ppr-ui/src/components/mhrTransfers/TransferType.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferType.vue
@@ -40,6 +40,7 @@
               :rules="transferTypeRules"
               :disabled="disableSelect"
               returnObject
+              :menu="true"
             >
               <template #item="{ props, item }">
                 <!-- Type Header -->
@@ -64,6 +65,7 @@
                   class="copy-normal gray7"
                   v-bind="props"
                   :title="null"
+                  @click="handleTypeChange(item.raw)"
                 >
                   <v-tooltip
                     location="right"
@@ -75,7 +77,6 @@
                       <v-list-item-title
                         class="pl-5"
                         v-bind="props"
-                        @click="handleTypeChange(item.raw)"
                       >
                         {{ item.raw.textLabel }}
                       </v-list-item-title>
@@ -100,7 +101,10 @@
         </v-row>
 
         <!-- Declared Value -->
-        <v-row noGutters>
+        <v-row
+          noGutters
+          class="mt-3"
+        >
           <v-col cols="3">
             <label
               class="generic-label"
@@ -226,6 +230,7 @@ export default defineComponent({
     }
 
     const handleTypeChange = async (item: TransferTypeSelectIF): Promise<void> => {
+      console.log(item)
       if (item.transferType !== localState.previousType?.transferType &&
         (hasUnsavedChanges.value || !!getMhrTransferDeclaredValue.value)) {
         localState.showTransferChangeDialog = true

--- a/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
@@ -61,7 +61,7 @@
                   class="auto-complete-item px-4 py-5"
                   :disabled="isBusinessTypeSPGP(result.legalType)"
                   :class="{ disabled: isBusinessTypeSPGP(result.legalType) }"
-                  @click="autoCompleteSelected = i"
+                  @mousedown="selectResult(i)"
                 >
                   <v-row class="auto-complete-row">
                     <v-col cols="2">
@@ -173,17 +173,15 @@ export default defineComponent({
       return [BusinessTypes.GENERAL_PARTNERSHIP, BusinessTypes.SOLE_PROPRIETOR].includes(businessType) && !props.isPPR
     }
 
-    watch(
-      () => localState.autoCompleteSelected,
-      (val: number) => {
-        if (val >= 0) {
-          const searchValue = localState.autoCompleteResults[val]?.name
-          localState.autoCompleteIsActive = false
-          localState.isSearchResultSelected = true
-          emit('searchValue', searchValue)
-        }
+    const selectResult = (resultIndex: number) => {
+      if (resultIndex >= 0) {
+        const searchValue = localState.autoCompleteResults[resultIndex]?.name
+        localState.autoCompleteIsActive = false
+        localState.isSearchResultSelected = true
+        emit('searchValue', searchValue)
       }
-    )
+    }
+
     watch(
       () => localState.autoCompleteIsActive,
       (val: boolean) => {
@@ -203,7 +201,7 @@ export default defineComponent({
           updateAutoCompleteResults(val)
           localState.isSearchResultSelected = false
         }
-      }, 1000) // add a one second delay before triggering the search, as per UXA
+      }, 1000) // add one-second delay before triggering the search, as per UXA
     )
     watch(
       () => localState.searching,
@@ -213,6 +211,7 @@ export default defineComponent({
     )
 
     return {
+      selectResult,
       isBusinessTypeSPGP,
       ...toRefs(localState)
     }
@@ -236,11 +235,11 @@ strong, p {
 }
 
 .auto-complete-sticky-row{
-  color: #465057 !important;
+  color: $gray7;
   font-size: 14px;
 }
 .auto-complete-row {
-  color: $gray7 !important;
+  color: $gray7;
   font-size: 16px;
 
   .org-name {
@@ -293,5 +292,8 @@ strong, p {
 
 :deep(.auto-complete-item.disabled) {
   opacity: 0.6;
+}
+:deep(.v-list-item--disabled) {
+  opacity: 1;
 }
 </style>

--- a/ppr-ui/src/components/userAccess/ReviewConfirm/QsInformationReview.vue
+++ b/ppr-ui/src/components/userAccess/ReviewConfirm/QsInformationReview.vue
@@ -35,7 +35,7 @@
       #topInfoSlot
     >
       <FormCard
-        label="Service Agreement"
+        label="Qualified Suppliers’ Agreement"
         class="pb-2"
       >
         <template #infoSlot>

--- a/ppr-ui/src/composables/address/BaseAddress.vue
+++ b/ppr-ui/src/composables/address/BaseAddress.vue
@@ -195,9 +195,9 @@ export default defineComponent({
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
+        region: null,
         postalCode: '',
-        country: '',
+        country: null,
         deliveryInstructions: ''
       })
     },

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -75,8 +75,8 @@ export const useNewMhrRegistration = () => {
         address: {
           street: '',
           city: '',
-          region: '',
-          country: '',
+          region: null,
+          country: null,
           postalCode: ''
         },
         emailAddress: '',
@@ -94,8 +94,8 @@ export const useNewMhrRegistration = () => {
           street: '',
           streetAdditional: '',
           city: '',
-          region: '',
-          country: '',
+          region: null,
+          country: null,
           postalCode: ''
         },
         leaveProvince: false,

--- a/ppr-ui/src/composables/userAccess/useUserAccess.ts
+++ b/ppr-ui/src/composables/userAccess/useUserAccess.ts
@@ -179,9 +179,9 @@ export const useUserAccess = () => {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
+        region: null,
         postalCode: '',
-        country: '',
+        country: null,
         deliveryInstructions: ''
       },
       phoneNumber: '',

--- a/ppr-ui/src/resources/userAccessOrgLookup.ts
+++ b/ppr-ui/src/resources/userAccessOrgLookup.ts
@@ -3,16 +3,15 @@ import { MhrSubTypes } from '@/enums'
 
 export const UserAccessOrgLookupConfig: Record<MhrSubTypes, OrgLookupConfigIF> = {
   [MhrSubTypes.LAWYERS_NOTARIES]: {
-    pluralTitle: 'Lawyer and Notarie\'s',
+    pluralTitle: 'Qualified Supplier\'s',
     lookupSubtitle: 'You can find the full legal name of an active B.C. business by entering the name or ' +
       'incorporation number of the business, or you can type the full legal name of the Qualified Supplier if it is ' +
       'not a registered B.C. business.',
     fieldLabel: 'Find or Enter the Full Legal Name of the Business',
     fieldHint: 'Example: Legal business name of lawyer, notary or law firm',
-    nilSearchText: 'If the Qualified Supplier is not an active registered B.C. business, you can manually enter the' +
-      ' full legal name of the business.',
+    nilSearchText: 'If the Qualified Supplier is not a registered B.C. business, enter the complete business name.',
     disableManualBusLookup: false,
-    addressSubtitle: 'Registry documents, if any, will be mailed to this address.'
+    addressSubtitle: ''
   },
   [MhrSubTypes.MANUFACTURER]: {
     pluralTitle: 'Home Manufacturer\'s',

--- a/ppr-ui/src/schemas/civic-address.ts
+++ b/ppr-ui/src/schemas/civic-address.ts
@@ -34,3 +34,36 @@ export const CivicAddressSchema = {
   deliveryInstructions: [
   ]
 }
+
+export const ManufacturerCivicAddressSchema = {
+  street: [
+    baseRules[ValidationRule.REQUIRED],
+    baseRules[ValidationRule.MAX_LENGTH](31),
+    ...spaceRules
+  ],
+  streetAdditional: [
+    baseRules[ValidationRule.MAX_LENGTH](50),
+    ...spaceRules
+  ],
+  city: [
+    baseRules[ValidationRule.REQUIRED],
+    baseRules[ValidationRule.MAX_LENGTH](20),
+    ...spaceRules
+  ],
+  country: [
+    baseRules[ValidationRule.REQUIRED],
+    ...spaceRules
+  ],
+  region: [
+    baseRules[ValidationRule.REQUIRED],
+    ...spaceRules
+  ],
+  /* NOTE: Canada/US postal code and zip code regex rules
+   * are added automatically as extra rules based on country
+   * inside the address components
+   */
+  postalCode: [
+  ],
+  deliveryInstructions: [
+  ]
+}

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -179,8 +179,8 @@ export const stateModel: StateModelIF = {
       address: {
         street: '',
         city: '',
-        region: '',
-        country: '',
+        region: null,
+        country: null,
         postalCode: ''
       },
       emailAddress: '',
@@ -198,8 +198,8 @@ export const stateModel: StateModelIF = {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
-        country: '',
+        region: null,
+        country: null,
         postalCode: ''
       },
       leaveProvince: false,
@@ -328,8 +328,8 @@ export const stateModel: StateModelIF = {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
-        country: '',
+        region: null,
+        country: null,
         postalCode: ''
       },
       emailAddress: '',
@@ -358,8 +358,8 @@ export const stateModel: StateModelIF = {
           street: '',
           streetAdditional: '',
           city: '',
-          region: '',
-          country: '',
+          region: null,
+          country: null,
           postalCode: ''
         },
         emailAddress: '',
@@ -378,9 +378,9 @@ export const stateModel: StateModelIF = {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
+        region: null,
         postalCode: '',
-        country: '',
+        country: null,
         deliveryInstructions: ''
       },
       phoneNumber: '',
@@ -391,8 +391,8 @@ export const stateModel: StateModelIF = {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
-        country: '',
+        region: null,
+        country: null,
         postalCode: ''
       },
     },
@@ -419,8 +419,8 @@ export const stateModel: StateModelIF = {
         street: '',
         streetAdditional: '',
         city: '',
-        region: '',
-        country: '',
+        region: null,
+        country: null,
         postalCode: ''
       },
       emailAddress: '',

--- a/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
@@ -30,6 +30,7 @@
 
       <HomeCivicAddress
         :value="getMhrRegistrationLocation.address"
+        :schema="CivicAddressSchema"
         :validate="validateCivicAddress"
         :class="{ 'border-error-left': validateCivicAddress }"
         @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, $event)"
@@ -57,6 +58,7 @@
 import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useStore } from '@/store/store'
+import { CivicAddressSchema } from '@/schemas/civic-address'
 import { HomeLocationType, HomeCivicAddress, HomeLandOwnership } from '@/components/mhrRegistration'
 import { useMhrValidations } from '@/composables/mhrRegistration/useMhrValidations'
 
@@ -106,6 +108,7 @@ export default defineComponent({
       MhrSectVal,
       setValidation,
       getMhrRegistrationLocation,
+      CivicAddressSchema,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/views/userAccess/QsInformation.vue
+++ b/ppr-ui/src/views/userAccess/QsInformation.vue
@@ -18,8 +18,8 @@
       <section class="qs-service-agreement mt-8">
         <h2>Qualified Suppliers’ Agreement</h2>
         <p class="mt-1">
-          Read and accept the terms of the service agreement. You may download and a copy of this agreement to save for
-          your records.
+          Read and accept the terms of the Qualified Suppliers’ Agreement. You may download a copy of this agreement to
+          save for your records.
         </p>
 
         <ServiceAgreement :validate="validate" />
@@ -88,6 +88,7 @@
         <HomeCivicAddress
           :stateKey="'mhrUserAccess'"
           :value="getMhrQsHomeLocation"
+          :schema="ManufacturerCivicAddressSchema"
           :validate="validate && !getMhrUserAccessValidation.qsLocationValid"
           :class="{ 'border-error-left': validate && !getMhrUserAccessValidation.qsLocationValid }"
           @isValid="updateQsLocationValid"
@@ -108,6 +109,7 @@ import { MhrSubTypes } from '@/enums'
 import { OrgLookupConfigIF } from '@/interfaces'
 import { ServiceAgreement } from '@/components/userAccess'
 import { HomeCivicAddress } from '@/components/mhrRegistration'
+import { ManufacturerCivicAddressSchema } from '@/schemas/civic-address'
 
 export default defineComponent({
   name: 'QsInformation',
@@ -152,6 +154,7 @@ export default defineComponent({
       getMhrQsHomeLocation,
       getMhrSubProduct,
       getMhrUserAccessValidation,
+      ManufacturerCivicAddressSchema,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/tests/unit/MhrCivicAddress.spec.ts
+++ b/ppr-ui/tests/unit/MhrCivicAddress.spec.ts
@@ -2,6 +2,7 @@ import { nextTick } from 'vue'
 
 import { HomeCivicAddress } from '@/components/mhrRegistration/HomeLocation'
 import { createComponent } from './utils'
+import { CivicAddressSchema } from '@/schemas/civic-address'
 
 // Error message class selector
 const ERROR_MSG = '.error--text .v-messages__message'
@@ -10,7 +11,7 @@ describe('mhr home civic address', () => {
   let wrapper
 
   beforeEach(async () => {
-    wrapper = await createComponent(HomeCivicAddress)
+    wrapper = await createComponent(HomeCivicAddress, { schema: CivicAddressSchema })
   })
 
   it('renders the component', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16952
/bcgov/entity#17647
/bcgov/entity#17463

*Description of changes:*
* Misc UXA fixes for Home Location and QS Information view
* Correct default values for address country and regions to v-selects thinking there was a selected value.
The above is a vuetify issue (or feature if you ask them) that allows empty strings to present as a legit value. 
https://github.com/vuetifyjs/vuetify/issues/16372

* Includes authHandler in app.vue to verify the CURRENT_ACCOUNT is set before initializing the application, prevent any timing issues where auth is slower than app initialization.
* Minor update to transfer type selector to prevent missed event firings on selection
* Modify CivicAddress to take it's schema as a prop, for reuse. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
