### PR TITLE
UXA Feedback for Amend Transport Permit

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.50",
+  "version": "3.0.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.50",
+      "version": "3.0.51",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.50",
+  "version": "3.0.51",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -116,6 +116,12 @@
               >
                 Pad
               </h3>
+              <UpdatedBadge
+                v-if="updatedBadge"
+                :action="updatedBadge.action"
+                :baseline="updatedBadge.baseline"
+                :currentState="updatedBadge.currentState"
+              />
             </v-col>
             <v-col
               cols="9"
@@ -447,10 +453,11 @@ import { useCountriesProvinces } from '@/composables/address/factories'
 import { FormIF, MhrRegistrationHomeLocationIF } from '@/interfaces'
 import { shortPacificDate } from '@/utils/date-helper'
 import { TransportPermitDetails } from '@/components/mhrTransportPermit'
+import { UpdatedBadge } from '@/components/common'
 
 export default defineComponent({
   name: 'HomeLocationReview',
-  components: { TransportPermitDetails },
+  components: { TransportPermitDetails, UpdatedBadge },
   props: {
     hideDefaultHeader: {
       type: Boolean,
@@ -512,6 +519,7 @@ export default defineComponent({
       showTaxCertificateExpiryDate: homeLocationInfo.taxCertificate
         && isNotManufacturersLot.value && !isMovingWithinSamePark.value,
       isNewPadNumberValid: false,
+      updatedBadge: null,
 
       hideLandLease: props.isTransportPermitReview &&
         getMhrTransportPermit.value.locationChangeType === LocationChangeTypes.TRANSPORT_PERMIT_SAME_PARK,
@@ -589,10 +597,17 @@ export default defineComponent({
       newPadNumberRef.value?.validate()
     })
 
-    // is editing Pad number - get the value from either Permit or Registration
+    // if editing Pad number - get the value from either Permit or Registration
     watch(() => props.isPadEditable, async () => {
       localState.newTransportPermitPadNumber =
         getMhrTransportPermit.value.newLocation.pad || structuredClone(homeLocationInfo.pad)
+        if (props.isPadEditable) {
+          localState.updatedBadge = {
+            action: 'AMENDED',
+            baseline: localState.currentPadNumber,
+            currentState: computed(() => localState.newTransportPermitPadNumber)
+          }
+        }
     }, { immediate: true })
 
     return {

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -111,7 +111,11 @@
               cols="3"
               class="pt-1"
             >
-              <h3>Pad</h3>
+              <h3
+                :class="{ 'error-text': isPadEditable && validate && !isNewPadNumberValid }"
+              >
+                Pad
+              </h3>
             </v-col>
             <v-col
               cols="9"
@@ -507,6 +511,7 @@ export default defineComponent({
       newTransportPermitPadNumber: '',
       showTaxCertificateExpiryDate: homeLocationInfo.taxCertificate
         && isNotManufacturersLot.value && !isMovingWithinSamePark.value,
+      isNewPadNumberValid: false,
 
       hideLandLease: props.isTransportPermitReview &&
         getMhrTransportPermit.value.locationChangeType === LocationChangeTypes.TRANSPORT_PERMIT_SAME_PARK,
@@ -576,7 +581,8 @@ export default defineComponent({
     watch(() => localState.newTransportPermitPadNumber, (val) => {
       setMhrTransportPermitNewLocation({ key: 'pad', value: val })
       // new Pad should be different than the current one
-      setValidation('isNewPadNumberValid', val && localState.currentPadNumber !== val)
+      localState.isNewPadNumberValid = val && localState.currentPadNumber !== val
+      setValidation('isNewPadNumberValid', localState.isNewPadNumberValid)
     })
 
     watch(() => props.validate, async () => {

--- a/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
@@ -84,20 +84,20 @@
     >
       <section
         id="transport-permit-home-location-type"
-        class="mt-12"
+        class="mt-10"
       >
-        <h2>1. Location Type</h2>
-        <p class="mt-2 mb-8">
-          {{ isAmendLocationActive ? 'Amend' : 'Enter' }} the new location type of the home.
-        </p>
-
         <div
           v-if="validate && !hasAmendmentChanges"
-          class="text-error"
+          class="text-error mb-7"
           data-test-id="amend-permit-changes-required-msg"
         >
           A change to the Location Type, Civic Address, and/or Land Details is required
         </div>
+
+        <h2>1. Location Type</h2>
+        <p class="mt-2 mb-8">
+          {{ isAmendLocationActive ? 'Amend' : 'Enter' }} the new location type of the home.
+        </p>
 
         <HomeLocationType
           :locationTypeInfo="getMhrTransportPermit.newLocation"

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -239,8 +239,8 @@ export const useMhrInformation = () => {
       permitData: permitRegistrationNumber
     })
 
-    const permitLandStatusConfirmation = mhrSummary?.permitLandStatusConfirmation || null
-    await mhrSummary?.permitLandStatusConfirmation && setMhrInformationPermitData({
+    const permitLandStatusConfirmation = mhrSummary?.permitLandStatusConfirmation ?? null
+    await setMhrInformationPermitData({
       permitKey: 'LandStatusConfirmation',
       permitData: permitLandStatusConfirmation
     })


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#19862

*Description of changes:*
- Fix bug when OwnLand radios are not pre-filled from original Transport Permit
- Update error state for Pad number
- Small styling fixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
