### PR TITLE
Do not set status to FROZEN for active permits.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -255,8 +255,7 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
        (SELECT n.docutype
           FROM mhomnote n
          WHERE n.manhomid = mh.manhomid AND n.status = 'A'
-           AND (n.docutype IN ('TAXN', 'NCON', 'REST') OR
-                (n.docutype IN ('103 ', '103E') AND n.expiryda IS NOT NULL AND n.expiryda > current date))
+           AND (n.docutype IN ('TAXN', 'NCON', 'REST'))
          FETCH FIRST 1 ROWS ONLY) AS frozen_doc_type,
         CASE
           WHEN trim(l.mhdealer) != '' THEN 'MANUFACTURER'

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -822,10 +822,4 @@ def update_reg_status(reg_json: dict, current: bool) -> dict:
             reg_json['status'] = STATUS_FROZEN
             reg_json['frozenDocumentType'] = note.get('documentType')
             break
-        elif note.get('documentType') in (MhrDocumentTypes.REG_103, MhrDocumentTypes.REG_103E, '103', '103E') and \
-                (not note.get('status') or note.get('status') == MhrNoteStatusTypes.ACTIVE):
-            if note.get('expiryDateTime') and not date_elapsed(note.get('expiryDateTime')):
-                reg_json['status'] = STATUS_FROZEN
-                reg_json['frozenDocumentType'] = note.get('documentType')
-                break
     return reg_json

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -282,7 +282,6 @@ ADD_OG_VALID = [
     }
 ]
 FROZEN_LIST = [
-    {'mhrNumber': '000926', 'documentType': 'REG_103'},
     {'mhrNumber': '000915', 'documentType': 'REST'}
 ]
 # testdata pattern is ({account_id}, {mhr_num}, {exists}, {reg_description}, {in_list})
@@ -413,8 +412,8 @@ TEST_DATA_STATUS = [
     ('000915', 'PS12345', 'FROZEN', False, 'REST'),
     ('000918', 'PS12345', 'FROZEN', True, 'NCON'),  # 040289
     ('000918', 'PS12345', 'FROZEN', False, 'NCON'),
-    ('000926', 'PS12345', 'FROZEN', True, 'REG_103'),  # 102605
-    ('000926', 'PS12345', 'FROZEN', False, 'REG_103')
+    ('000926', 'PS12345', 'ACTIVE', True, 'REG_103'),  # 102605
+    ('000926', 'PS12345', 'ACTIVE', False, 'REG_103')
 ]
 # testdata pattern is ({mhr_num}, {staff}, {current}, {has_notes}, {account_id}, {has_caution}, {ncan_doc_id})
 TEST_MHR_NUM_DATA_NOTE = [
@@ -525,7 +524,7 @@ def test_find_account_registrations(session, account_id, has_results):
                     if reg.get('registrationType') == MhrRegistrationTypes.REG_NOTE and desc.find('CAUTION') > 0:
                         assert reg.get('expireDays')
                     elif reg.get('registrationType') == MhrRegistrationTypes.PERMIT:
-                        assert reg.get('expireDays')
+                        assert 'expireDays' in reg
     else:
         assert not reg_list
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19768

*Description of changes:*
- Get current MH information do not set status to FROZEN or set the frozenDocumentType when there is an active transport permit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
