### PR TITLE
SBC Staff - Transport Permit Access

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.36",
+      "version": "3.0.37",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -1079,15 +1079,18 @@ export default defineComponent({
 
         localState.myRegDataAdding = false
 
-        // If added reg is a Manufactured Home Registration...
-        if (val.addedRegSummary?.registrationType === APIMhrTypes.MANUFACTURED_HOME_REGISTRATION) {
-          // check if success registration dialog for Manufacturers is permanently hidden (via user settings)
-          localState.manufacturerRegSuccessDialogDisplay =
-            !localState.dialogPermanentlyHidden && !isRoleStaffReg.value && !localState.hideSuccessDialog && props.isMhr
-        }
-
         // trigger snackbar
         context.emit('snackBarMsg', 'Registration was successfully added to your table.')
+
+        // Allow scroll-to effect before prompting Manufacturer registration dialog
+        setTimeout(() => {
+          // If added reg is a Manufactured Home Registration...
+          if (val.addedRegSummary?.registrationType === APIMhrTypes.MANUFACTURED_HOME_REGISTRATION) {
+            // check if success registration dialog for Manufacturers is permanently hidden (via user settings)
+            localState.manufacturerRegSuccessDialogDisplay = !localState.dialogPermanentlyHidden &&
+              !isRoleStaffReg.value && !localState.hideSuccessDialog && props.isMhr
+          }
+        }, 2000)
 
         // set to empty strings after 6 seconds
         setTimeout(() => {

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -745,8 +745,8 @@ export default defineComponent({
         return props.setItem
       }),
       enableOpenEdit: computed(() => {
-        return (isRoleQualifiedSupplier.value || isRoleStaffReg.value || isRoleStaff.value) &&
-          !isRoleStaffSbc.value && !isRoleStaffBcol.value
+        return (isRoleQualifiedSupplier.value || isRoleStaffReg.value || isRoleStaff.value || isRoleStaffSbc.value) &&
+          !isRoleStaffBcol.value
       }),
       hasLienForQS: computed(() => {
         return isRoleQualifiedSupplier.value &&

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -55,7 +55,7 @@ export const useMhrInformation = () => {
     setMhrTransferOwnLand,
     setMhrTransferAttentionReference,
     setMhrTransferConsideration,
-    setMhrTransferSubmittingParty,
+    setMhrAccountSubmittingParty,
     setMhrInformationPermitData
   } = useStore()
   const {
@@ -189,7 +189,7 @@ export const useMhrInformation = () => {
   const parseSubmittingPartyInfo = (accountInfo: AccountInfoIF): void => {
     const submittingParty = parseAccountToSubmittingParty(accountInfo)
 
-    setMhrTransferSubmittingParty(submittingParty)
+    setMhrAccountSubmittingParty(submittingParty)
   }
 
   const parseMhrLocationInfo = async (locationData: MhrRegistrationHomeLocationIF): Promise<void> => {
@@ -304,7 +304,7 @@ export const useMhrInformation = () => {
     setMhrTransferHomeOwnerGroups([...draft.addOwnerGroups])
 
     // Set submitting party
-    setMhrTransferSubmittingParty(draft.submittingParty)
+    setMhrAccountSubmittingParty(draft.submittingParty)
 
     // Set Attention
     setMhrTransferAttentionReference(draft.attentionReference)

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -69,7 +69,7 @@ export const useMhrInformation = () => {
     getMhrTransferConsideration,
     getMhrTransferDate,
     getMhrTransferOwnLand,
-    getMhrTransferSubmittingParty,
+    getMhrAccountSubmittingParty,
     getMhrTransferAttentionReference,
     getMhrTransferHomeOwnerGroups,
     getMhrTransferCurrentHomeOwnerGroups,
@@ -424,19 +424,19 @@ export const useMhrInformation = () => {
       }),
       registrationType: getMhrTransferType.value?.transferType,
       submittingParty: {
-        businessName: getMhrTransferSubmittingParty.value.businessName,
-        personName: getMhrTransferSubmittingParty.value.personName,
-        address: getMhrTransferSubmittingParty.value.address,
-        ...(getMhrTransferSubmittingParty.value.emailAddress && {
-          emailAddress: getMhrTransferSubmittingParty.value.emailAddress
+        businessName: getMhrAccountSubmittingParty.value.businessName,
+        personName: getMhrAccountSubmittingParty.value.personName,
+        address: getMhrAccountSubmittingParty.value.address,
+        ...(getMhrAccountSubmittingParty.value.emailAddress && {
+          emailAddress: getMhrAccountSubmittingParty.value.emailAddress
         }),
-        ...(getMhrTransferSubmittingParty.value.phoneNumber && {
-          phoneNumber: getMhrTransferSubmittingParty.value.phoneNumber?.replace(/[^A-Z0-9]/ig, '')
+        ...(getMhrAccountSubmittingParty.value.phoneNumber && {
+          phoneNumber: getMhrAccountSubmittingParty.value.phoneNumber?.replace(/[^A-Z0-9]/ig, '')
         }),
-        ...(getMhrTransferSubmittingParty.value.phoneExtension && {
-          phoneExtension: getMhrTransferSubmittingParty.value.phoneExtension
+        ...(getMhrAccountSubmittingParty.value.phoneExtension && {
+          phoneExtension: getMhrAccountSubmittingParty.value.phoneExtension
         }),
-        ...(isDraft && getMhrTransferSubmittingParty.value.hasUsedPartyLookup && {
+        ...(isDraft && getMhrAccountSubmittingParty.value.hasUsedPartyLookup && {
           hasUsedPartyLookup: true
         })
       },

--- a/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
@@ -12,12 +12,15 @@ import { cloneDeep } from 'lodash'
 const isChangeLocationActive: Ref<boolean> = ref(false)
 
 export const useTransportPermits = () => {
-  const { isRoleStaffReg,
+  const {
+    isRoleStaffSbc,
+    isRoleStaffReg,
     isRoleQualifiedSupplier,
     getLienRegistrationType,
     getMhrUnitNotes,
     getMhrTransportPermit,
-    getMhrInformation
+    getMhrInformation,
+    getMhrAccountSubmittingParty
   } = storeToRefs(useStore())
 
   const {
@@ -34,7 +37,8 @@ export const useTransportPermits = () => {
 
   /** Returns true when staff or qualified supplier and the feature flag is enabled **/
   const isChangeLocationEnabled: ComputedRef<boolean> = computed((): boolean => {
-    return (isRoleStaffReg.value || isRoleQualifiedSupplier.value) && getFeatureFlag('mhr-transport-permit-enabled')
+    return (isRoleStaffReg.value || isRoleQualifiedSupplier.value || isRoleStaffSbc.value) &&
+      getFeatureFlag('mhr-transport-permit-enabled')
   })
 
   /** Toggle location change flow **/
@@ -89,7 +93,12 @@ export const useTransportPermits = () => {
   }
 
   const buildPayload = (): MhrTransportPermitIF => {
-    const payloadData: MhrTransportPermitIF = cloneDeep(getMhrTransportPermit.value)
+    const payloadData: MhrTransportPermitIF = cloneDeep({
+      ... getMhrTransportPermit.value,
+      ...(!isRoleStaffReg.value && {
+        submittingParty: { ...getMhrAccountSubmittingParty.value }
+      })
+    })
     deleteEmptyProperties(payloadData)
 
     // only regular Transport Permit has Tax Certificate date

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -1282,11 +1282,11 @@ export const useStore = defineStore('assetsStore', () => {
     state.value.mhrTransfer.ownLand = isOwnLand
   }
 
-  function setMhrTransferSubmittingPartyKey ({ key, value }) {
+  function setMhrAccountSubmittingParty ({ key, value }) {
     state.value.mhrTransfer.submittingParty[key] = value
   }
 
-  function setMhrTransferSubmittingParty (submittingPartyInfo: SubmittingPartyIF) {
+  function setMhrAccountSubmittingParty (submittingPartyInfo: SubmittingPartyIF) {
     state.value.mhrTransfer.submittingParty = submittingPartyInfo
   }
 
@@ -1648,8 +1648,8 @@ export const useStore = defineStore('assetsStore', () => {
     setMhrTransferConsideration,
     setMhrTransferDate,
     setMhrTransferOwnLand,
-    setMhrTransferSubmittingPartyKey,
-    setMhrTransferSubmittingParty,
+    setMhrAccountSubmittingParty,
+    setMhrAccountSubmittingParty,
     setMhrTransferAttentionReference,
     setMhrTransferAffidavitCompleted,
 

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -718,7 +718,7 @@ export const useStore = defineStore('assetsStore', () => {
   const getMhrTransferOwnLand = computed(() => {
     return state.value.mhrTransfer.ownLand
   })
-  const getMhrTransferSubmittingParty = computed(() => {
+  const getMhrAccountSubmittingParty = computed(() => {
     return state.value.mhrTransfer.submittingParty
   })
   const getMhrTransferAttentionReference = computed(() => {
@@ -1524,7 +1524,7 @@ export const useStore = defineStore('assetsStore', () => {
     getMhrTransferConsideration,
     getMhrTransferDate,
     getMhrTransferOwnLand,
-    getMhrTransferSubmittingParty,
+    getMhrAccountSubmittingParty,
     getMhrTransferAttentionReference,
     getMhrTransferAffidavitCompleted,
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -217,7 +217,7 @@
                     :validate="validateSubmittingParty"
                     @setStoreProperty="isChangeLocationActive
                       ? setMhrTransportPermit({ key: 'submittingParty', value: $event })
-                      : setMhrTransferSubmittingParty($event)"
+                      : setMhrAccountSubmittingParty($event)"
                     @isValid="setValidation('isSubmittingPartyValid', $event)"
                   />
                 </section>
@@ -608,7 +608,7 @@ export default defineComponent({
     const {
       // Actions
       setMhrStatusType,
-      setMhrTransferSubmittingParty,
+      setMhrAccountSubmittingParty,
       setMhrTransferAttentionReference,
       setUnsavedChanges,
       setRegTableNewItem,
@@ -1282,7 +1282,7 @@ export default defineComponent({
       isTransferDueToSaleOrGift,
       isTransferToExecutorProbateWill,
       setMhrTransferAttentionReference,
-      setMhrTransferSubmittingParty,
+      setMhrAccountSubmittingParty,
       setLocationChangeType,
       handleDocumentIdUpdate,
       handleTransferTypeChange,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -211,7 +211,7 @@
                   <ContactInformation
                     :contactInfo="isChangeLocationActive
                       ? getMhrTransportPermit.submittingParty
-                      : getMhrTransferSubmittingParty"
+                      : getMhrAccountSubmittingParty"
                     :sectionNumber="1"
                     :content="submittingPartyChangeContent"
                     :validate="validateSubmittingParty"
@@ -634,6 +634,7 @@ export default defineComponent({
       hasUnsavedChanges,
       hasLien,
       getLienRegistrationType,
+      isRoleStaffSbc,
       isRoleStaffReg,
       isRoleQualifiedSupplier,
       getMhrRegistrationLocation,
@@ -643,7 +644,7 @@ export default defineComponent({
       getMhrInfoValidation,
       getMhrTransportPermit,
       getMhrTransferAttentionReference,
-      getMhrTransferSubmittingParty
+      getMhrAccountSubmittingParty
     } = storeToRefs(useStore())
     const {
       isFrozenMhr,
@@ -790,7 +791,7 @@ export default defineComponent({
         return localState.isReviewMode ? 'Register Changes and Pay' : 'Review and Confirm'
       }),
       enableHomeOwnerChanges: computed((): boolean => {
-        return getFeatureFlag('mhr-transfer-enabled')
+        return !isRoleStaffSbc.value && getFeatureFlag('mhr-transfer-enabled')
       }),
       isDraft: computed((): boolean => {
         return getMhrInformation.value.draftNumber
@@ -857,7 +858,7 @@ export default defineComponent({
         await setUnsavedChanges(false)
       }
 
-      if (isRoleQualifiedSupplier.value && !isRoleStaffReg.value) {
+      if ((isRoleQualifiedSupplier.value || isRoleStaffSbc.value) && !isRoleStaffReg.value) {
         // Get Account Info from Auth to be used in Submitting Party section in Review screen
         localState.accountInfo = await getAccountInfoFromAuth() as AccountInfoIF
         parseSubmittingPartyInfo(localState.accountInfo)
@@ -1253,6 +1254,7 @@ export default defineComponent({
     })
 
     return {
+      isRoleStaffSbc,
       isRoleStaffReg,
       isFrozenMhr,
       isFrozenMhrDueToAffidavit,
@@ -1297,7 +1299,7 @@ export default defineComponent({
       incompleteRegistrationDialog,
       transferRequiredDialog,
       getMhrUnitNotes,
-      getMhrTransferSubmittingParty,
+      getMhrAccountSubmittingParty,
       submittingPartyChangeContent,
       isChangeLocationActive,
       isChangeLocationEnabled,

--- a/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
@@ -116,7 +116,7 @@
       </p>
 
       <p
-        v-if="!isRoleStaffReg"
+        v-if="!isRoleStaffReg && !isRoleStaffSbc"
         class="mt-4"
       >
         <span class="font-weight-bold">Note:</span> If the home has already been moved without a permit, a change of
@@ -250,7 +250,7 @@ const emit = defineEmits(['updateLocationType', 'cancelTransportPermitChanges'])
 
 const { setMhrTransportPermit } = useStore()
 
-const { isRoleStaffReg, getMhrInfoValidation, getMhrTransportPermit } = storeToRefs(useStore())
+const { isRoleStaffReg, isRoleStaffSbc, getMhrInfoValidation, getMhrTransportPermit } = storeToRefs(useStore())
 const { hasActiveTransportPermit, isChangeLocationActive, setLocationChange } = useTransportPermits()
 
 const {


### PR DESCRIPTION
*Issue #:*

*Description of changes:*

/bcgov/entity#19252: 
- Grants SBC STAFF access to OPEN an MHR and make Transport Permit Transactions
- Minor refactors to provide Transport Permit Flow to a non BCREG Staff user, will also be applicable work to help support Qualified Suppliers
- Renamed Mhr Transfer Submitting Party getter/setter to Mhr Account Submitting Party as it's no longer exclusive to Transfer but for general mhr info transactions. 

/bcgov/entity#18666:
- Minor refactors to the scroll-to effect conflicting with the Manufacturers Registration complete dialog. 

/bcgov/entity#17211:
- Verified correct dialog interactions when closing modal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
