### PR TITLE
Update PPR party client code formatting and matching.

### DIFF
--- a/ppr-api/src/ppr_api/models/party.py
+++ b/ppr-api/src/ppr_api/models/party.py
@@ -123,7 +123,7 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
             party['partyId'] = self.id
 
         if self.client_code and self.branch_id:
-            party['code'] = str(self.branch_id)
+            party['code'] = self.format_party_code()
             if self.client_code.name:
                 party['businessName'] = self.client_code.name
 
@@ -167,6 +167,10 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
         db.session.commit()
 
         return self.json
+
+    def format_party_code(self) -> str:
+        """Return the client party code in the 8 character format padded with leading zeroes."""
+        return str(self.branch_id).strip().rjust(8, '0')
 
     @property
     def name(self) -> str:

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.1.8'  # pylint: disable=invalid-name
+__version__ = '1.1.9'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19436

*Description of changes:*
- Format client party codes with leading zeroes. Currently 0115 returns no results when 3 codes exist with a head office code of 115.
- The first 4 digits will always match on the head office code. Currently 001 and 0001 match on 00000001. 001 will match on head office codes 1 and 10 to 19. 0001 will match on head office code 1.
- When matching on more than 4 digits, match on the formatted values with leading zeroes.
- Sort by party code when multiple results exist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
