### PR TITLE
Prevent Multiple MHR Submissions

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.69",
+  "version": "3.0.70",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.69",
+      "version": "3.0.70",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.69",
+  "version": "3.0.70",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/ButtonFooter.vue
+++ b/ppr-ui/src/components/common/ButtonFooter.vue
@@ -111,7 +111,7 @@
 <script lang="ts">
 import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
 import { useStore } from '@/store/store'
-import _ from 'lodash'
+import { throttle } from 'lodash'
 import { saveFinancingStatement, saveFinancingStatementDraft } from '@/utils'
 import { RouteNames } from '@/enums'
 import { BaseDialog } from '@/components/dialogs'
@@ -348,7 +348,7 @@ export default defineComponent({
       }
     }
 
-    const throttleSubmitStatement = _.throttle(async (stateModel: StateModelIF): Promise<FinancingStatementIF> => {
+    const throttleSubmitStatement = throttle(async (stateModel: StateModelIF): Promise<FinancingStatementIF> => {
       // Prevents multiple submits (i.e. double click)
       localState.submitting = true
       const statement = await saveFinancingStatement(stateModel)
@@ -356,7 +356,7 @@ export default defineComponent({
       return statement
     }, 2000, { trailing: false })
 
-    const throttleSubmitStatementDraft = _.throttle(async (stateModel: StateModelIF): Promise<DraftIF> => {
+    const throttleSubmitStatementDraft = throttle(async (stateModel: StateModelIF): Promise<DraftIF> => {
       // Prevents multiple submits (i.e. double click)
       localState.submitting = true
       const statement = await saveFinancingStatementDraft(stateModel)

--- a/ppr-ui/src/components/common/ButtonsStacked.vue
+++ b/ppr-ui/src/components/common/ButtonsStacked.vue
@@ -106,6 +106,7 @@ import {
   reactive,
   toRefs
 } from 'vue'
+import { debounce } from 'lodash'
 
 export default defineComponent({
   name: 'ButtonsStacked',
@@ -147,9 +148,10 @@ export default defineComponent({
     const cancel = () => {
       emit('cancel', true)
     }
-    const submit = () => {
+    const submit = debounce(() => {
       emit('submit', true)
-    }
+    }, 500) // prevent multiple submissions by adding a small delay
+
     const save = () => {
       emit('save', true)
     }

--- a/ppr-ui/src/components/search/SearchBar.vue
+++ b/ppr-ui/src/components/search/SearchBar.vue
@@ -330,7 +330,7 @@
 <script lang="ts">
 import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
 import { useStore } from '@/store/store'
-import _ from 'lodash'
+import { throttle } from 'lodash'
 import { mhrSearch, search, staffSearch, validateSearchAction, validateSearchRealTime } from '@/utils'
 import { MHRSearchTypes, SearchTypes } from '@/resources'
 import { paymentConfirmaionDialog, staffPaymentDialog } from '@/resources/dialogOptions'
@@ -616,7 +616,7 @@ export default defineComponent({
         clientReferenceId: localState.folioNumber
       }
     }
-    const searchAction = _.throttle(async (proceed: boolean) => {
+    const searchAction = throttle(async (proceed: boolean) => {
       localState.confirmationDialog = false
       if (proceed) {
         // pad mhr number with 0s

--- a/ppr-ui/tests/setup.ts
+++ b/ppr-ui/tests/setup.ts
@@ -59,6 +59,16 @@ beforeAll(() => {
     }
   })
 
+  // Mock lodash library and override the 'debounce' method to immediately invoke the provided function without delays
+  vi.mock('lodash', async () => {
+    const actualLodash: any = await vi.importActual('lodash')
+    return {
+      ...actualLodash.default,
+      // throttle: vi.fn((fn) => fn),
+      debounce: vi.fn((fn) => fn)
+    }
+  })
+
   // Mock the WysiwygEditors (imported editor portion) component functions
   global.ClipboardEvent = class ClipboardEvent {
     constructor(type, eventInitDict) {

--- a/ppr-ui/tests/setup.ts
+++ b/ppr-ui/tests/setup.ts
@@ -64,7 +64,6 @@ beforeAll(() => {
     const actualLodash: any = await vi.importActual('lodash')
     return {
       ...actualLodash.default,
-      // throttle: vi.fn((fn) => fn),
       debounce: vi.fn((fn) => fn)
     }
   })

--- a/ppr-ui/tests/unit/SearchBar.spec.ts
+++ b/ppr-ui/tests/unit/SearchBar.spec.ts
@@ -13,6 +13,7 @@ import { APIMHRSearchTypes, UISearchTypes } from '@/enums'
 import { MHRSearchTypes, SearchTypes } from '@/resources'
 import { ConfirmationDialog } from '@/components/dialogs'
 import flushPromises from 'flush-promises'
+import { delayActions } from '@/utils'
 
 const store = useStore()
 
@@ -331,12 +332,14 @@ describe('Business debtor search', () => {
     // verify payment confirmation disabled, otherwise it would not have gotten the response yet
     expect(store.getStateModel.userInfo.settings.paymentConfirmationDialog).toBe(false)
   })
+
   it('shows business dropdown after 3 characters', async () => {
     wrapper.vm.returnSearchSelection(select)
     wrapper.vm.selectedSearchType = select
     await nextTick()
     wrapper.vm.searchValue = 'Abc'
     await nextTick()
+    await delayActions(500)
 
     expect(wrapper.findComponent(BusinessSearchAutocomplete).exists()).toBe(true)
     expect(wrapper.find('#business-search-autocomplete').exists()).toBe(true)


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#20458

*Description of changes:*
- Add `debounce()` of 500ms to create a delay emitting MHR `submit`, to prevent multiple submission calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
