### PR TITLE
Get current MH info conditionally add new property exemptDateTime.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -885,6 +885,8 @@ def get_new_registration_json(registration):
         reg_json = legacy_reg_utils.update_location_json(registration, reg_json)
         reg_json = legacy_reg_utils.update_description_json(registration, reg_json)
         reg_json = legacy_reg_utils.set_own_land(registration.manuhome, reg_json)
+        if reg_json.get('status') == MhrRegistrationStatusTypes.EXEMPT:
+            reg_json = legacy_reg_utils.set_exempt_timestamp(registration.manuhome, reg_json)
     if reg_json.get('notes') and registration.staff:
         for note in reg_json.get('notes'):
             note_doc_type: str = note.get('documentType')

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -391,7 +391,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
     def find_summary_by_mhr_number(cls, account_id: str, mhr_number: str, staff: bool = False):
         """Return the MHR registration summary information matching the MH registration number."""
         formatted_mhr = model_utils.format_mhr_number(mhr_number)
-        current_app.logger.debug(f'Account_id={account_id}, mhr_number={formatted_mhr}')
+        current_app.logger.debug(f'Account_id={account_id}, mhr_number={formatted_mhr}, staff={staff}')
         if model_utils.is_legacy():
             return legacy_utils.find_summary_by_mhr_number(account_id, formatted_mhr, staff)
         return reg_utils.find_summary_by_mhr_number(account_id, formatted_mhr, staff)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19705

*Description of changes:*
- If the home is in an exempt state, include exemptDateTime in the GET /mhr/api/v1/registrations/{mhr_number} response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
