### PR TITLE
MHR API update permitStatus, post-migration sort order.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/registration_utils.py
@@ -162,6 +162,10 @@ def set_permit_json(registration, reg_json: dict) -> dict:
                     permit_number = doc.document_reg_id
                     permit_ts = doc.registration_ts
                     permit_doc_id = doc.id
+                if doc.id == note.reg_document_id and doc.document_type == Db2Document.DocumentTypes.CORRECTION \
+                        and permit_ts and doc.registration_ts > permit_ts:
+                    permit_status = FROM_LEGACY_STATUS.get(note.status)
+                    permit_doc_id = doc.id
     if permit_number:
         reg_json['permitRegistrationNumber'] = permit_number
         reg_json['permitDateTime'] = model_utils.format_local_ts(permit_ts)

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -96,7 +96,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
     locations = db.relationship('MhrLocation', order_by='asc(MhrLocation.id)', back_populates='registration')
     documents = db.relationship('MhrDocument', order_by='asc(MhrDocument.id)', back_populates='registration')
     notes = db.relationship('MhrNote', order_by='asc(MhrNote.id)', back_populates='registration')
-    owner_groups = db.relationship('MhrOwnerGroup', order_by='asc(MhrOwnerGroup.id)', back_populates='registration')
+    owner_groups = db.relationship('MhrOwnerGroup', order_by='asc(MhrOwnerGroup.group_id)',
+                                   back_populates='registration')
     descriptions = db.relationship('MhrDescription', order_by='asc(MhrDescription.id)', back_populates='registration')
     sections = db.relationship('MhrSection', order_by='asc(MhrSection.id)', back_populates='registration')
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.1'  # pylint: disable=invalid-name
+__version__ = '1.8.2'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19619

*Description of changes:*
- Include amend transport permits in NOC location email report. 
- Update current permit status to remain active after amending a transport permit.

*Issue #:* /bcgov/entity#20219

*Description of changes:*
- Sort tenants in common owner groups in ascending order by group id.
- Sort notes in descending order by timestamp.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
