### PR TITLE
Fix Transfer Details parsing

### DIFF
--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,12 +10,12 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': false, // Enables MHR table tab
-  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': false,
-  'mhr-transport-permit-enabled': false,
-  'mhr-amend-transport-permit-enabled': false,
+  'mhr-registration-enabled': true, // Enables MHR table tab
+  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': true,
+  'mhr-transport-permit-enabled': true,
+  'mhr-amend-transport-permit-enabled': true,
   'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,12 +10,12 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': true, // Enables MHR table tab
-  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': true,
-  'mhr-transport-permit-enabled': true,
-  'mhr-amend-transport-permit-enabled': true,
+  'mhr-registration-enabled': false, // Enables MHR table tab
+  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': false,
+  'mhr-transport-permit-enabled': false,
+  'mhr-amend-transport-permit-enabled': false,
   'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -902,7 +902,7 @@ export default defineComponent({
         getMhrInformation.value.frozenDocumentType === UnitNoteDocTypes.TRANSPORT_PERMIT
 
       // Set baseline MHR Information to state
-      // Allow to parse Transfer details when frozen doc type is Transport Permit - bug 19780
+      // Do not parse Transfer details when frozen doc type is Transport Permit - bug 19780
       await parseMhrInformation(isFrozenMhr.value && !isFrozenDueToTransportPermit)
       await setLocationChange(false)
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -902,7 +902,7 @@ export default defineComponent({
         getMhrInformation.value.frozenDocumentType === UnitNoteDocTypes.TRANSPORT_PERMIT
 
       // Set baseline MHR Information to state
-      // Do not parse Transfer details when frozen doc type is Transport Permit - bug 19780
+      // Do not parse Transfer details when frozen doc type is Transport Permit
       await parseMhrInformation(isFrozenMhr.value && !isFrozenDueToTransportPermit)
       await setLocationChange(false)
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -539,7 +539,8 @@ import {
   RouteNames,
   UIMHRSearchTypes,
   LocationChangeTypes,
-  ErrorCategories
+  ErrorCategories,
+  UnitNoteDocTypes
 } from '@/enums'
 import {
   useAuth,
@@ -897,8 +898,12 @@ export default defineComponent({
       setEmptyMhrTransfer(initMhrTransfer())
       setEmptyMhrTransportPermit(initTransportPermit())
 
+      const isFrozenDueToTransportPermit =
+        getMhrInformation.value.frozenDocumentType === UnitNoteDocTypes.TRANSPORT_PERMIT
+
       // Set baseline MHR Information to state
-      await parseMhrInformation(isFrozenMhr.value)
+      // Allow to parse Transfer details when frozen doc type is Transport Permit - bug 19780
+      await parseMhrInformation(isFrozenMhr.value && !isFrozenDueToTransportPermit)
       await setLocationChange(false)
 
       if (getMhrInformation.value.draftNumber) {


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#19780

*Description of changes:*
- Do not parse Transfer details when the frozen doc type is Transport Permit
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
