### PR TITLE
Update logic for getting current home ownLand.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/registration_utils.py
@@ -106,7 +106,8 @@ def set_own_land(manuhome, reg_json: dict) -> dict:
         return reg_json
     own_land: bool = False
     for doc in manuhome.reg_documents:
-        if doc.document_type in ('101', '101 ', 'TRAN', 'DEAT', 'AFFE', 'LETA', 'WILL'):
+        if doc.document_type in ('101', '101 ', 'TRAN', 'DEAT', 'AFFE', 'LETA',
+                                 'WILL', 'STAT', '103 ', '103E', 'REGC', 'PUBA'):
             own_land = (doc.own_land and doc.own_land == 'Y')
     reg_json['ownLand'] = own_land
     return reg_json

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -54,9 +54,17 @@ def set_current_misc_json(registration, reg_json: dict, search: bool = False) ->
     if registration.change_registrations:
         for reg in registration.change_registrations:
             doc = reg.documents[0]
-            if reg.is_transfer():
+            if reg.is_transfer() or reg.documents[0].document_type in (MhrDocumentTypes.REG_103,
+                                                                       MhrDocumentTypes.REG_103E,
+                                                                       MhrDocumentTypes.AMEND_PERMIT,
+                                                                       MhrDocumentTypes.STAT,
+                                                                       MhrDocumentTypes.REGC_CLIENT,
+                                                                       MhrDocumentTypes.REGC_STAFF,
+                                                                       MhrDocumentTypes.REGC,
+                                                                       MhrDocumentTypes.PUBA):
                 own_land = bool(doc.own_land and doc.own_land == 'Y')
-            if doc.declared_value and doc.declared_value > 0 and (dec_ts is None or reg.registration_ts > dec_ts):
+            if reg.is_transfer() and doc.declared_value and doc.declared_value > 0 and \
+                    (dec_ts is None or reg.registration_ts > dec_ts):
                 dec_value = doc.declared_value
                 dec_ts = reg.registration_ts
     reg_json['declaredValue'] = dec_value


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20183

*Description of changes:*
- GET /mhr/api/v1/registrations/{mhr_number}?current=true include transport permits, corrections, amendments, change of location registrations when setting the ownLand property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
