### PR TITLE
Updated Badge Component

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.41",
+  "version": "3.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.41",
+      "version": "3.0.42",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.41",
+  "version": "3.0.42",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -68,7 +68,7 @@ import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
 import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 import SbcSystemBanner from 'sbc-common-components/src/components/SbcSystemBanner.vue'
 import * as Dialogs from '@/components/dialogs'
-import { Breadcrumb } from '@/components/common'
+import { Breadcrumb, UpdatedBadge } from '@/components/common'
 import { Tombstone } from '@/components/tombstone'
 import * as Views from '@/views'
 import {
@@ -104,6 +104,7 @@ import { useAuth, useNavigation } from '@/composables'
 export default defineComponent({
   name: 'App',
   components: {
+    UpdatedBadge,
     SbcHeader,
     SbcFooter,
     Breadcrumb,

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -68,7 +68,7 @@ import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
 import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 import SbcSystemBanner from 'sbc-common-components/src/components/SbcSystemBanner.vue'
 import * as Dialogs from '@/components/dialogs'
-import { Breadcrumb, UpdatedBadge } from '@/components/common'
+import { Breadcrumb } from '@/components/common'
 import { Tombstone } from '@/components/tombstone'
 import * as Views from '@/views'
 import {
@@ -104,7 +104,6 @@ import { useAuth, useNavigation } from '@/composables'
 export default defineComponent({
   name: 'App',
   components: {
-    UpdatedBadge,
     SbcHeader,
     SbcFooter,
     Breadcrumb,

--- a/ppr-ui/src/components/common/UpdatedBadge.vue
+++ b/ppr-ui/src/components/common/UpdatedBadge.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-chip
+    v-if="hasChanges"
+    id="updated-badge-component"
+    xSmall
+    variant="flat"
+    color="primary"
+    :data-test-id="`${action}-badge`"
+  >
+    <b>{{ action }}</b>
+  </v-chip>
+</template>
+<script setup lang="ts">
+import { computed } from 'vue'
+import { BaseDataUnionIF } from '@/interfaces'
+import { deepChangesComparison } from '@/utils'
+
+const props = withDefaults(defineProps<{
+  action?: string,
+  baseline: BaseDataUnionIF,
+  currentState: BaseDataUnionIF
+}>(), {
+  action: 'CORRECTED',
+  baseline: null,
+  currentState: null
+})
+
+/** Is true when there is a difference between the baseline and current state **/
+const hasChanges = computed(() => {
+  return deepChangesComparison(props.baseline, props.currentState)
+})
+</script>

--- a/ppr-ui/src/components/common/index.ts
+++ b/ppr-ui/src/components/common/index.ts
@@ -36,7 +36,5 @@ export { default as FormCard } from './FormCard.vue'
 export { default as OrgNameLookup } from './OrgNameLookup.vue'
 export { default as ReviewCard } from './ReviewCard.vue'
 export { default as LienAlert } from './LienAlert.vue'
+export { default as UpdatedBadge } from './UpdatedBadge.vue'
 export { default as StaffPayment } from './StaffPayment.vue'
-
-// Shared Components from https://github.com/bcgov/bcrs-shared-components/tree/feature-vue3/src/components
-// export { InputFieldDatePicker } from '@bcrs-shared-components/input-field-date-picker'

--- a/ppr-ui/src/interfaces/base-data-union-interface.ts
+++ b/ppr-ui/src/interfaces/base-data-union-interface.ts
@@ -1,0 +1,3 @@
+export interface BaseDataUnionIF {
+  myProperty: object | Array<any> | string | number | boolean
+}

--- a/ppr-ui/src/interfaces/index.ts
+++ b/ppr-ui/src/interfaces/index.ts
@@ -25,6 +25,7 @@ export * from './unit-note-interfaces'
 export * from './mhr-user-access-interfaces'
 export * from './user-access-interfaces'
 export * from './exemption-interfaces'
+export * from './base-data-union-interface'
 
 /** A filing's business object from the API. */
 export interface StaffPaymentIF {

--- a/ppr-ui/src/utils/utilities.ts
+++ b/ppr-ui/src/utils/utilities.ts
@@ -1,3 +1,5 @@
+import { BaseDataUnionIF } from '@/interfaces'
+
 export function isSigningIn (): boolean {
   const path = window.location.pathname
   return path.includes('/login') || path.includes('/signin')
@@ -80,4 +82,32 @@ export const filterDuplicates = (list: Array<any>, filterBy: string) => {
     }
     return false
   })
+}
+
+/**
+ * Deeply compares two values, supporting objects, arrays, and case-insensitive string comparison.
+ *
+ * @param {*} base - The first value to compare.
+ * @param {*} current - The second value to compare.
+ * @returns {boolean} - Returns true if the values are different, false if they are equal.
+ */
+export const deepChangesComparison = (base: BaseDataUnionIF, current: BaseDataUnionIF): boolean => {
+  // Object safety-check
+  const isObject = (value) => typeof value === 'object' && value !== null
+  // String normalization safety-check: Case Insensitive
+  const caseInsensitiveStringCompare = (val1, val2) => {
+    if (typeof val1 === 'string' && typeof val2 === 'string') {
+      return val1.toUpperCase() !== val2.toUpperCase()
+    }
+    return val1 !== val2
+  }
+
+  // Main deep change comparison
+  if (isObject(base) && isObject(current)) {
+    const keys1 = Object.keys(base)
+    const keys2 = Object.keys(current)
+
+    return keys1.length !== keys2.length || keys1.some(key => deepChangesComparison(base[key], current[key]))
+  }
+  return caseInsensitiveStringCompare(base, current)
 }

--- a/ppr-ui/tests/unit/UpdatedBadge.spec.ts
+++ b/ppr-ui/tests/unit/UpdatedBadge.spec.ts
@@ -1,0 +1,142 @@
+import { UpdatedBadge } from '@/components/common'
+import { createComponent } from './utils'
+
+const mockBaseline= [
+  {
+    item1: 1,
+    item2: 'A',
+    item4: false,
+    item3: { item1: 2, item2: 'TEST' },
+    item5: { item1: 2, item2: 'TEST' },
+    item6: [
+      { item1: 2, item2: 'TEST' }
+    ]
+  }
+]
+
+const mockCurrentStateMatch= [
+  {
+    item1: 1,
+    item2: 'A',
+    item4: false,
+    item5: { item1: 2, item2: 'TEST' },
+    item3: { item1: 2, item2: 'test' },
+    item6: [
+      { item1: 2, item2: 'test' }
+    ]
+  }
+]
+
+const mockCurrentStateDeepMismatch= [
+  {
+    item1: 1,
+    item2: 'A',
+    item4: false,
+    item3: { item1: 2, item2: 'TEST' },
+    item5: { item1: 2, item2: 'test' },
+    item6: [
+      { item1: 12, item2: 'TEST' }
+    ]
+  }
+]
+
+const mockCurrentStateDeepMismatchAdditionalProperty= [
+  {
+    item1: 1,
+    item2: 'A',
+    item4: false,
+    item3: { item1: 2, item2: 'TEST' },
+    item5: { item1: 2, item2: 'test' },
+    item6: [
+      { item1: 2, item2: 'TEST', item7: 'another one' }
+    ]
+  }
+]
+
+describe('UpdatedBadge', () => {
+  let wrapper, badge
+
+  it('wont render by default', async () => {
+    wrapper = await createComponent(UpdatedBadge)
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(false)
+  })
+
+  it('renders with the CORRECTED label by default when there is a basic change', async () => {
+    wrapper = await createComponent(UpdatedBadge, { baseline: 'test', currentState: 'testTest' })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('CORRECTED')
+  })
+
+  it('renders with a dynamic label by default when there is a basic change', async () => {
+    wrapper = await createComponent(UpdatedBadge, { action: 'AMEND', baseline: 'test', currentState: 'testTest' })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('AMEND')
+  })
+
+  it('is not case sensitive on string comparisons', async () => {
+    wrapper = await createComponent(UpdatedBadge, { baseline: 'test', currentState: 'TEST' })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(false)
+  })
+
+  it('handles boolean comparisons matches', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: { v1: true }, currentState: { v1: true }
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(false)
+  })
+
+  it('handles boolean comparisons mismatches', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: { v1: true }, currentState: { v1: false }
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('CORRECTED')
+  })
+
+  it('handles number comparisons matches', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: { v1: 123 }, currentState: { v1: 123 }
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(false)
+  })
+
+  it('handles number comparisons mismatches', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: { v1: 123 }, currentState: { v1: 1234 }
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('CORRECTED')
+  })
+
+  it('handles deep comparisons (nested objects and arrays) that match', async () => {
+    wrapper = await createComponent(UpdatedBadge, { baseline: mockBaseline, currentState: mockCurrentStateMatch })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(false)
+  })
+
+  it('handles deep comparisons (nested objects and arrays) that mismatch', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: mockBaseline, currentState: mockCurrentStateDeepMismatch
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('CORRECTED')
+  })
+
+  it('handles deep comparisons (nested objects and arrays) with additional properties', async () => {
+    wrapper = await createComponent(UpdatedBadge, {
+      baseline: mockBaseline, currentState: mockCurrentStateDeepMismatchAdditionalProperty
+    })
+    badge = await wrapper.find('#updated-badge-component')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('CORRECTED')
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19503

*Description of changes:*
* Created small badge component which takes two data sets, compares them and renders when there is differences. 
* Deep comparison function will normalize strings, take numbers, booleans, objects and arrays, including nested objects and arrays (see unit tests).
* Lots of unit tests
* Included screens for example implementation:

(baseline would take the snapshot value, just hardcoded this for the example)
<img width="706" alt="Screenshot 2024-02-16 at 9 29 46 AM" src="https://github.com/bcgov/ppr/assets/53542131/781ee226-a36f-4ef8-89dd-a347d11943d9">
<img width="954" alt="Screenshot 2024-02-16 at 9 29 26 AM" src="https://github.com/bcgov/ppr/assets/53542131/d83060a7-97ad-4035-a8c7-b8299f4345b0">
<img width="916" alt="Screenshot 2024-02-16 at 9 29 20 AM" src="https://github.com/bcgov/ppr/assets/53542131/3bc844aa-83bd-4556-a5a1-0659f8078831">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
