### PR TITLE
Corrections Table Items & PDF Item Enhancement

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.71",
+  "version": "3.0.72",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.71",
+      "version": "3.0.72",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.71",
+  "version": "3.0.72",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/ButtonsStacked.vue
+++ b/ppr-ui/src/components/common/ButtonsStacked.vue
@@ -106,7 +106,7 @@ import {
   reactive,
   toRefs
 } from 'vue'
-import { debounce } from 'lodash'
+import { throttle } from 'lodash'
 
 export default defineComponent({
   name: 'ButtonsStacked',
@@ -148,7 +148,7 @@ export default defineComponent({
     const cancel = () => {
       emit('cancel', true)
     }
-    const submit = debounce(() => {
+    const submit = throttle(() => {
       emit('submit', true)
     }, 2500) // prevent multiple submissions by adding a small delay
 

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
@@ -140,6 +140,8 @@ export interface RegistrationSummaryIF {
   statusType?: string
   totalRegistrationCount?: number // Included by the api in the 1st item in the registration list
   vehicleCount?: number // Number of vehicle collateral in the registration
+  documentRegistrationNumber?: string // unique document identifier
+  submittingParty?: string
 }
 
 export interface MhRegistrationSummaryIF {

--- a/ppr-ui/tests/setup.ts
+++ b/ppr-ui/tests/setup.ts
@@ -64,7 +64,7 @@ beforeAll(() => {
     const actualLodash: any = await vi.importActual('lodash')
     return {
       ...actualLodash.default,
-      debounce: vi.fn((fn) => fn)
+      throttle: vi.fn((fn) => fn)
     }
   })
 

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -13,7 +13,6 @@ import {
   DocumentId,
   LienAlert,
   InputFieldDatePicker,
-  StaffPayment
 } from '@/components/common'
 import {
   AuthRoles,
@@ -24,12 +23,11 @@ import {
   ProductCode,
   UnitNoteDocTypes,
   MhApiStatusTypes,
-  LocationChangeTypes,
   ProductType,
   ProductStatus
 } from '@/enums'
 import { HomeOwnersTable } from '@/components/mhrRegistration/HomeOwners'
-import { createComponent, getTestId, setupActiveTransportPermit } from './utils'
+import { createComponent, getTestId } from './utils'
 import {
   mockedAddedPerson,
   mockedRemovedPerson,
@@ -52,16 +50,10 @@ import {
   MhrRegistrationHomeOwnerIF,
   TransferTypeSelectIF
 } from '@/interfaces'
-import { ConfirmCompletion, TaxCertificate, TransferDetails, TransferDetailsReview, TransferType } from '@/components/mhrTransfers'
+import { TransferDetails, TransferDetailsReview, TransferType } from '@/components/mhrTransfers'
 
-import { calendarDates, defaultFlagSet, shortPacificDate, toDisplayPhone } from '@/utils'
+import { defaultFlagSet, toDisplayPhone } from '@/utils'
 import { UnitNotesInfo } from '@/resources'
-import { BaseDialog } from '@/components/dialogs'
-import { incompleteRegistrationDialog } from '@/resources/dialogOptions'
-import { useTransportPermits } from '@/composables'
-import { LocationChange, LocationChangeReview } from '@/components/mhrTransportPermit'
-import { HomeLocationType, HomeCivicAddress, HomeLandOwnership } from '@/components/mhrRegistration'
-import { HomeLocationReview } from '@/components/mhrRegistration/ReviewConfirm'
 
 const store = useStore()
 


### PR DESCRIPTION
*Description of changes:*

*Issue #:* /bcgov/entity#19518
- Verify proper display of Corrections in Table

*Issue #:* /bcgov/entity#20413
- Updated logic to handle History Items where `path` is absent due to the improved filing processing speed.
- Display appropriate Tooltips for Staff and Clients
- Allow clickable refresh of PDF Information Icon to pull in path from api

*Issue #:* /bcgov/entity#20458
- Replaced `debounce` with `throttle`: Debounce would delay a function call and in turn was delaying navigation between views when prompted by that submission button. Throttle will limit the function calls. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
