### PR TITLE
Common Components Validations + Active Permit MHR Correction Scenario

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.63",
+  "version": "3.0.64",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.63",
+      "version": "3.0.64",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.63",
+  "version": "3.0.64",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/DocumentId.vue
+++ b/ppr-ui/src/components/common/DocumentId.vue
@@ -129,6 +129,7 @@ export default defineComponent({
             isNumber()
           )
           : customRules(
+            required('Enter a Document ID'),
             maxLength(8, true),
             isNumber()
           )

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeCivicAddress.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeCivicAddress.vue
@@ -211,8 +211,9 @@ export default defineComponent({
       // Clear fields when country changes
       addressLocal.value.street = ''
       addressLocal.value.city = ''
-      addressLocal.value.region = ''
+      addressLocal.value.region = null
 
+      !props.validate && addressForm.value?.resetValidation()
       emit('setStoreProperty', { key: 'country', value: country })
     })
 

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
@@ -15,7 +15,7 @@
       >
         <label
           class="generic-label"
-          :class="{'error-text': validate}"
+          :class="{'error-text': validate && !isLocationTypeValid}"
         >Location Type</label>
         <UpdatedBadge
           v-if="updatedBadge"
@@ -223,8 +223,7 @@
 </template>
 
 <script lang="ts">
-
-import { computed, defineComponent, reactive, ref, toRefs, watch } from 'vue'
+import { computed, defineComponent, nextTick, reactive, ref, toRefs, watch } from 'vue'
 import { useStore } from '@/store/store'
 import { HomeLocationTypes } from '@/enums'
 import { PidNumber, UpdatedBadge } from '@/components/common'
@@ -372,6 +371,13 @@ export default defineComponent({
       }
     }
 
+    const resetFormValidations = async () => {
+      if (!props.validate) {
+        lotForm.value?.resetValidation()
+        homeParkForm.value?.resetValidation()
+      }
+    }
+
     /** Apply local models to store when they change. **/
     watch(() => localState.dealerManufacturerLot, () => {
       emit('setStoreProperty', { key: 'dealerName', value: localState.dealerManufacturerLot })
@@ -408,7 +414,8 @@ export default defineComponent({
     })
 
     /** Clear/reset forms when select option changes. **/
-    watch(() => localState.locationTypeOption, () => {
+    watch(() => localState.locationTypeOption, async () => {
+      await resetFormValidations()
       localState.homeParkName = ''
       localState.homeParkPad = ''
       localState.pidNumber = ''
@@ -418,7 +425,9 @@ export default defineComponent({
       setIsManualLocation(false)
       localState.legalDescription = ''
       localState.locationInfo = resetLocationInfoFields(localState.locationInfo)
-      validateForms()
+
+      await nextTick()
+      await validateForms()
     })
     watch(() => localState.otherTypeOption, () => {
       localState.pidNumber = ''
@@ -429,9 +438,6 @@ export default defineComponent({
       setIsManualLocation(false)
       localState.legalDescription = ''
       localState.locationInfo = resetLocationInfoFields(localState.locationInfo)
-    })
-    watch(() => localState.validate, () => {
-      validateForms()
     })
 
     return {

--- a/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeLocation/HomeLocationType.vue
@@ -364,14 +364,14 @@ export default defineComponent({
       localState.legalDescription = pidInfo.legalDescription
     }
 
-    const validateForms = async () => {
+    const validateForms = () => {
       if (props.validate) {
         lotForm.value?.validate()
         homeParkForm.value?.validate()
       }
     }
 
-    const resetFormValidations = async () => {
+    const resetFormValidations = () => {
       if (!props.validate) {
         lotForm.value?.resetValidation()
         homeParkForm.value?.resetValidation()
@@ -410,12 +410,12 @@ export default defineComponent({
       emit('isValid', val)
     })
     watch(() => props.validate, async () => {
-      await validateForms()
+      validateForms()
     })
 
     /** Clear/reset forms when select option changes. **/
     watch(() => localState.locationTypeOption, async () => {
-      await resetFormValidations()
+      resetFormValidations()
       localState.homeParkName = ''
       localState.homeParkPad = ''
       localState.pidNumber = ''
@@ -426,8 +426,9 @@ export default defineComponent({
       localState.legalDescription = ''
       localState.locationInfo = resetLocationInfoFields(localState.locationInfo)
 
+      // Await data propagation before validation
       await nextTick()
-      await validateForms()
+      validateForms()
     })
     watch(() => localState.otherTypeOption, () => {
       localState.pidNumber = ''

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -16,9 +16,13 @@
       <label class="font-weight-bold pl-2">Location of Home</label>
     </header>
 
-    <div :class="{ 'border-error-left': showStepError && !isTransferReview && !isTransportPermitReview }">
+    <div
+      :class="{
+        'border-error-left': showStepError && !isTransferReview && !isTransportPermitReview && !isMhrCorrection
+      }"
+    >
       <section
-        v-if="showStepError && !isTransferReview && !isTransportPermitReview"
+        v-if="showStepError && !isTransferReview && !isTransportPermitReview && !isMhrCorrection"
         :class="{ 'pb-8': !(!!homeLocationInfo.locationType) && !hasAddress }"
         class="mx-6 pt-8"
       >
@@ -39,7 +43,7 @@
         <!-- Transport permit details rendered when there is an active permit -->
         <!-- add top margin to compensate negative bottom margin of the section tag -->
         <TransportPermitDetails
-          v-if="hasActiveTransportPermit && !isChangeLocationActive"
+          v-if="hasActiveTransportPermit && !isChangeLocationActive && !isCorrectionReview"
           class="mt-5"
         />
 
@@ -404,7 +408,7 @@
           </v-col>
         </v-row>
         <template
-          v-if="!isMhrManufacturerRegistration && !isTransferReview && !hideLandLease"
+          v-if="!isMhrManufacturerRegistration && !isTransferReview && !hideLandLease && !isCorrectionReview"
         >
           <v-divider class="mx-8 mt-6" />
 
@@ -473,7 +477,13 @@
 import { computed, defineComponent, onMounted, reactive, ref, toRefs, watch } from 'vue'
 import { HomeLocationTypes, LocationChangeTypes, RouteNames } from '@/enums'
 import { useStore } from '@/store/store'
-import { useInputRules, useMhrInfoValidation, useMhrValidations, useTransportPermits } from '@/composables'
+import {
+  useInputRules,
+  useMhrCorrections,
+  useMhrInfoValidation,
+  useMhrValidations,
+  useTransportPermits
+} from '@/composables'
 import { storeToRefs } from 'pinia'
 import { useCountriesProvinces } from '@/composables/address/factories'
 import { FormIF, MhrRegistrationHomeLocationIF } from '@/interfaces'
@@ -498,6 +508,10 @@ export default defineComponent({
       default: false
     },
     isTransportPermitReview: {
+      type: Boolean,
+      default: false
+    },
+    isCorrectionReview: {
       type: Boolean,
       default: false
     },
@@ -538,6 +552,7 @@ export default defineComponent({
       isNotManufacturersLot,
       isMovingWithinSamePark
     } = useTransportPermits()
+    const { isMhrCorrection } = useMhrCorrections()
 
     const homeLocationInfo: MhrRegistrationHomeLocationIF =
       props.isTransportPermitReview ? getMhrTransportPermit.value.newLocation : getMhrRegistrationLocation.value
@@ -663,6 +678,7 @@ export default defineComponent({
       isNotManufacturersLot,
       isAmendLocationActive,
       isChangeLocationActive,
+      isMhrCorrection,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
@@ -103,7 +103,7 @@
           :key="getMhrTransportPermit.locationChangeType"
           :locationTypeInfo="getMhrTransportPermit.newLocation"
           :class="{ 'border-error-left': state.isLocationTypeInvalid }"
-          :validate="state.isLocationTypeInvalid"
+          :validate="validate"
           :updatedBadge="isAmendLocationActive ? state.amendedBadgeHomeLocationType : null"
           @setStoreProperty="handleLocationTypeUpdate($event)"
           @isValid="setValidation('isHomeLocationTypeValid', $event)"

--- a/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
@@ -26,63 +26,60 @@
                 </v-col>
               </v-row>
             </v-list-item>
-            <v-list-item class="px-0">
+            <v-list-item
+              v-for="(result, i) in autoCompleteResults"
+              :key="i"
+              class="px-0"
+              :class="{ 'disabled-item': isBusinessTypeSPGP(result.legalType) }"
+            >
               <div
-                v-for="(result, i) in autoCompleteResults"
-                :key="i"
+                v-if="isBusinessTypeSPGP(result.legalType)"
+                class="info-tooltip"
               >
-                <div
-                  v-if="isBusinessTypeSPGP(result.legalType)"
-                  class="info-tooltip"
+                <v-tooltip
+                  location="right"
+                  contentClass="start-tooltip py-5"
                 >
-                  <v-tooltip
-                    location="right"
-                    contentClass="right-tooltip py-5"
-                    transition="fade-transition"
-                  >
-                    <template #activator="{ props }">
-                      <v-icon
-                        v-bind="props"
-                        class="mt-n1"
-                        color="primary"
-                      >
-                        mdi-information-outline
-                      </v-icon>
-                    </template>
-                    <p>
-                      Registered owners of a manufactured home cannot be a sole proprietorship, partnership or limited
-                      partnership. The home must be registered in the name of the sole proprietor or partner (person or
-                      business).
-                    </p>
-                  </v-tooltip>
-                </div>
-
-                <v-list-item-subtitle
-                  class="auto-complete-item px-4 py-5"
-                  :disabled="isBusinessTypeSPGP(result.legalType)"
-                  :class="{ disabled: isBusinessTypeSPGP(result.legalType) }"
-                  @mousedown="selectResult(i)"
-                >
-                  <v-row class="auto-complete-row">
-                    <v-col cols="2">
-                      {{ result.identifier }}
-                    </v-col>
-                    <v-col
-                      cols="8"
-                      class="org-name"
+                  <template #activator="{ props }">
+                    <v-icon
+                      v-bind="props"
+                      class="mt-n1"
+                      color="primary"
                     >
-                      {{ result.name }}
-                    </v-col>
-                    <v-col
-                      v-if="!isBusinessTypeSPGP(result.legalType)"
-                      cols="2"
-                      class="selectable"
-                    >
-                      Select
-                    </v-col>
-                  </v-row>
-                </v-list-item-subtitle>
+                      mdi-information-outline
+                    </v-icon>
+                  </template>
+                  <p class="text-white">
+                    Registered owners of a manufactured home cannot be a sole proprietorship, partnership or limited
+                    partnership. The home must be registered in the name of the sole proprietor or partner (person or
+                    business).
+                  </p>
+                </v-tooltip>
               </div>
+
+              <v-list-item-subtitle
+                class="auto-complete-item px-4 py-5"
+                @mousedown="!isBusinessTypeSPGP(result.legalType) && selectResult(i)"
+              >
+                <v-row class="auto-complete-row">
+                  <v-col cols="2">
+                    {{ result.identifier }}
+                  </v-col>
+                  <v-col
+                    cols="8"
+                    class="org-name"
+                  >
+                    {{ result.name }}
+                  </v-col>
+                  <v-col
+                    v-if="!isBusinessTypeSPGP(result.legalType)"
+                    cols="2"
+                    class="selectable"
+                  >
+                    Select
+                  </v-col>
+                </v-row>
+              </v-list-item-subtitle>
             </v-list-item>
           </v-list>
           <div
@@ -231,10 +228,10 @@ export default defineComponent({
 }
 
 strong, p {
-  color: $gray7 !important;
+  color: $gray7;
 }
 
-.auto-complete-sticky-row{
+.auto-complete-sticky-row {
   color: $gray7;
   font-size: 14px;
 }
@@ -261,19 +258,17 @@ strong, p {
     overflow-y: scroll;
   }
 }
-.auto-complete-item:hover {
-  .auto-complete-row {
-    color: $primary-blue !important;
-  }
-  background-color: #f1f3f5 !important;
+.auto-complete-row:hover {
+  cursor: pointer;
+  color: $primary-blue;
 }
 
 .auto-complete-item[aria-selected='true'] {
-  color: $primary-blue !important;
+  color: $primary-blue;
 }
 
 .auto-complete-item:focus {
-  background-color: $gray3 !important;
+  background-color: $gray3;
 }
 
 .info-tooltip {
@@ -290,10 +285,12 @@ strong, p {
   font-size: 14px;
 }
 
-:deep(.auto-complete-item.disabled) {
+.disabled-item {
   opacity: 0.6;
-}
-:deep(.v-list-item--disabled) {
-  opacity: 1;
+  background-color: $gray1;
+  cursor: default;
+  :hover {
+    color: $gray7;
+  }
 }
 </style>

--- a/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
@@ -3,79 +3,104 @@
     id="mhr-home-location"
     class="increment-sections"
   >
-    <section
-      id="mhr-home-location-type-wrapper"
-      class="mt-10"
-    >
-      <h2>Location Type</h2>
-      <p class="mt-2 mb-6">
-        Indicate the type of location for the home.
-      </p>
+    <!-- Correction Template when Active Transport Permit -->
+    <template v-if="isMhrCorrection && hasActiveTransportPermit">
+      <section id="mhr-correction-has-active-permit">
+        <CautionBox
+          class="mt-12"
+          setImportantWord="Note"
+          setMsg="A transport permit has been issued for this home. While the permit is still active, the
+       home’s location on the transport permit can be amended from the Manufactured Home Information page. "
+        />
 
-      <HomeLocationType
-        :locationTypeInfo="getMhrRegistrationLocation"
-        :validate="validateLocationType"
-        :class="{ 'border-error-left': validateLocationType }"
-        @setStoreProperty="setMhrLocation($event)"
-        @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, $event)"
-      />
-    </section>
+        <HomeLocationReview
+          :hideDefaultHeader="true"
+          class="mt-10"
+        />
+      </section>
+    </template>
 
-    <section
-      id="mhr-home-civic-address-wrapper"
-      class="mt-10"
-    >
-      <h2>Civic Address of the Home</h2>
-      <p class="mt-2">
-        Enter the Street Address (Number and Name) and City of the location of the home. Street Address must be entered
-        if there is one.
-      </p>
+    <!-- Standard MHR Home Location Components -->
+    <template v-else>
+      <section
+        id="mhr-home-location-type-wrapper"
+        class="mt-10"
+      >
+        <h2>Location Type</h2>
+        <p class="mt-2 mb-6">
+          Indicate the type of location for the home.
+        </p>
 
-      <HomeCivicAddress
-        :value="getMhrRegistrationLocation.address"
-        :schema="CivicAddressSchema"
-        :validate="validateCivicAddress"
-        :class="{ 'border-error-left': validateCivicAddress }"
-        @setStoreProperty="setCivicAddress('mhrRegistration', $event)"
-        @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, $event)"
-      />
-    </section>
+        <HomeLocationType
+          :locationTypeInfo="getMhrRegistrationLocation"
+          :validate="getValidation(MhrSectVal.REVIEW_CONFIRM_VALID, MhrCompVal.VALIDATE_STEPS)"
+          :class="{ 'border-error-left': validateLocationType }"
+          @setStoreProperty="setMhrLocation($event)"
+          @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, $event)"
+        />
+      </section>
 
-    <section
-      id="mhr-home-land-ownership-wrapper"
-      class="mt-10"
-    >
-      <h2>Land Details</h2>
-      <p class="mt-2">
-        Confirm the land lease or ownership information for the home.
-      </p>
+      <section
+        id="mhr-home-civic-address-wrapper"
+        class="mt-10"
+      >
+        <h2>Civic Address of the Home</h2>
+        <p class="mt-2">
+          Enter the Street Address (Number and Name) and City of the location of the home. Street Address must be
+          entered if there is one.
+        </p>
 
-      <HomeLandOwnership
-        :ownLand="getMhrRegistrationOwnLand"
-        :validate="validateLandDetails"
-        :class="{ 'border-error-left': validateLandDetails }"
-        :content="{
-          description: 'Is the manufactured home located on land that the homeowners own or on ' +
-            'land that they have a registered lease of 3 years or more?'
-        }"
-        @setStoreProperty="setMhrRegistrationOwnLand($event)"
-        @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LAND_DETAILS_VALID, $event)"
-      />
-    </section>
+        <HomeCivicAddress
+          :value="getMhrRegistrationLocation.address"
+          :schema="CivicAddressSchema"
+          :validate="validateCivicAddress"
+          :class="{ 'border-error-left': validateCivicAddress }"
+          @setStoreProperty="setCivicAddress('mhrRegistration', $event)"
+          @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, $event)"
+        />
+      </section>
+
+      <section
+        id="mhr-home-land-ownership-wrapper"
+        class="mt-10"
+      >
+        <h2>Land Details</h2>
+        <p class="mt-2">
+          Confirm the land lease or ownership information for the home.
+        </p>
+
+        <HomeLandOwnership
+          :ownLand="getMhrRegistrationOwnLand"
+          :validate="validateLandDetails"
+          :class="{ 'border-error-left': validateLandDetails }"
+          :content="{
+            description: 'Is the manufactured home located on land that the homeowners own or on ' +
+              'land that they have a registered lease of 3 years or more?'
+          }"
+          @setStoreProperty="setMhrRegistrationOwnLand($event)"
+          @isValid="setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LAND_DETAILS_VALID, $event)"
+        />
+      </section>
+    </template>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
+import { computed, defineComponent, onMounted, reactive, toRefs, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useStore } from '@/store/store'
 import { CivicAddressSchema } from '@/schemas/civic-address'
 import { HomeLocationType, HomeCivicAddress, HomeLandOwnership } from '@/components/mhrRegistration'
 import { useMhrValidations } from '@/composables/mhrRegistration/useMhrValidations'
+import { HomeLocationReview } from '@/components/mhrRegistration'
+import { useMhrCorrections, useTransportPermits } from '@/composables'
+import { CautionBox } from '@/components/common'
 
 export default defineComponent({
   name: 'HomeLocation',
   components: {
+    CautionBox,
+    HomeLocationReview,
     HomeLocationType,
     HomeCivicAddress,
     HomeLandOwnership
@@ -93,10 +118,13 @@ export default defineComponent({
     const {
       MhrCompVal,
       MhrSectVal,
+      getValidation,
       getSectionValidation,
       scrollToInvalid,
       setValidation
     } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
+    const { isMhrCorrection } = useMhrCorrections()
+    const { hasActiveTransportPermit } = useTransportPermits()
 
     const localState = reactive({
       validateLocationType: computed((): boolean => {
@@ -110,6 +138,17 @@ export default defineComponent({
       })
     })
 
+    onMounted(() => {
+      console.log('is Correction', isMhrCorrection.value)
+      console.log('hasActiveTransportPermit.value', hasActiveTransportPermit.value)
+      // Override validation for MhrCorrections: Active Transport Permit disables corrections and components are hidden
+      if (isMhrCorrection.value && hasActiveTransportPermit.value) {
+        setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, true)
+        setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.CIVIC_ADDRESS_VALID, true)
+        setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LAND_DETAILS_VALID, true)
+      }
+    })
+
     const scrollOnValidationUpdates = () => {
       scrollToInvalid(MhrSectVal.LOCATION_VALID, 'mhr-home-location')
     }
@@ -121,6 +160,7 @@ export default defineComponent({
     return {
       MhrCompVal,
       MhrSectVal,
+      getValidation,
       setValidation,
       setMhrLocation,
       setCivicAddress,
@@ -128,6 +168,8 @@ export default defineComponent({
       getMhrRegistrationOwnLand,
       setMhrRegistrationOwnLand,
       CivicAddressSchema,
+      isMhrCorrection,
+      hasActiveTransportPermit,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeLocation.vue
@@ -9,8 +9,8 @@
         <CautionBox
           class="mt-12"
           setImportantWord="Note"
-          setMsg="A transport permit has been issued for this home. While the permit is still active, the
-       home’s location on the transport permit can be amended from the Manufactured Home Information page. "
+          setMsg="A transport permit has been issued for this home. While the permit is still active, the home’s
+            location on the transport permit can be amended from the Manufactured Home Information page."
         />
 
         <HomeLocationReview
@@ -139,8 +139,6 @@ export default defineComponent({
     })
 
     onMounted(() => {
-      console.log('is Correction', isMhrCorrection.value)
-      console.log('hasActiveTransportPermit.value', hasActiveTransportPermit.value)
       // Override validation for MhrCorrections: Active Transport Permit disables corrections and components are hidden
       if (isMhrCorrection.value && hasActiveTransportPermit.value) {
         setValidation(MhrSectVal.LOCATION_VALID, MhrCompVal.LOCATION_TYPE_VALID, true)

--- a/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
@@ -48,7 +48,7 @@
     <HomeOwnersReview />
 
     <!-- Home Location Review -->
-    <HomeLocationReview />
+    <HomeLocationReview :isCorrectionReview="isMhrCorrection" />
 
     <div id="mhr-review-confirm-components">
       <template v-if="isMhrManufacturerRegistration">
@@ -378,6 +378,7 @@ export default defineComponent({
     return {
       setShowGroups,
       isRoleStaffSbc,
+      isMhrCorrection,
       getFolioOrReferenceNumber,
       getMhrAttentionReference,
       isMhrManufacturerRegistration,

--- a/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
+++ b/ppr-ui/src/views/newMhrRegistration/SubmittingParty.vue
@@ -164,6 +164,7 @@ export default defineComponent({
             isNumber()
           )
           : customRules(
+            required('Enter a Document ID'),
             maxLength(8, true),
             isNumber()
           )

--- a/ppr-ui/tests/unit/HomeLocation.spec.ts
+++ b/ppr-ui/tests/unit/HomeLocation.spec.ts
@@ -1,0 +1,50 @@
+import { createComponent } from './utils'
+import { HomeLocation } from '@/views'
+import { MhApiStatusTypes, RouteNames } from '@/enums'
+import { MhrCorrectionStaff } from '@/resources'
+import { useStore } from '@/store/store'
+import { CautionBox } from '@/components/common'
+import HomeLocationReview from '@/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue'
+import { nextTick } from 'vue'
+
+const store = useStore()
+
+describe('HomeLocation', () => {
+  it('renders correctly in default state', async () => {
+    const wrapper = await createComponent(HomeLocation)
+
+    // Assert that the component renders correctly
+    expect(wrapper.exists()).toBe(true)
+
+    // Assert that the standard MHR Home Location Components are rendered
+    expect(wrapper.find('#mhr-home-location-type-wrapper').exists()).toBe(true)
+    expect(wrapper.find('#mhr-home-civic-address-wrapper').exists()).toBe(true)
+    expect(wrapper.find('#mhr-home-land-ownership-wrapper').exists()).toBe(true)
+
+    // Assert that the correction template is not rendered
+    expect(wrapper.find('#mhr-correction-has-active-permit').exists()).toBe(false)
+  })
+
+  it('renders correctly when isMhrCorrection is true and hasActiveTransportPermit is true',async () => {
+    const wrapper = await createComponent(HomeLocation, null, RouteNames.HOME_LOCATION)
+    await store.setRegistrationType(MhrCorrectionStaff)
+    await store.setMhrInformation({
+      permitDateTime: '2024-02-05T08:40:53-08:00',
+      permitExpiryDateTime: '2024-03-06T09:00:00-07:53',
+      permitRegistrationNumber: '00502383',
+      permitStatus: MhApiStatusTypes.ACTIVE
+    })
+    await nextTick()
+
+    // Assert that the component renders correctly
+    expect(wrapper.exists()).toBe(true)
+
+    // Assert that the standard MHR Home Location Components are not rendered
+    expect(wrapper.find('#mhr-home-location-type-wrapper').exists()).toBe(false)
+    expect(wrapper.find('#mhr-home-civic-address-wrapper').exists()).toBe(false)
+    expect(wrapper.find('#mhr-home-land-ownership-wrapper').exists()).toBe(false)
+
+    // Assert that the correction template is rendered HomeLocationReview
+    expect(wrapper.find('#mhr-correction-has-active-permit').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
 /bcgov/entity#19515
- Display HomeLocation information with Active Permit Details on Location step (When active Permit)
- Associated validation and Review Confirm updates

 /bcgov/entity#19536
- Common Component Validation fixes for Civic Address and Home Location Types for both Transport Permits and MHR's
- DocId validation rule update as per ticket to include REQUIRED always (ie not just when the flow validation prompts)
 
 /bcgov/entity#19871
- Minor refactors to Business Lookup to allow tooltip for SPs
- Minor styling adjustments to meet design requirements

 
![Screenshot 2024-03-18 at 10 28 36 AM](https://github.com/bcgov/ppr/assets/53542131/cd05d005-175d-44c1-ad07-7e59728d3878)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
