### PR TITLE
Fix debtor search empty string middle name exact match.

### DIFF
--- a/ppr-api/src/ppr_api/models/party.py
+++ b/ppr-api/src/ppr_api/models/party.py
@@ -214,17 +214,17 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
         party = Party()
         if party_type != model_utils.PARTY_DEBTOR_BUS:
             party.party_type = party_type
-        elif 'businessName' in json_data:
+        elif json_data.get('businessName'):
             party.party_type = party_type
         else:
             party.party_type = model_utils.PARTY_DEBTOR_IND
 
-        if party_type != model_utils.PARTY_DEBTOR_BUS and 'code' in json_data:
+        if party_type != model_utils.PARTY_DEBTOR_BUS and json_data.get('code'):
             party.branch_id = int(json_data['code'])
         else:
-            if party_type == model_utils.PARTY_DEBTOR_BUS and 'birthDate' in json_data:
+            if party_type == model_utils.PARTY_DEBTOR_BUS and json_data.get('birthDate'):
                 party.birth_date = model_utils.ts_from_date_iso_format(json_data['birthDate'])
-            if 'businessName' in json_data:
+            if json_data.get('businessName'):
                 party.business_name = json_data['businessName'].strip().upper()
             else:
                 party.last_name = json_data['personName']['last'].strip().upper()
@@ -232,10 +232,10 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
                 party.first_name_char1 = party.first_name[0:1]
                 if len(party.first_name) > 1:
                     party.first_name_char2 = party.first_name[1:2]
-                if 'middle' in json_data['personName']:
+                if json_data['personName'].get('middle'):
                     party.middle_initial = json_data['personName']['middle'].strip().upper()
 
-            if 'emailAddress' in json_data:
+            if json_data.get('emailAddress'):
                 party.email_id = json_data['emailAddress']
 
             party.address = Address.create_from_json(json_data['address'])

--- a/ppr-api/src/ppr_api/version.py
+++ b/ppr-api/src/ppr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.2.2'  # pylint: disable=invalid-name
+__version__ = '1.2.3'  # pylint: disable=invalid-name

--- a/ppr-api/tests/unit/models/test_party.py
+++ b/ppr-api/tests/unit/models/test_party.py
@@ -124,6 +124,9 @@ def test_party_json(session):
     }
 
     assert party.json == party_json
+    party.middle_initial = None
+    del party_json['personName']['middle']
+    assert party.json == party_json
 
 
 def test_create_from_json(session):
@@ -172,7 +175,7 @@ def test_create_from_json(session):
     assert party_bus.address.postal_code
     assert not party_bus.last_name
 
-    party_ind = Party.create_from_json(party_ind_json, 'DB', 1234)
+    party_ind = Party.create_from_json(party_ind_json, 'DI', 1234)
     assert party_ind.registration_id
     assert party_ind.party_type == 'DI'
     assert party_ind.last_name
@@ -186,6 +189,9 @@ def test_create_from_json(session):
     assert party_ind.address.country
     assert party_ind.address.postal_code
     assert not party_ind.business_name
+    del party_ind_json['personName']['middle']
+    party_ind2 = Party.create_from_json(party_ind_json, 'DI', 1234)
+    assert party_ind2.middle_initial is None
 
 
 def test_create_from_financing_json(session):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2475

*Description of changes:*
- Fix individual debtor search with a middle name excluding exact match when the middle name is an empty string. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
