### PR TITLE
BaseAddress: Region and Validation update

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.26",
+      "version": "3.0.27",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/address/BaseAddress.vue
+++ b/ppr-ui/src/composables/address/BaseAddress.vue
@@ -243,7 +243,7 @@ export default defineComponent({
     const origPostalCodeRules = localSchema.postalCode
     const origRegionRules = localSchema.region
 
-    const { addressForm, resetValidation, validate } = useBaseValidations()
+    const { addressForm, validate } = useBaseValidations()
 
     const { enableAddressComplete, uniqueIds } = useAddressComplete(addressLocal)
 
@@ -273,7 +273,7 @@ export default defineComponent({
       }
       // wait for schema update and validate the form
       setTimeout(() => {
-        props.triggerErrors ? validate() : resetValidation()
+        props.triggerErrors && validate()
       }, 5)
     }
 

--- a/ppr-ui/src/composables/address/factories/countries-provinces-factory.ts
+++ b/ppr-ui/src/composables/address/factories/countries-provinces-factory.ts
@@ -72,8 +72,9 @@ export function useCountriesProvinces () {
         short: (p.short && p.short.length <= 2) ? p.short : '--'
       }))
     regions = regions.concat(result)
-    window['countryRegionsCache'][code] = regions
-    return regions
+
+    window['countryRegionsCache'][code] = filterDuplicates(regions, 'name')
+    return filterDuplicates(regions, 'name')
   }
   return {
     getCountries,

--- a/ppr-ui/src/composables/address/factories/countries-provinces-factory.ts
+++ b/ppr-ui/src/composables/address/factories/countries-provinces-factory.ts
@@ -71,10 +71,10 @@ export function useCountriesProvinces () {
         name: p.english || p.name,
         short: (p.short && p.short.length <= 2) ? p.short : '--'
       }))
-    regions = regions.concat(result)
+    regions = filterDuplicates(regions.concat(result), 'name')
 
-    window['countryRegionsCache'][code] = filterDuplicates(regions, 'name')
-    return filterDuplicates(regions, 'name')
+    window['countryRegionsCache'][code] = regions
+    return regions
   }
   return {
     getCountries,


### PR DESCRIPTION
*Issue #:*

 /bcgov/entity#17464
*Description of changes:*
- Removed Validation Reset in countryChangeHandler.  

 /bcgov/entity#19386
*Description of changes:*
- Prevent duplicated Regions in Region list. 
- example: only show 1 BC IF it is manually added to top of Region List. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
