### PR TITLE
MHR API allow helpdesk to download modernized registration reports.

### DIFF
--- a/mhr_api/report-templates/adminRegistrationV2.html
+++ b/mhr_api/report-templates/adminRegistrationV2.html
@@ -208,6 +208,9 @@
         <div class="no-page-break section-data pt-5">
           {%  if status == 'EXEMPT' and previousStatus == 'ACTIVE' %}
             The registration status for this home was changed to Exempt and this home is now exempt from the Manufactured Home Act.
+          {%  elif status == 'ACTIVE' and previousStatus == 'EXEMPT_EXEMPTION' %}
+            The registration status for this home was changed to Active, therefore the existing Residential and/or Non-Residential Exemption(s)
+            on this home have been cancelled.
           {% else %}
             The registration status for this home was changed to Active.
           {% endif %}

--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -97,9 +97,9 @@
           {% if registrationType in ('MHREG', 'EXEMPTION_NON_RES', 'EXEMPTION_RES') %}    
             {{ documentDescription|title }}
           {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'REGC_STAFF' %}
-            {{ documentDescription|title }} &ndash; Staff Error or Omission
+            Registry Correction &ndash; Staff Error or Omission
           {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'REGC_CLIENT' %}
-            {{ documentDescription|title }} &ndash; Client Error or Omission
+            Registry Correction &ndash; Client Error or Omission
           {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'CANCEL_PERMIT' %}
             {{ documentDescription|title }}
           {% elif registrationType == 'REG_STAFF_ADMIN' and note is defined and note.coverDocumentDescription is defined %}    

--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -96,6 +96,10 @@
         <div class="cover-data mt-4"><span class="cover-data-bold">Registration Type:</span>
           {% if registrationType in ('MHREG', 'EXEMPTION_NON_RES', 'EXEMPTION_RES') %}    
             {{ documentDescription|title }}
+          {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'REGC_STAFF' %}
+            {{ documentDescription|title }} &ndash; Staff Error or Omission
+          {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'REGC_CLIENT' %}
+            {{ documentDescription|title }} &ndash; Client Error or Omission
           {% elif registrationType == 'REG_STAFF_ADMIN' and documentType is defined and documentType == 'CANCEL_PERMIT' %}
             {{ documentDescription|title }}
           {% elif registrationType == 'REG_STAFF_ADMIN' and note is defined and note.coverDocumentDescription is defined %}    

--- a/mhr_api/report-templates/registrationV2.html
+++ b/mhr_api/report-templates/registrationV2.html
@@ -58,8 +58,8 @@
 
     {% if usergroup is not defined or usergroup != 'mhr_manufacturer' %}
       <div class="no-page-break">
-        <div class="separator mt-5"></div>
-        <div class="section-title mt-3">Rebuilt Status</div>
+        <div class="separator-section mt-5"></div>
+        <div class="section-sub-title mt-3">Rebuilt Status</div>
         {% if description.rebuiltRemarks is defined and description.rebuiltRemarks != '' %}
           <div class="section-data pt-3">{{description.rebuiltRemarks|safe}}</div>
         {% else %}
@@ -68,8 +68,8 @@
       </div>
 
       <div class="no-page-break">
-        <div class="separator mt-5"></div>
-        <div class="section-title mt-3">Other Information</div>
+        <div class="separator-section mt-5"></div>
+        <div class="section-sub-title mt-3">Other Information</div>
         {% if description.otherRemarks is defined and description.otherRemarks != '' %}
           <div class="section-data pt-3">{{description.otherRemarks|safe}}</div>
         {% else %}

--- a/mhr_api/report-templates/template-parts/registration/details.html
+++ b/mhr_api/report-templates/template-parts/registration/details.html
@@ -4,9 +4,9 @@
         <div class="section-title mt-3">
             Description of Manufactured Home
             {% if documentType is defined and documentType in ('REGC_STAFF', 'REGC_CLIENT') %}
-                <span class="pl-2">&nbsp;</span><span class="label">CORRECTED</span>
+                <span class="pl-2">&nbsp;</span><span class="section-label">CORRECTED</span>
             {% elif documentType is defined and documentType == 'PUBA' %}
-                <span class="pl-2">&nbsp;</span><span class="label">AMENDED</span>            
+                <span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span>            
             {% endif %}            
         </div>
         <table class="no-page-break section-data details-table mt-4" role="presentation">

--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -5,14 +5,14 @@
     {% elif registrationType in ('PERMIT', 'REG_STAFF_ADMIN') and (documentType is not defined or documentType not in ('CANCEL_PERMIT', 'REGC_STAFF', 'REGC_CLIENT')) %}
         <div class="section-title mt-5">New Registered Location</div>
     {% elif amendment is defined and amendment %}
-        <div class="section-title mt-5">New Registered Location<span class="pl-2">&nbsp;</span><span class="label">AMENDED</span></div>
+        <div class="section-title mt-5">New Registered Location<span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span></div>
     {% elif registrationType not in ('EXEMPTION_RES', 'EXEMPTION_NON_RES') %}
         {% if documentType is not defined or documentType not in ('CANCEL_PERMIT', 'REGC_STAFF', 'REGC_CLIENT') %}
             <div class="separator mt-5"></div>
         {% endif %}
         <div class="section-title mt-3">Registered Location
             {% if documentType is defined and documentType in ('REGC_STAFF', 'REGC_CLIENT') %}
-                <span class="pl-2">&nbsp;</span><span class="label">CORRECTED</span>            
+                <span class="pl-2">&nbsp;</span><span class="section-label">CORRECTED</span>            
             {% endif %}
         </div>
     {% endif %}

--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -1,9 +1,9 @@
 <div class="section-title mt-3">
     {% if registrationType in ('TRANS', 'TRAND') %}New{% endif %} Registered Owner(s) Information
     {% if documentType is defined and documentType in ('REGC_STAFF', 'REGC_CLIENT') %}
-        <span class="pl-2">&nbsp;</span><span class="label">CORRECTED</span>
+        <span class="pl-2">&nbsp;</span><span class="section-label">CORRECTED</span>
     {% elif documentType is defined and documentType == 'PUBA' %}
-        <span class="pl-2">&nbsp;</span><span class="label">AMENDED</span>            
+        <span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span>            
     {% endif %}
 </div>
 <div class="no-page-break mt-3">

--- a/mhr_api/report-templates/template-parts/search-result/sections.html
+++ b/mhr_api/report-templates/template-parts/search-result/sections.html
@@ -1,7 +1,7 @@
 <div class="no-page-break">
 {% if detail.description is defined and detail.description.sections is defined %}
    <div class="separator-section mt-5"></div>
-   <div class="section-data pt-3"><span class="sections-table-header">Number of Home Sections:</span> {{ detail.description.sectionCount }}</div> 
+   <div class="section-data pt-3"><span class="sections-sub-title">Number of Home Sections:</span> {{ detail.description.sectionCount }}</div> 
    <table class="sections-table mt-4" role="presentation">         
       <tr class="sections-table-header no-page-break mb-0">
          <td class="top-align">Section</td>

--- a/mhr_api/report-templates/template-parts/search-result/sections.html
+++ b/mhr_api/report-templates/template-parts/search-result/sections.html
@@ -1,7 +1,7 @@
 <div class="no-page-break">
 {% if detail.description is defined and detail.description.sections is defined %}
    <div class="separator-section mt-5"></div>
-   <div class="section-data pt-3"><span class="sections-sub-title">Number of Home Sections:</span> {{ detail.description.sectionCount }}</div> 
+   <div class="section-data pt-3"><span class="section-sub-title">Number of Home Sections:</span> {{ detail.description.sectionCount }}</div> 
    <table class="sections-table mt-4" role="presentation">         
       <tr class="sections-table-header no-page-break mb-0">
          <td class="top-align">Section</td>

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -57,8 +57,8 @@
   [[search-result/sections.html]]
 
   <div class="no-page-break">
-    <div class="separator mt-5"></div>
-    <div class="section-title mt-3">Rebuilt Status</div>
+    <div class="separator-section mt-5"></div>
+    <div class="section-sub-title mt-3">Rebuilt Status</div>
     {% if detail.description is defined and detail.description.rebuiltRemarks is defined and detail.description.rebuiltRemarks != '' %}
       <div class="section-data pt-3">{{detail.description.rebuiltRemarks|safe}}</div>
     {% else %}
@@ -67,8 +67,8 @@
   </div>
 
   <div class="no-page-break">
-    <div class="separator mt-5"></div>
-    <div class="section-title mt-3">Other Information</div>
+    <div class="separator-section mt-5"></div>
+    <div class="section-sub-title mt-3">Other Information</div>
     {% if detail.description is defined and detail.description.otherRemarks is defined and detail.description.otherRemarks != '' %}
       <div class="section-data pt-3">{{detail.description.otherRemarks|safe}}</div>
     {% else %}

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -1481,24 +1481,26 @@
 
 	.section-label {
 		font-size: 7pt;
-		line-height: 22px;
+		line-height: 13px;
 		font-family: 'BC Sans', sans-serif !important;
 		font-weight: bold;
 		color: #313132;
+		vertical-align: 15% !important;
 		padding: 3px 8px !important;
-		margin: 4px 3px 4px 0px !important;
+		margin: 0px 3px 0px 0px !important;
 		border-radius: 4px;
 		background-color:#E2E7ED; /* #e7e7e7; */
 	}
 
 	.tombstone-label {
 		font-size: 7pt;
-		line-height: 18px;
+		line-height: 13px !important;
 		font-family: 'BC Sans', sans-serif !important;
 		font-weight: bold;
 		color: #313132;
+		vertical-align: 15% !important;
 		padding: 3px 8px !important;
-		margin: 2px 3px 3px 0px !important;
+		margin: 0px 3px 0px 0px !important;
 		border-radius: 4px;
 		background-color:#CBD5E0; /* #E2E7ED; */
 	}

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -1479,14 +1479,26 @@
 		background-color:#E2E7ED; /* #e7e7e7; */
 	}
 
-	.tombstone-label {
+	.section-label {
 		font-size: 7pt;
-		line-height: 13px;
+		line-height: 22px;
 		font-family: 'BC Sans', sans-serif !important;
 		font-weight: bold;
 		color: #313132;
 		padding: 3px 8px !important;
-		margin: 0 3px 0 0 !important; /* 0px 8px !important; */
+		margin: 4px 3px 4px 0px !important;
+		border-radius: 4px;
+		background-color:#E2E7ED; /* #e7e7e7; */
+	}
+
+	.tombstone-label {
+		font-size: 7pt;
+		line-height: 18px;
+		font-family: 'BC Sans', sans-serif !important;
+		font-weight: bold;
+		color: #313132;
+		padding: 3px 8px !important;
+		margin: 2px 3px 3px 0px !important;
 		border-radius: 4px;
 		background-color:#CBD5E0; /* #E2E7ED; */
 	}

--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -101,11 +101,11 @@ SELECT (SELECT COUNT(mr.id)
           WHERE mer.account_id = :query_value
             AND mer.mhr_number = :query_value2
             AND (mer.removed_ind IS NULL OR mer.removed_ind != 'Y')) as extra_reg_count,
-       (SELECT  mr.account_id
-           FROM mhr_registrations mr
-          WHERE mr.account_id = :query_value
-            AND mr.mhr_number = :query_value2
-            AND mr.registration_type IN ('MHREG')),
+       (SELECT mr.account_id
+          FROM mhr_registrations mr, mhr_registration_reports mrr
+         WHERE mr.mhr_number = :query_value2
+           AND mr.registration_type IN ('MHREG')
+           AND mr.id = mrr.registration_id),
       (SELECT mlc.registration_type
          FROM mhr_lien_check_vw mlc
         WHERE mlc.mhr_number = :query_value2

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -223,7 +223,7 @@ def find_summary_by_mhr_number(account_id: str, mhr_number: str, staff: bool):
             row = result.first()
             reg_count = int(row[0])
             extra_count = int(row[1])
-            reg_account_id = str(row[2])
+            reg_account_id = str(row[2]) if row[2] else ''
             lien_registration_type: str = str(row[3]) if row[3] else ''
             current_app.logger.debug(f'reg_count={reg_count}, extra_count={extra_count}, staff={staff}')
             # Set inUserList to true if MHR number already added to account extra registrations.
@@ -235,12 +235,15 @@ def find_summary_by_mhr_number(account_id: str, mhr_number: str, staff: bool):
                         (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
                     registration['lienRegistrationType'] = lien_registration_type
             # Path to download report only available for staff and registrations created by the account.
-            if reg_count > 0 and (staff or account_id == reg_account_id):
+            # if reg_count > 0 and (staff or account_id == reg_account_id):
+            if reg_account_id and (staff or (reg_count> 0 and account_id == reg_account_id)):
                 for reg in registrations:
-                    if reg['documentType'] in (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
-                        reg['path'] = REGISTRATION_PATH + mhr_number
-                    else:
-                        reg['path'] = DOCUMENT_PATH + reg.get('documentId')
+                    if not reg.get('path'):
+                        if reg['documentType'] in (Db2Document.DocumentTypes.CONV,
+                                                   Db2Document.DocumentTypes.MHREG_TRIM):
+                            reg['path'] = REGISTRATION_PATH + mhr_number
+                        else:
+                            reg['path'] = DOCUMENT_PATH + reg.get('documentId')
             registrations = __collapse_results(registrations)
             return registrations[0]
         except Exception as db_exception:   # noqa: B902; return nicer error
@@ -273,7 +276,7 @@ def find_summary_by_doc_reg_number(account_id: str, doc_reg_number: str, staff: 
             row = result.first()
             reg_count = int(row[0])
             extra_count = int(row[1])
-            reg_account_id = str(row[2])
+            reg_account_id = str(row[2]) if row[2] else ''
             lien_registration_type: str = str(row[3]) if row[3] else ''
             current_app.logger.debug(f'reg_count={reg_count}, extra_count={extra_count}, staff={staff}')
             # Set inUserList to true if MHR number already added to account extra registrations.
@@ -285,12 +288,15 @@ def find_summary_by_doc_reg_number(account_id: str, doc_reg_number: str, staff: 
                         (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
                     registration['lienRegistrationType'] = lien_registration_type
             # Path to download report only available for staff and registrations created by the account.
-            if reg_count > 0 and (staff or account_id == reg_account_id):
+            # if reg_count > 0 and (staff or account_id == reg_account_id):
+            if reg_account_id and (staff or (reg_count > 0 and account_id == reg_account_id)):
                 for reg in registrations:
-                    if reg['documentType'] in (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
-                        reg['path'] = REGISTRATION_PATH + mhr_number
-                    else:
-                        reg['path'] = DOCUMENT_PATH + reg.get('documentId')
+                    if not reg.get('path'):
+                        if reg['documentType'] in (Db2Document.DocumentTypes.CONV,
+                                                   Db2Document.DocumentTypes.MHREG_TRIM):
+                            reg['path'] = REGISTRATION_PATH + mhr_number
+                        else:
+                            reg['path'] = DOCUMENT_PATH + reg.get('documentId')
             registrations = __collapse_results(registrations)
             return registrations[0]
         except Exception as db_exception:   # noqa: B902; return nicer error

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -236,7 +236,7 @@ def find_summary_by_mhr_number(account_id: str, mhr_number: str, staff: bool):
                     registration['lienRegistrationType'] = lien_registration_type
             # Path to download report only available for staff and registrations created by the account.
             # if reg_count > 0 and (staff or account_id == reg_account_id):
-            if reg_account_id and (staff or (reg_count> 0 and account_id == reg_account_id)):
+            if reg_account_id and (staff or (reg_count > 0 and account_id == reg_account_id)):
                 for reg in registrations:
                     if not reg.get('path'):
                         if reg['documentType'] in (Db2Document.DocumentTypes.CONV,

--- a/mhr_api/src/mhr_api/reports/v2/report_utils.py
+++ b/mhr_api/src/mhr_api/reports/v2/report_utils.py
@@ -18,6 +18,7 @@ from flask import current_app
 from jinja2 import Template
 import PyPDF2
 
+from mhr_api.models.type_tables import MhrDocumentTypes
 from mhr_api.utils.base import BaseEnum
 
 
@@ -317,7 +318,11 @@ def get_report_files(request_data: dict, report_type: str, mail: bool = False) -
             if report_type == ReportTypes.MHR_ADMIN_REGISTRATION and request_data['templateVars'].get('nocLocation'):
                 title_text = 'NOTICE OF CHANGE IN LOCATION'
             elif report_type == ReportTypes.MHR_ADMIN_REGISTRATION and \
-                    request_data['templateVars'].get('documentType', '') == 'NCAN' and \
+                    request_data['templateVars'].get('documentType', '') in (MhrDocumentTypes.REGC_STAFF,
+                                                                             MhrDocumentTypes.REGC_CLIENT):
+                title_text = 'REGISTRY CORRECTION'
+            elif report_type == ReportTypes.MHR_ADMIN_REGISTRATION and \
+                    request_data['templateVars'].get('documentType', '') == MhrDocumentTypes.NCAN and \
                     request_data['templateVars']['note'].get('cancelledDocumentDescription'):
                 title_text += ' (' + request_data['templateVars']['note'].get('cancelledDocumentDescription') + ')'
         subtitle_text = request_data['templateVars'].get('meta_subtitle', '')

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -71,10 +71,10 @@ def get_account_registrations():
             collapse_param = True
         elif isinstance(collapse_param, str):
             collapse_param = False
-
+        is_read_staff: bool = (is_staff(jwt) or is_bcol_help(account_id, jwt))
         params: AccountRegistrationParams = AccountRegistrationParams(account_id=account_id,
                                                                       collapse=collapse_param,
-                                                                      sbc_staff=is_staff(jwt))
+                                                                      sbc_staff=is_read_staff)
         params = resource_utils.get_account_registration_params(request, params)
         statement_list = MhrRegistration.find_all_by_account_id(params)
         return jsonify(statement_list), HTTPStatus.OK


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19399

*Description of changes:*
- Treat BCOL helpdesk as similar to registries staff: they can download registration reports created by another account if they exist.

*Issue #:* /bcgov/entity#19249

*Description of changes:*
- Updates to correction registration report from UXA review
- Update new MH registration report description section styling
- Update search report description section styling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
