### PR TITLE
Transfers: Stale Draft Dialog and Removal

### DIFF
--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -345,13 +345,13 @@ export const useNewMhrRegistration = () => {
     let mhRegDrafts = []
 
     if (!sortOptions?.status || sortOptions?.status === MhApiStatusTypes.DRAFT) {
-      mhRegDrafts = mhrDrafts.filter(draft =>
+      mhRegDrafts = mhrDrafts?.filter(draft =>
         !draft.mhrNumber && draft.registrationType === APIMhrTypes.MANUFACTURED_HOME_REGISTRATION
       )
     }
 
     // add Transfer drafts to parent registrations.
-    mhrHistory.forEach(transfer => {
+    mhrHistory?.forEach(transfer => {
       transfer.baseRegistrationNumber = transfer.mhrNumber
 
       // Prepare existing changes

--- a/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useNewMhrRegistration.ts
@@ -374,6 +374,7 @@ export const useNewMhrRegistration = () => {
         mhrDrafts.forEach(draft => {
           const newDraft: MhRegistrationSummaryIF = {
             mhrNumber: transfer.mhrNumber,
+            outOfDate: draft.outOfDate,
             baseRegistrationNumber: transfer.mhrNumber,
             draftNumber: draft.draftNumber,
             submittingParty: draft.submittingParty,

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
@@ -151,6 +151,7 @@ export interface MhRegistrationSummaryIF {
   draftNumber?: string
   hasCaution?: boolean
   mhrNumber: string
+  outOfDate?: boolean // Stale draft flag
   ownerNames: string
   path: string
   registrationType?: DraftTypes | APIMhrTypes

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -97,3 +97,13 @@ export const manufacturerRegSuccessDialogOptions: DialogOptionsIF = {
     <b>Note: The registration decals must be affixed to the home, according to the instructions on the
     decal envelope.</b>`
 }
+
+export const staleDraftDialogOptions = (draftIdentifier: string): DialogOptionsIF => {
+  return {
+    acceptText: 'Delete Draft',
+    cancelText: '',
+    title: 'Draft No Long Valid',
+    text: `Your draft for ${draftIdentifier} is no longer valid as changes have been made since your draft was
+    created. Delete your draft and open the latest version of the manufactured home information to make changes.`
+  }
+}

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -102,7 +102,7 @@ export const staleDraftDialogOptions = (draftIdentifier: string): DialogOptionsI
   return {
     acceptText: 'Delete Draft',
     cancelText: '',
-    title: 'Draft No Long Valid',
+    title: 'Draft No Longer Valid',
     text: `Your draft for ${draftIdentifier} is no longer valid as changes have been made since your draft was
     created. Delete your draft and open the latest version of the manufactured home information to make changes.`
   }

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -616,7 +616,7 @@ export async function updateMhrDraft (draftId: string, type: APIMhrTypes, draft:
 }
 
 // Get all existing drafts
-export async function getMhrDrafts (sortOptions?): Promise<Array<MhrDraftIF>> {
+export async function getMhrDrafts (sortOptions?): Promise<Array<MhrDraftIF>|any> {
   let path = 'drafts'
   if (sortOptions) {
     path = addSortParams(
@@ -632,10 +632,13 @@ export async function getMhrDrafts (sortOptions?): Promise<Array<MhrDraftIF>> {
       }
       return data
     })
+    .catch(() => {
+      // Continue
+    })
 }
 
 // Get an existing draft by id.
-export async function getMhrDraft (draftId: string): Promise<MhrDraftApiIF> {
+export async function getMhrDraft (draftId: string): Promise<MhrDraftApiIF|any> {
   const draft = {} as MhrDraftApiIF
   if (!draftId) {
     draft.error = {
@@ -653,6 +656,9 @@ export async function getMhrDraft (draftId: string): Promise<MhrDraftApiIF> {
         throw new Error('Invalid API response')
       }
       return data
+    })
+    .catch(() => {
+      // Continue
     })
 }
 

--- a/ppr-ui/tests/unit/RegistrationsWrapper.spec.ts
+++ b/ppr-ui/tests/unit/RegistrationsWrapper.spec.ts
@@ -278,7 +278,7 @@ describe('Dashboard add registration tests', () => {
   })
 })
 
-describe.only('MHR registration table tests', () => {
+describe('MHR registration table tests', () => {
   let wrapper
 
   const myRegDrafts: MhrDraftIF[] = [{ ...mockedMhDraft }]

--- a/ppr-ui/tests/unit/test-data/mock-registration-responses.ts
+++ b/ppr-ui/tests/unit/test-data/mock-registration-responses.ts
@@ -224,7 +224,8 @@ export const mockedResidentialExemptionMhRegistration: MhRegistrationSummaryIF =
 export const mockedMhDraft: MhrDraftIF = {
   lastUpdateDateTime: '2021-08-03T17:21:17+00:00',
   type: APIMhrTypes.MANUFACTURED_HOME_REGISTRATION,
-  mhrNumber: '',
+  mhrNumber: '12345',
+  draftNumber: '54321',
   registrationType: APIMhrTypes.MANUFACTURED_HOME_REGISTRATION,
   registrationDescription: '',
   path: '/path/to/doc',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15820

*Description of changes:*
* Prompt User when trying to resume a stale draft(transfers) as flagged by the api using the `outOfDate` flag. 
* Delete draft is prompted.

![Screenshot 2024-01-30 at 2 03 27 PM](https://github.com/bcgov/ppr/assets/53542131/7fa42f9b-1cb1-4ae3-b5c0-8fd0da275c44)

![Screenshot 2024-01-30 at 2 06 17 PM](https://github.com/bcgov/ppr/assets/53542131/a1a33b1b-1cb3-4916-927c-e66cda77506e)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
