### PR TITLE
UI amend permit API add location.permitWithinSamePark

### DIFF
--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.7.1'  # pylint: disable=invalid-name
+__version__ = '1.7.2'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19870

*Description of changes:*
- When an active transport permit exists, add a new boolean location property permitWithinSamePark to support UI transport permits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
