### PR TITLE
Cleanup Tax Cert in Transport Permit payload

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.55",
+      "version": "3.0.56",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
@@ -166,6 +166,12 @@ export const useTransportPermits = () => {
       }
     }
 
+    // clean up tax certificate data because it is not showing in UI
+    if (getMhrTransportPermit.value.locationChangeType === LocationChangeTypes.TRANSPORT_PERMIT_SAME_PARK) {
+      payloadData.newLocation.taxCertificate = false
+      delete payloadData.newLocation.taxExpiryDate
+    }
+
     // api does not support otherType, and it should be set to the locationType
     if (payloadData.newLocation.otherType) {
       payloadData.newLocation.locationType = payloadData.newLocation.otherType


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#19800

*Description of changes:*
- Cleanup Tax Cert in Transport Permit payload when moving within same park

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
