### PR TITLE
StaffPayment and HomeOwners Styling/UXA

### DIFF
--- a/ppr-ui/src/components/common/StaffPayment.vue
+++ b/ppr-ui/src/components/common/StaffPayment.vue
@@ -61,6 +61,7 @@
             <v-text-field
               id="bcol-account-number-textfield"
               v-model="staffPaymentData.bcolAccountNumber"
+              class="pb-2"
               variant="filled"
               color="primary"
               label="BC Online Account Number"
@@ -72,6 +73,7 @@
             <v-text-field
               id="dat-number-textfield"
               v-model="staffPaymentData.datNumber"
+              class="pb-2"
               variant="filled"
               color="primary"
               label="DAT Number"
@@ -83,6 +85,7 @@
             <v-text-field
               id="folio-number-textfield"
               v-model="staffPaymentData.folioNumber"
+              class="pb-2"
               variant="filled"
               color="primary"
               label="Folio Number (Optional)"
@@ -139,10 +142,10 @@ export default defineComponent({
       default: () => {
         return {
           option: StaffPaymentOptions.NONE,
-          routingSlipNumber: null,
-          bcolAccountNumber: null,
-          datNumber: null,
-          folioNumber: null,
+          routingSlipNumber: '',
+          bcolAccountNumber: '',
+          datNumber: '',
+          folioNumber: '',
           isPriority: false
         }
       }

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -148,6 +148,7 @@
                 </p>
 
                 <SimpleHelpToggle
+                  class="pt-1"
                   toggleButtonTitle="Help with Business and Organization Owners"
                   :defaultHideText="false"
                 >
@@ -283,7 +284,7 @@
             </v-tooltip>
           </label>
 
-          <v-row>
+          <v-row class="py-2">
             <v-col class="col">
               <v-tooltip
                 location="right"
@@ -315,7 +316,7 @@
           <label class="generic-label">
             Phone Number
           </label>
-          <v-row>
+          <v-row class="py-2">
             <v-col cols="6">
               <v-text-field
                 id="phone-number"

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -147,7 +147,7 @@
               >
                 <!-- Start of Name -->
                 <td
-                  class="owner-name"
+                  class="owner-name pr-6"
                   :class="[
                     {
                       'no-bottom-border': hideRowBottomBorder(item),


### PR DESCRIPTION
*Issue #:*
*Description of changes:*
 /bcgov/entity#19671
 - Minor padding fixes
 - Corrected default data types to prevent Vuetify validation prompts
 
<img width="978" alt="Screenshot 2024-02-14 at 10 23 51 AM" src="https://github.com/bcgov/ppr/assets/53542131/adb74f96-d08b-471a-b0da-bb05ca54446b">

 
  /bcgov/entity#15982
- Minor UXA listed in this ticket to increase some padding between Name and Address for HomeOwners

<img width="1008" alt="Screenshot 2024-02-14 at 10 23 41 AM" src="https://github.com/bcgov/ppr/assets/53542131/dba55291-1efc-473b-91e3-855004cc5516">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
