### PR TITLE
Fix to preserve data for Transport Permit. Payload cleanup.

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.46",
+      "version": "3.0.47",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -504,7 +504,7 @@ export default defineComponent({
     const localState = reactive({
       // transport permit
       currentPadNumber: homeLocationInfo.pad,
-      newTransportPermitPadNumber: homeLocationInfo.pad,
+      newTransportPermitPadNumber: getMhrTransportPermit.value.newLocation.pad,
       showTaxCertificateExpiryDate: homeLocationInfo.taxCertificate
         && isNotManufacturersLot.value && !isMovingWithinSamePark.value,
 

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -504,7 +504,7 @@ export default defineComponent({
     const localState = reactive({
       // transport permit
       currentPadNumber: homeLocationInfo.pad,
-      newTransportPermitPadNumber: getMhrTransportPermit.value.newLocation.pad,
+      newTransportPermitPadNumber: '',
       showTaxCertificateExpiryDate: homeLocationInfo.taxCertificate
         && isNotManufacturersLot.value && !isMovingWithinSamePark.value,
 
@@ -582,6 +582,12 @@ export default defineComponent({
     watch(() => props.validate, async () => {
       newPadNumberRef.value?.validate()
     })
+
+    // is editing Pad number - get the value from either Permit or Registration
+    watch(() => props.isPadEditable, async () => {
+      localState.newTransportPermitPadNumber =
+        getMhrTransportPermit.value.newLocation.pad || structuredClone(homeLocationInfo.pad)
+    }, { immediate: true })
 
     return {
       homeLocationInfo,

--- a/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
@@ -147,8 +147,6 @@ export const useTransportPermits = () => {
           .toISOString()
           .replace('.000Z', '+00:00')
       }
-      // set empty postal code because it is not captured in the form
-      payloadData.newLocation.address.postalCode = ' '
     }
 
     // api does not support otherType, and it should be set to the locationType

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -20,6 +20,7 @@ import { APIMhrTypes, ErrorCategories, ErrorCodes, ErrorRootCauses, StaffPayment
 import { useSearch } from '@/composables/useSearch'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { addTimestampToDate } from '@/utils'
+import { trim } from 'lodash'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { AxiosError } from 'axios'
 
@@ -716,7 +717,7 @@ export function deleteEmptyProperties (obj) {
       if (Object.keys(obj[key] || {}).length === 0) {
         delete obj[key] // delete empty nested object
       }
-    } else if (obj[key] === null || obj[key] === undefined || obj[key] === '') {
+    } else if (obj[key] === null || obj[key] === undefined || trim(obj[key]) === '') {
       delete obj[key] // delete empty property value
     }
   }


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#18345

*Description of changes:*
- The Pad data is not preserved when going between the Main and Review pages in Transport Permit. This fixes it.
- Cleanup payload to prevent API errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
