### PR TITLE
API post migration fix account registrations permit expire days.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/cmpserno.py
+++ b/mhr_api/src/mhr_api/models/db2/cmpserno.py
@@ -143,7 +143,7 @@ class Db2Cmpserno(db.Model):
         current_app.logger.debug(f'key={key} last 3 bytes={key_bytes} hex={key_hex}')
         return key_hex
 
-    def update_serial_key(self):
+    def update_serial_key(self, conn):
         """Set the serial number compressed key value for searching."""
         if not self.serial_number:
             return
@@ -165,7 +165,6 @@ class Db2Cmpserno(db.Model):
                                      sequence_id=self.compressed_id)
             current_app.logger.debug(f'Executing update query {query_s}')
             query = text(query_s)
-            with db.engines['db2'].connect() as conn:
-                conn.execute(query)
+            conn.execute(query)
         except Exception as db_exception:   # noqa: B902; return nicer error
             current_app.logger.error('DB2 update_serial_key exception: ' + str(db_exception))

--- a/mhr_api/src/mhr_api/models/db2/descript.py
+++ b/mhr_api/src/mhr_api/models/db2/descript.py
@@ -175,11 +175,12 @@ class Db2Descript(db.Model):
             descript.strip()
         return descript
 
-    def update_serial_keys(self):
+    def update_serial_keys(self, conn):
         """Set the serial number compressed key value for searching."""
         if self.compressed_keys:
             for key in self.compressed_keys:
-                key.update_serial_key()
+                key.update_serial_key(conn)
+                conn.commit()
 
     @property
     def json(self):

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -240,12 +240,12 @@ class Db2Manuhome(db.Model):
             current_app.logger.error('Db2Manuhome.save_permit exception: ' + str(db_exception))
             raise DatabaseException(db_exception)
 
-    def update_serial_keys(self):
+    def update_serial_keys(self, conn):
         """Set the serial number compressed key value for searching."""
         if self.new_descript:
-            self.new_descript.update_serial_keys()
+            self.new_descript.update_serial_keys(conn)
         elif self.reg_descript:
-            self.reg_descript.update_serial_keys()
+            self.reg_descript.update_serial_keys(conn)
 
     @classmethod
     def find_by_id(cls, man_id: int, search: bool = False):

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -315,8 +315,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                   self.reg_json.get('documentType', '') in (MhrDocumentTypes.PUBA,
                                                             MhrDocumentTypes.REGC_CLIENT,
                                                             MhrDocumentTypes.REGC_STAFF))):
-            self.manuhome.update_serial_keys()
-            db.session.commit()
+            with db.engines['db2'].connect() as conn:
+                self.manuhome.update_serial_keys(conn)
 
     def save_exemption(self):
         """Set the state of the original MH registration to exempt."""
@@ -753,7 +753,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                                 status_type=MhrNoteStatusTypes.ACTIVE,
                                 remarks='',
                                 change_registration_id=registration.id,
-                                expiry_date=model_utils.today_ts_offset(30, True))
+                                expiry_date=model_utils.compute_permit_expiry())
         # Amendment use existing expiry timestamp
         if json_data.get('amendment'):
             for reg in base_reg.change_registrations:  # Updating a change registration location.

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -365,9 +365,9 @@ def expiry_date_days(expiry_dt: date) -> int:
 
 def expiry_ts_days(expiry_ts: _datetime) -> int:
     """Compute the date difference in days between the expiry timstamp and and the current timestamp."""
-    today_ts = now_ts()
-    expiry = expiry_ts.astimezone(timezone.utc)
-    date_diff = expiry - today_ts
+    today_ts = today_local()
+    expiry = expiry_ts.astimezone(LOCAL_TZ)
+    date_diff = expiry.date() - today_ts.date()
     return date_diff.days
 
 
@@ -788,6 +788,18 @@ def compute_caution_expiry(registration_ts, end_of_day: bool = False):
         # Return as UTC
         return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)
     return registration_ts
+
+
+def compute_permit_expiry():
+    """For transport permits expiry is end of day 30 days from now local time."""
+    local_dt = today_local()
+    # Naive time
+    expiry_time = time(23, 59, 59, tzinfo=None)
+    future_ts = _datetime.combine(local_dt, expiry_time) + datedelta(days=30)
+    # Explicitly set to local timezone which will adjust for daylight savings.
+    local_ts = LOCAL_TZ.localize(future_ts)
+    # Return as UTC
+    return _datetime.utcfromtimestamp(local_ts.timestamp()).replace(tzinfo=timezone.utc)
 
 
 def expiry_datetime(expiry_iso: str):

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -263,7 +263,11 @@ def validate_permit_location(json_data: dict, current_location: dict, staff: boo
         location = json_data.get('newLocation')
         error_msg += validator_utils.validate_location(location)
         error_msg += validator_utils.validate_location_different(current_location, location)
-        error_msg += validator_utils.validate_tax_certificate(location, current_location, staff)
+        # Skip tax cert info validation for amendments if not provided.
+        if json_data.get('amendment') and json_data.get('taxCertificate'):
+            error_msg += validator_utils.validate_tax_certificate(location, current_location, staff)
+        elif not json_data.get('amendment'):
+            error_msg += validator_utils.validate_tax_certificate(location, current_location, staff)
         if not json_data.get('landStatusConfirmation'):
             if location.get('locationType') and \
                     location['locationType'] in (MhrLocationTypes.STRATA,

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.2'  # pylint: disable=invalid-name
+__version__ = '1.8.3'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_utils.py
+++ b/mhr_api/tests/unit/models/test_utils.py
@@ -128,3 +128,10 @@ def test_tax_cert_date(session, valid, registration_ts, tax_cert_ts):
         assert is_valid
     else:
         assert not is_valid
+
+
+def test_permit_expiry_days(session):
+    """Assert that setting and computing expiry days works as expected."""
+    expiry_ts = model_utils.compute_permit_expiry()
+    expiry_days = model_utils.expiry_ts_days(expiry_ts)
+    assert expiry_days == 30

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -372,6 +372,7 @@ TEST_DATA_PID = [
 ]
 # test data pattern is ({description}, {valid}, {staff}, {message_content}, {mhr_num}, {account}, {group})
 TEST_AMEND_PERMIT_DATA = [
+    ('Valid staff tax cert', True, True, None, '000931', 'PS12345', STAFF_ROLE),
     ('Valid staff', True, True, None, '000931', 'PS12345', STAFF_ROLE),
     ('Valid non-staff', True, False, None, '000931', 'PS12345', QUALIFIED_USER_GROUP),
     ('Invalid no permit', False, True, validator.AMEND_PERMIT_INVALID, '000900', 'PS12345', STAFF_ROLE),
@@ -428,8 +429,14 @@ def test_validate_amend_permit(session, desc, valid, staff, message_content, mhr
         json_data['newLocation'] = LOCATION_RESERVE
     elif desc == 'Valid non-staff':
         json_data['newLocation'] = LOCATION_OTHER
-    if valid and json_data['newLocation'].get('taxExpiryDate'):
-        json_data['newLocation']['taxExpiryDate'] = get_valid_tax_cert_dt()
+    if desc == 'Valid staff tax cert':
+       json_data['newLocation']['taxExpiryDate'] = get_valid_tax_cert_dt()
+    else:
+        if 'taxExpiryDate' in json_data['newLocation']:
+            del json_data['newLocation']['taxExpiryDate']
+        if 'taxCertificate' in json_data['newLocation']:
+            del json_data['newLocation']['taxCertificate']
+
     # current_app.logger.info(json_data)
     valid_format, errors = schema_utils.validate(json_data, 'permit', 'mhr')
     # Additional validation not covered by the schema.


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20401

*Description of changes:*
- Compute post migration permit expiry date as end of day local time 30 days in the future.
- Small performance improvement setting legacy search serial number key.  


*Issue #:* /bcgov/entity#20398

*Description of changes:*
- Skip amend transport permit tax certificate information data validation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
