### PR TITLE
Transfer Race Condition Handling

### DIFF
--- a/ppr-ui/src/enums/errorCategories.ts
+++ b/ppr-ui/src/enums/errorCategories.ts
@@ -17,6 +17,7 @@ export enum ErrorCategories {
   REGISTRATION_SAVE = 'registration-save',
   REGISTRATION_TRANSFER = 'registration-transfer',
   REGISTRATION_TRANSFER_SAVE = 'registration-transfer-save',
+  TRANSFER_DRAFT_STALE = 'transfer-draft-stale',
   REPORT_GENERATION = 'report-generation',
   SEARCH = 'search',
   SEARCH_COMPLETE = 'search-complete',
@@ -25,4 +26,12 @@ export enum ErrorCategories {
   MHR_UNIT_NOTE_FILING = 'mhr-unit-note-filing',
   EXEMPTION_SAVE = 'exemption-save',
   TRANSPORT_PERMIT_FILING = 'mhr-transport-permit-filing'
+}
+
+/**
+ * RootCause Api Error Enum
+ * These string snippets/values should derive directly from api error responses.
+ * **/
+export enum ErrorRootCauses {
+  OUT_OF_DATE_DRAFT = 'The draft for this registration is out of date'
 }

--- a/ppr-ui/src/enums/errorCategories.ts
+++ b/ppr-ui/src/enums/errorCategories.ts
@@ -18,6 +18,7 @@ export enum ErrorCategories {
   REGISTRATION_TRANSFER = 'registration-transfer',
   REGISTRATION_TRANSFER_SAVE = 'registration-transfer-save',
   TRANSFER_DRAFT_STALE = 'transfer-draft-stale',
+  TRANSFER_OUT_OF_DATE_OWNERS = 'transfer-out-of-date-owners',
   REPORT_GENERATION = 'report-generation',
   SEARCH = 'search',
   SEARCH_COMPLETE = 'search-complete',
@@ -33,5 +34,7 @@ export enum ErrorCategories {
  * These string snippets/values should derive directly from api error responses.
  * **/
 export enum ErrorRootCauses {
-  OUT_OF_DATE_DRAFT = 'The draft for this registration is out of date'
+  OUT_OF_DATE_DRAFT = 'The draft for this registration is out of date',
+  // Potential Future update: Api specific messaging for outdated owners
+  OUT_OF_DATE_OWNERS = `^.*The owner group with ID \\d+ is not active and cannot be changed.*$`
 }

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -114,7 +114,6 @@ export const outOfDateOwnersDialogOptions = (mhrIdentifier: string): DialogOptio
     cancelText: 'Return to My Registration',
     title: 'Changes Cannot Be Saved',
     text: `The information for this home has been changed by another user. You will need to update to the latest version
-     of MHR Number ${mhrIdentifier} and redo your changes.
-`
+     of MHR Number ${mhrIdentifier} and redo your changes.`
   }
 }

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -107,3 +107,14 @@ export const staleDraftDialogOptions = (draftIdentifier: string): DialogOptionsI
     created. Delete your draft and open the latest version of the manufactured home information to make changes.`
   }
 }
+
+export const outOfDateOwnersDialogOptions = (mhrIdentifier: string): DialogOptionsIF => {
+  return {
+    acceptText: 'Update to Latest Version',
+    cancelText: 'Return to My Registration',
+    title: 'Changes Cannot Be Saved',
+    text: `The information for this home has been changed by another user. You will need to update to the latest version
+     of MHR Number ${mhrIdentifier} and redo your changes.
+`
+  }
+}

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -1195,6 +1195,10 @@ export const useStore = defineStore('assetsStore', () => {
     state.value.mhrInformation = mhrInfo
   }
 
+  function setMhrInformationDraftId (draftId: string) {
+    state.value.mhrInformation.draftNumber = draftId
+  }
+
   function setMhrStatusType (status: MhApiStatusTypes) {
     state.value.mhrInformation.statusType = status
   }
@@ -1625,6 +1629,7 @@ export const useStore = defineStore('assetsStore', () => {
 
     // MHR Information
     setMhrInformation,
+    setMhrInformationDraftId,
     setMhrStatusType,
     setMhrFrozenDocumentType,
     setLienType,

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,11 +10,11 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': false, // Enables MHR table tab
-  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': false,
-  'mhr-transport-permit-enabled': false,
-  'mhr-user-access-enabled': false,
+  'mhr-registration-enabled': true, // Enables MHR table tab
+  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': true,
+  'mhr-transport-permit-enabled': true,
+  'mhr-user-access-enabled': true,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,11 +10,11 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': true, // Enables MHR table tab
-  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': true,
-  'mhr-transport-permit-enabled': true,
-  'mhr-user-access-enabled': true,
+  'mhr-registration-enabled': false, // Enables MHR table tab
+  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': false,
+  'mhr-transport-permit-enabled': false,
+  'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -2,24 +2,27 @@
 import { axios } from '@/utils/axios-ppr'
 import { StatusCodes } from 'http-status-codes'
 import {
-  StaffPaymentIF,
-  ManufacturedHomeSearchResultIF,
-  SearchResponseIF,
-  MhrSearchCriteriaIF,
-  MhRegistrationSummaryIF,
+  ErrorDetailIF,
   ErrorIF,
+  ExemptionIF,
+  ManufacturedHomeSearchResultIF,
   MhrDraftApiIF,
-  RegistrationSortIF,
   MhrDraftIF,
+  MhRegistrationSummaryIF,
   MhrManufacturerInfoIF,
-  MhrQsPayloadIF, ExemptionIF, ErrorDetailIF
+  MhrQsPayloadIF,
+  MhrSearchCriteriaIF,
+  RegistrationSortIF,
+  SearchResponseIF,
+  StaffPaymentIF
 } from '@/interfaces'
-import { StaffPaymentOptions, APIMhrTypes, ErrorCategories, ErrorCodes } from '@/enums'
+import { APIMhrTypes, ErrorCategories, ErrorCodes, ErrorRootCauses, StaffPaymentOptions } from '@/enums'
 import { useSearch } from '@/composables/useSearch'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { addTimestampToDate } from '@/utils'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { AxiosError } from 'axios'
+
 const { mapMhrSearchType } = useSearch()
 
 // Create default request base URL and headers.
@@ -421,7 +424,9 @@ export async function submitMhrTransfer (payloadData, mhrNumber, staffPayment) {
   } catch (error: any) {
     return {
       error: {
-        category: ErrorCategories.REGISTRATION_TRANSFER,
+        category: error?.response?.data?.rootCause.includes(ErrorRootCauses.OUT_OF_DATE_DRAFT)
+          ? ErrorCategories.TRANSFER_DRAFT_STALE
+          : ErrorCategories.REGISTRATION_TRANSFER,
         statusCode: error?.response?.status || StatusCodes.NOT_FOUND,
         msg: error?.response?.data?.errorMesage || 'Unknown Error',
         detail: error?.response?.data?.rootCause

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -424,8 +424,8 @@ export async function submitMhrTransfer (payloadData, mhrNumber, staffPayment) {
   } catch (error: any) {
     return {
       error: {
-        category: error?.response?.data?.rootCause.includes(ErrorRootCauses.OUT_OF_DATE_DRAFT)
-          ? ErrorCategories.TRANSFER_DRAFT_STALE
+        category: new RegExp(ErrorRootCauses.OUT_OF_DATE_OWNERS).test(error?.response?.data?.rootCause)
+          ? ErrorCategories.TRANSFER_OUT_OF_DATE_OWNERS
           : ErrorCategories.REGISTRATION_TRANSFER,
         statusCode: error?.response?.status || StatusCodes.NOT_FOUND,
         msg: error?.response?.data?.errorMesage || 'Unknown Error',

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -18,39 +18,39 @@
       :closeAction="true"
       :setOptions="cancelOptions"
       :setDisplay="showCancelDialog"
-      @proceed="handleDialogResp($event)"
+      @proceed="handleDialogResp"
     />
 
     <BaseDialog
       :setOptions="cancelOwnerChangeConfirm"
       :setDisplay="showCancelChangeDialog"
-      @proceed="handleCancelDialogResp($event)"
+      @proceed="handleCancelDialogResp"
     />
 
     <BaseDialog
       :closeAction="true"
       :setOptions="incompleteRegistrationDialog"
       :setDisplay="showIncompleteRegistrationDialog"
-      @proceed="handleIncompleteRegistrationsResp($event)"
+      @proceed="handleIncompleteRegistrationsResp"
     />
 
     <BaseDialog
       :setOptions="transferRequiredDialogOptions"
       :setDisplay="showStartTransferRequiredDialog"
       reverseActionButtons
-      @proceed="handleStartTransferRequiredDialogResp($event)"
+      @proceed="handleStartTransferRequiredDialogResp"
     />
 
     <BaseDialog
       :setOptions="cancelTransportPermitDialog"
       :setDisplay="showCancelTransportPermitDialog"
-      @proceed="handleCancelTransportPermitDialogResp($event)"
+      @proceed="handleCancelTransportPermitDialogResp"
     />
 
     <BaseDialog
-      :setOptions="null"
-      :setDisplay="null"
-      @proceed="handleDialogResp($event)"
+      :setOptions="outOfDateOwnersDialogOptions(getMhrInformation.mhrNumber)"
+      :setDisplay="showOutOfDateTransferDialog"
+      @proceed="handleOutOfDateDialogResp"
     />
 
     <div class="pt-0 pb-5">
@@ -308,7 +308,7 @@
                       :staffPaymentData="staffPayment"
                       :invalidSection="validateStaffPayment"
                       :validate="validate"
-                      @update:staff-payment-data="onStaffPaymentDataUpdate($event)"
+                      @update:staff-payment-data="onStaffPaymentDataUpdate"
                       @valid="setValidation('isStaffPaymentValid', $event)"
                     />
                   </v-card>
@@ -405,14 +405,14 @@
                         hintText: 'Enter the 8-digit Document ID number'
                       }"
                       :validate="validate"
-                      @setStoreProperty="handleDocumentIdUpdate($event)"
+                      @setStoreProperty="handleDocumentIdUpdate"
                       @isValid="setValidation('isDocumentIdValid', $event)"
                     />
                     <TransferType
                       :validate="validate"
                       :disableSelect="isFrozenMhrDueToAffidavit && !isRoleStaffReg"
-                      @emitType="handleTransferTypeChange($event)"
-                      @emitDeclaredValue="handleDeclaredValueChange($event)"
+                      @emitType="handleTransferTypeChange"
+                      @emitDeclaredValue="handleDeclaredValueChange"
                       @emitValid="setValidation('isValidTransferType', $event)"
                     />
                   </div>
@@ -507,7 +507,8 @@ import {
   MhApiStatusTypes,
   RouteNames,
   UIMHRSearchTypes,
-  LocationChangeTypes, ErrorCategories
+  LocationChangeTypes,
+  ErrorCategories
 } from '@/enums'
 import {
   useAuth,
@@ -533,7 +534,8 @@ import {
   transferRequiredDialog,
   unsavedChangesDialog,
   cancelTransportPermitDialog,
-  changeTransportPermitLocationTypeDialog
+  changeTransportPermitLocationTypeDialog,
+  outOfDateOwnersDialogOptions
 } from '@/resources/dialogOptions'
 import AccountInfo from '@/components/common/AccountInfo.vue'
 import MhrTransportPermit from '@/views/mhrInformation/MhrTransportPermit.vue'
@@ -554,6 +556,7 @@ import {
   getMHRegistrationSummary,
   mhrSearch,
   pacificDate,
+  scrollToTop,
   submitMhrTransfer,
   updateMhrDraft
 } from '@/utils'
@@ -618,7 +621,8 @@ export default defineComponent({
       setEmptyMhrTransfer,
       setStaffPayment,
       setEmptyMhrTransportPermit,
-      setMhrTransportPermit
+      setMhrTransportPermit,
+      setMhrInformationDraftId
     } = useStore()
     const {
       // Getters
@@ -716,6 +720,7 @@ export default defineComponent({
       showIncompleteRegistrationDialog: false,
       showStartTransferRequiredDialog: false,
       showCancelTransportPermitDialog: false,
+      showOutOfDateTransferDialog: false,
       isTransportPermitDisabled: computed((): boolean =>
         localState.showTransferType ||
         isExemptMhr.value ||
@@ -864,9 +869,10 @@ export default defineComponent({
     })
 
     const emitError = (error: ErrorIF): void => {
-      // Intercept and handle Stale Draft Error
-      if(error.category === ErrorCategories.TRANSFER_DRAFT_STALE) {
-
+      // Intercept and handle out of date error
+      if(error.category === ErrorCategories.TRANSFER_OUT_OF_DATE_OWNERS) {
+        localState.showOutOfDateTransferDialog = true
+        return
       }
       context.emit('error', error)
     }
@@ -1192,6 +1198,17 @@ export default defineComponent({
       }
     }
 
+    const handleOutOfDateDialogResp = async (proceed: boolean) => {
+      if (proceed) {
+        await resetMhrInformation()
+        setMhrInformationDraftId('')
+        localState.isReviewMode = false
+        localState.showTransferType = false
+        scrollToTop()
+      }
+      localState.showOutOfDateTransferDialog = false
+    }
+
     const handleDocumentIdUpdate = (documentId: string) => {
       setMhrTransferDocumentId(documentId)
     }
@@ -1273,6 +1290,7 @@ export default defineComponent({
       toggleTypeSelector,
       onStaffPaymentDataUpdate,
       handleCancelDialogResp,
+      handleOutOfDateDialogResp,
       handleIncompleteRegistrationsResp,
       handleStartTransferRequiredDialogResp,
       cancelOwnerChangeConfirm,
@@ -1290,6 +1308,7 @@ export default defineComponent({
       getMhrInfoValidation,
       isValidTransfer,
       getLienInfo,
+      outOfDateOwnersDialogOptions,
 
       // transport permit
       isValidTransportPermit,
@@ -1300,7 +1319,6 @@ export default defineComponent({
       handleCancelTransportPermitDialogResp,
       cancelTransportPermitDialog,
       changeTransportPermitLocationTypeDialog,
-
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -47,6 +47,12 @@
       @proceed="handleCancelTransportPermitDialogResp($event)"
     />
 
+    <BaseDialog
+      :setOptions="null"
+      :setDisplay="null"
+      @proceed="handleDialogResp($event)"
+    />
+
     <div class="pt-0 pb-5">
       <div class="container pa-0 pt-4">
         <v-row noGutters>
@@ -501,7 +507,7 @@ import {
   MhApiStatusTypes,
   RouteNames,
   UIMHRSearchTypes,
-  LocationChangeTypes
+  LocationChangeTypes, ErrorCategories
 } from '@/enums'
 import {
   useAuth,
@@ -858,6 +864,10 @@ export default defineComponent({
     })
 
     const emitError = (error: ErrorIF): void => {
+      // Intercept and handle Stale Draft Error
+      if(error.category === ErrorCategories.TRANSFER_DRAFT_STALE) {
+
+      }
       context.emit('error', error)
     }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15846

*Description of changes:*
* Unable to save Transfer due to out of date Home Owners Information handling
* Dialog with MHR Number and functionality to reset to baseline MHR (Also clears draft in the event on of the users racing was on a draft)

*Note:*
- It's a very unlikely scenario, even if two users open the same registration at the same time, anytime a transfer type is selected the data is fetched and up to date. Requires two users to both have selected a transfer type at the same time and proceed from there but alas, the ticket was made.
- Drafts are also handled at the entry point, so that will probably be like 99% of scenarios. 


![Screenshot 2024-02-02 at 7 42 06 AM](https://github.com/bcgov/ppr/assets/53542131/781f0a17-7928-47ca-a22a-535c23e2921c)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
