### PR TITLE
UI amend permit API add permitLandStatusConfirmation

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -907,7 +907,7 @@ def get_new_registration_json(registration):
             note = legacy_reg_utils.update_note_json(registration, note)
     elif reg_json.get('notes'):  # Non BC Registries staff minimal information, same subset as search
         reg_json['notes'] = get_non_staff_notes(reg_json)
-    reg_json = legacy_reg_utils.set_permit_json(registration.manuhome, reg_json)
+    reg_json = legacy_reg_utils.set_permit_json(registration, reg_json)
     current_app.logger.debug('Built JSON from DB2 and PostgreSQL')
     return reg_json_utils.set_payment_json(registration, reg_json)
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19870

*Description of changes:*
- When amending a transport permit the UI needs to know the land status confirmation value of the latest transport permit. This value is only available for existing, modernized transport permit registrations. It does not exist in the legacy data model. Conditionally add a new property named "permitLandStatusConfirmation" to the GET /mhr/api/v1/regstrations/{mhr_number}?current=true response.

Note: the API will not return permitLandStatusConfirmation if amending a legacy transport permit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
