### PR TITLE
Support for Business Removal in SJT Transfer

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.23",
+      "version": "3.0.24",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/InfoChip.vue
+++ b/ppr-ui/src/components/common/InfoChip.vue
@@ -37,6 +37,7 @@ export default defineComponent({
         switch (props.action) {
           case 'DELETED':
           case 'DECEASED':
+          case 'HISTORICAL':
             return { bgColor: 'grey-lighten-2' }
           case 'LIEN':
           case 'LOCKED':

--- a/ppr-ui/src/components/mhrTransfers/BusinessRemovalForm.vue
+++ b/ppr-ui/src/components/mhrTransfers/BusinessRemovalForm.vue
@@ -1,0 +1,123 @@
+<template>
+  <v-form
+    id="business-removal-form"
+    ref="businessRemovalFormRef"
+    class="pt-4"
+  >
+    <v-row noGutters>
+      <v-col cols="3">
+        <div
+          class="generic-label pr-2"
+          :class="{ 'error-text': validate && !state?.deathCorpNumber }"
+        >
+          Incorporation or Registration Number
+        </div>
+      </v-col>
+      <v-col
+        cols="9"
+        class="pl-2"
+      >
+        <v-text-field
+          id="corp-or-reg-num"
+          ref="corpOrRegNumRef"
+          v-model="state.deathCorpNumber"
+          variant="filled"
+          label="Incorporation or Registration Number"
+          :rules="state?.corpNumRules"
+        />
+      </v-col>
+    </v-row>
+    <v-row
+      noGutters
+      class="mt-4"
+    >
+      <v-col cols="3">
+        <div
+          class="generic-label"
+          :class="{ 'error-text': validate && !state?.dateOfDissolution }"
+        >
+          Date of Dissolution or Cancellation
+        </div>
+      </v-col>
+      <v-col
+        cols="9"
+        class="pl-2"
+      >
+        <InputFieldDatePicker
+          id="date-of-dissolution"
+          ref="dateOfDissolutionRef"
+          title="Date of Dissolution or Cancellation"
+          :errorMsg="validate && !state?.dateOfDissolution ? 'Date of Dissolution or Cancellation' : ''"
+          :initialValue="state?.dateOfDissolution"
+          :maxDate="state?.todayDate"
+          @emitDate="state.dateOfDissolution = $event"
+          @emitCancel="state.dateOfDissolution = null"
+          @emitClear="state.dateOfDissolution = null"
+        />
+      </v-col>
+    </v-row>
+  </v-form>
+</template>
+<script setup lang="ts">
+import { InputFieldDatePicker } from '@/components/common'
+import { computed, reactive, ref, watch } from 'vue'
+import { useHomeOwners, useInputRules } from '@/composables'
+import { FormIF, MhrRegistrationHomeOwnerIF } from '@/interfaces'
+import { localTodayDate } from '@/utils'
+import { useStore } from '@/store/store'
+
+// Refs
+const businessRemovalFormRef: FormIF = ref(null)
+
+// Props
+const props = defineProps<{
+  validate?: boolean,
+  historicalOwner: MhrRegistrationHomeOwnerIF
+}>()
+
+// Composables
+const { setUnsavedChanges } = useStore()
+const { customRules, required, maxLength } = useInputRules()
+const { editHomeOwner } = useHomeOwners(true)
+
+// Local State
+const state = reactive({
+  deathCorpNumber: props.historicalOwner?.deathCorpNumber || '',
+  dateOfDissolution: props.historicalOwner?.deathDateTime || null,
+  corpNumRules: computed((): Array<()=>string|boolean> => {
+    return customRules(
+      maxLength(20),
+      required('Enter an Incorporation or Registration Number')
+    )
+  }),
+  todayDate: computed((): string => {
+    return localTodayDate(new Date(), true)
+  })
+})
+
+// Validate form when prompted
+watch(() => props.validate, async (validate: boolean) => {
+  validate && businessRemovalFormRef.value.validate()
+})
+
+// Update historical owner deathCorpNumber when value changes
+watch(() => state.deathCorpNumber, async (val: string) => {
+  editHomeOwner(
+    { ...props.historicalOwner, deathCorpNumber: val },
+    props.historicalOwner?.groupId
+  )
+  setUnsavedChanges(true)
+})
+
+// Update historical owner deathDateTime when value changes
+watch(() => state.dateOfDissolution, async (val: string) => {
+  editHomeOwner(
+    { ...props.historicalOwner, deathDateTime: val },
+    props.historicalOwner?.groupId
+  )
+  setUnsavedChanges(true)
+})
+</script>
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+</style>

--- a/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
@@ -8,7 +8,7 @@
       ref="deathCertificateForm"
       v-model="isFormValid"
     >
-      <v-row>
+      <v-row noGutters>
         <v-col cols="3">
           <div
             class="generic-label"
@@ -34,7 +34,10 @@
           />
         </v-col>
       </v-row>
-      <v-row>
+      <v-row
+        noGutters
+        class="mt-4"
+      >
         <v-col cols="3">
           <div
             class="generic-label"
@@ -119,12 +122,6 @@ export default defineComponent({
     const { setUnsavedChanges } = useStore()
     const deathCertificateForm: FormIF = ref(null)
     const deathCertificateNumberRef: FormIF = ref(null)
-    const deathCertificateNumberRules = computed(
-      (): Array<()=>string|boolean> => customRules(
-        maxLength(20),
-        required('Enter Death Certificate Registration Number')
-      )
-    )
 
     const localState = reactive({
       isFormValid: false, // Death Certificate form without Death Date Picker
@@ -189,7 +186,6 @@ export default defineComponent({
       hasError,
       deathCertificateForm,
       deathCertificateNumberRef,
-      deathCertificateNumberRules,
       localTodayDate,
       ...toRefs(localState)
     }

--- a/ppr-ui/src/components/mhrTransfers/index.ts
+++ b/ppr-ui/src/components/mhrTransfers/index.ts
@@ -1,3 +1,4 @@
+export { default as BusinessRemovalForm } from './BusinessRemovalForm.vue'
 export { default as TransferDetails } from './TransferDetails.vue'
 export { default as TransferDetailsReview } from './TransferDetailsReview.vue'
 export { default as ConfirmCompletion } from './ConfirmCompletion.vue'

--- a/ppr-ui/src/composables/mhrInformation/useMhrInfoValidation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInfoValidation.ts
@@ -37,8 +37,14 @@ export const useMhrInfoValidation = (validationState: mhrInfoValidationStateIF) 
 
   /** Returns true when the specified owner is a valid deceased owner **/
   const isValidDeceasedOwner = (owner: MhrRegistrationHomeOwnerIF): boolean => {
-    return (!isTransferDueToDeath.value || owner.action !== ActionTypes.REMOVED) || (owner.hasDeathCertificate &&
-      !!owner.deathCertificateNumber && owner.deathCertificateNumber?.length <= 20 && !!owner.deathDateTime)
+    return (!isTransferDueToDeath.value || owner.action !== ActionTypes.REMOVED) ||
+      (
+        // Deceased Owner validations
+        (owner.hasDeathCertificate && !!owner.deathCertificateNumber && owner.deathCertificateNumber?.length <= 20 &&
+          !!owner.deathDateTime) ||
+        // Historical Owner validations
+        (!!owner.deathCorpNumber && owner.deathCorpNumber?.length <= 20 && !!owner.deathDateTime)
+      )
   }
 
   /**  Returns true when the specific group is a valid deceased owner group **/

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -564,10 +564,13 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
         .filter(owner => owner.action === ActionTypes.REMOVED)
         .every(
           owner =>
-            owner.hasDeathCertificate &&
+            // Deceased owner validations
+            (owner.hasDeathCertificate &&
             !!owner.deathCertificateNumber &&
             owner.deathCertificateNumber?.length <= 20 &&
-            !!owner.deathDateTime
+            !!owner.deathDateTime) ||
+            // Historical owner validations
+            (!!owner.deathCorpNumber && owner.deathCorpNumber?.length <= 20 && !!owner.deathDateTime)
         )
       const hasLivingOwners = !groupWithDeletedOwners.owners.every(owner => owner.action === ActionTypes.REMOVED)
 
@@ -657,7 +660,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
 
     // When a user edits the current group before removing all current owners - update the action to ADDED
     const updatedGroup = updatedGroups.find(updatedGroup => updatedGroup.groupId === group.groupId + 1)
-    if (groupHasAllAddedOwners(updatedGroup) && updatedGroup.action === ActionTypes.CHANGED) {
+    if (groupHasAllAddedOwners(updatedGroup)) {
       updatedGroup.action = ActionTypes.ADDED
     }
 

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeOwnerIF.ts
@@ -12,6 +12,7 @@ export interface MhrRegistrationHomeOwnerIF {
   },
   suffix?: string
   organizationName?: string
+  deathCorpNumber?: string
   phoneNumber: string
   phoneExtension: string
   address: AddressIF

--- a/ppr-ui/tests/unit/BusinessRemovalForm.spec.ts
+++ b/ppr-ui/tests/unit/BusinessRemovalForm.spec.ts
@@ -1,0 +1,52 @@
+import { BusinessRemovalForm } from '@/components/mhrTransfers'
+import { createComponent } from './utils'
+import { expect } from 'vitest'
+import { nextTick } from 'vue'
+
+describe('Business Removal Form component', () => {
+  let wrapper
+
+  it('renders defaults correctly', async () => {
+    wrapper = await createComponent(BusinessRemovalForm)
+    await nextTick()
+
+    // Assert that the component is rendered
+    expect(wrapper.exists()).toBe(true)
+
+    expect(wrapper.find('#corp-or-reg-num').exists()).toBe(true)
+    expect(wrapper.vm.state.deathCorpNumber).toBe('')
+
+    expect(wrapper.find('#date-of-dissolution').exists()).toBe(true)
+    expect(wrapper.vm.state.deathDateTime).toBeUndefined()
+  })
+
+  it('renders with props correctly', async () => {
+    wrapper = await createComponent(BusinessRemovalForm, {
+      validate: false,
+      historicalOwner: {
+        deathCorpNumber: '123',
+        deathDateTime: '2024-01-01',
+        groupId: '5',
+      }
+    })
+    await nextTick()
+
+    expect(wrapper.exists()).toBe(true)
+
+    expect(wrapper.find('#corp-or-reg-num').exists()).toBe(true)
+    expect(wrapper.vm.state.deathCorpNumber).toBe('123')
+
+    expect(wrapper.find('#date-of-dissolution').exists()).toBe(true)
+    expect(wrapper.vm.state.dateOfDissolution).toBe('2024-01-01')
+  })
+
+  it('displays error-text with validation is prompted', async () => {
+    wrapper = await createComponent(BusinessRemovalForm, {
+      validate: true
+    })
+    await nextTick()
+
+    const errorCount = await wrapper.findAll('.error-text').length
+    expect(errorCount).toBe(2)
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18066
/bcgov/entity#18656
/bcgov/entity#18197

*Description of changes:*
* New component for handling Business Removal in Transfers to Surviving Joint Tenants.
* Updated labels, messaging and validations to handle 'Historical' business removals alongside 'Deceased' owner removals in Transfer to SJT's.
* Minor Label fix edge case scenario (ie, ADDED/CHANGED badge when group has removed all original owners) see 18197
* Minor property updates and handling to submit Transfer SJT's when a business is present.
* Misc styling fixes to correct the spacing of Death Certificates and the new component in the Home Owners table during a transfer.
* Some pics for context, for groupless and grouped scenarios:


![Screenshot 2024-01-17 at 1 01 10 PM](https://github.com/bcgov/ppr/assets/53542131/9c712f34-5306-4ad4-8a32-7869f95907c5)

![Screenshot 2024-01-17 at 1 01 24 PM](https://github.com/bcgov/ppr/assets/53542131/56381ff3-08bf-470c-8948-86931ed53f05)


![Screenshot 2024-01-17 at 1 03 23 PM](https://github.com/bcgov/ppr/assets/53542131/32a4ce06-483e-41d1-bb5e-8808aabaa624)

![Screenshot 2024-01-17 at 1 09 47 PM](https://github.com/bcgov/ppr/assets/53542131/4b574e72-828b-47e8-8b85-ccdbfbe21e86)

![Screenshot 2024-01-17 at 1 10 05 PM](https://github.com/bcgov/ppr/assets/53542131/b6eb7066-a708-45ca-a457-c36dfa9a76b2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
