### PR TITLE
MHR API fix legacy individual name parsing

### DIFF
--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -690,12 +690,12 @@ def valid_court_order_date(financing_ts, order_ts: str):
 
 def get_ind_name_from_db2(db2_name: str):
     """Get an individual name json from a DB2 legacy name."""
-    last = db2_name[0:24].strip()
+    last = db2_name[0:25].strip()
     first = db2_name[25:].strip()
     middle = None
     if len(db2_name) > 40:
-        first = db2_name[25:38].strip()
-        middle = db2_name[39:].strip()
+        first = db2_name[25:40].strip()
+        middle = db2_name[40:].strip()
     name = {
         'first': first,
         'last': last

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.0'  # pylint: disable=invalid-name
+__version__ = '1.8.1'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_owner.py
+++ b/mhr_api/tests/unit/models/db2/test_owner.py
@@ -63,6 +63,16 @@ TEST_DATA_PARTY_TYPE_CREATE = [
    (MhrPartyTypes.TRUSTEE, 'Trustee of estate of John Smith, a bankrupt', 'TRUSTEE OF ESTATE OF JOHN SMITH, A BANKRUPT'),
    (MhrPartyTypes.TRUSTEE, 'Trustee of estate of John Smith', 'BANKRUPT TRUSTEE OF ESTATE OF JOHN SMITH')
 ]
+DB2_IND_NAME_MIDDLE = 'DANYLUK                  LEONARD        MICHAEL                       '
+DB2_IND_NAME = 'KING                     MARDI                                        '
+DB2_IND_NAME_MAX = 'M.BELLERIVE-MAXIMILLIAN-JCHARLES-OLIVIERGUILLAUME-JEAN-CLAUDE-VAN-DAMN'
+# testdata pattern is ({last}, {first}, {middle}, {db2_name})
+TEST_DATA_INDIVIDUAL_NAME = [
+    ('DANYLUK', 'LEONARD', 'MICHAEL', DB2_IND_NAME_MIDDLE),
+    ('KING', 'MARDI', None, DB2_IND_NAME),
+    ('M.BELLERIVE-MAXIMILLIAN-J', 'CHARLES-OLIVIER', 'GUILLAUME-JEAN-CLAUDE-VAN-DAMN', DB2_IND_NAME_MAX)
+]
+
 
 @pytest.mark.parametrize('exists,manuhome_id,owner_id,type', TEST_DATA)
 def test_find_by_manuhome_id(session, exists, manuhome_id, owner_id, type):
@@ -178,3 +188,17 @@ def test_owner_json(session):
             'partyType': 'OWNER_IND'
         }
         assert owner.json == test_json
+
+
+@pytest.mark.parametrize('last, first, middle, db2_name', TEST_DATA_INDIVIDUAL_NAME)
+def test_individual_name(session, last, first, middle, db2_name):
+    """Assert that parsing a legacy individual name works as expected."""
+    name = {
+        'last': last,
+        'first': first
+    }
+    if middle:
+        name['middle'] = middle
+    value = model_utils.get_ind_name_from_db2(db2_name)
+    current_app.logger.info(value)
+    assert value == name

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -23,7 +23,7 @@ from mhr_api.models.db2.search_utils import get_search_serial_number_key
 
 DB2_IND_NAME_MIDDLE = 'DANYLUK                  LEONARD        MICHAEL                       '
 DB2_IND_NAME = 'KING                     MARDI                                        '
-
+DB2_IND_NAME_MAX = 'M.BELLERIVE-MAXIMILLIAN-JCHARLES-OLIVIERGUILLAUME-JEAN-CLAUDE-VAN-DAMN'
 # testdata pattern is ({last}, {first}, {middle}, {db2_name})
 TEST_DATA_LEGACY_NAME = [
     ('Danyluk', 'Leonard', 'Michael', DB2_IND_NAME_MIDDLE),
@@ -32,7 +32,8 @@ TEST_DATA_LEGACY_NAME = [
     ('Danyluk', 'Leonard', 'MICHAEL', DB2_IND_NAME_MIDDLE),
     ('King', 'Mardi', None, DB2_IND_NAME),
     ('KING', 'Mardi', None, DB2_IND_NAME),
-    ('King', 'MARDI', None, DB2_IND_NAME)
+    ('King', 'MARDI', None, DB2_IND_NAME),
+    ('M.BELLERIVE-MAXIMILLIAN-J', 'CHARLES-OLIVIER', 'GUILLAUME-JEAN-CLAUDE-VAN-DAMN', DB2_IND_NAME_MAX)
 ]
 # testdata pattern is ({name}, {key_value})
 TEST_DATA_ORG_KEY = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20194

*Description of changes:*
- Fix legacy db2 individual owner name parsing when the first name is the maximum legacy length of 15 characters. 
- Display the name correctly in a modernized search report.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
