### PR TITLE
Update cancel Transport Permit dialog

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.30",
+      "version": "3.0.31",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1036,7 +1036,10 @@ export default defineComponent({
     const handleIncompleteRegistrationsResp = async (val: boolean) => {
       if (!val) {
         setUnsavedChanges(false)
-        goToDashboard()
+        setEmptyMhrTransfer(initMhrTransfer())
+        resetTransportPermit(true)
+        resetValidationState()
+        await scrollToFirstError(false, 'mhr-information-header')
       }
       localState.showIncompleteRegistrationDialog = false
     }


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#18315

*Description of changes:*
- UXA to keep user on MHR Info page when cancelling the Transport Permit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
