### PR TITLE
Misc SBC items and Submission Fixes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.75",
+  "version": "3.0.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.75",
+      "version": "3.0.76",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.75",
+  "version": "3.0.76",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/ButtonsStacked.vue
+++ b/ppr-ui/src/components/common/ButtonsStacked.vue
@@ -86,6 +86,7 @@
         class="btn-stacked important-btn"
         color="primary"
         :disabled="disableSubmitBtn"
+        :loading="setIsLoading"
         @click="submit"
       >
         {{ setSubmitBtn }}
@@ -130,6 +131,10 @@ export default defineComponent({
     setSaveButton: {
       type: String,
       default: ''
+    },
+    setIsLoading: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['back', 'cancel', 'submit', 'save'],

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -23,6 +23,7 @@
       :setSubmitBtn="setSubmitBtn"
       :setSaveButton="saveBtn"
       :setDisableSubmitBtn="disableSubmitBtn"
+      :setIsLoading="setIsLoading"
       @back="back()"
       @cancel="cancel()"
       @submit="submit()"
@@ -134,6 +135,10 @@ export default defineComponent({
     setSaveBtn: {
       type: String,
       default: ''
+    },
+    setIsLoading: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['back', 'cancel', 'submit', 'save'],

--- a/ppr-ui/src/components/registration/RegistrationBar.vue
+++ b/ppr-ui/src/components/registration/RegistrationBar.vue
@@ -4,7 +4,7 @@
     fluid
   >
     <v-btn
-      v-if="isMhr && (isRoleStaff || isRoleManufacturer)"
+      v-if="isMhr && (isRoleStaffReg || isRoleManufacturer)"
       class="mhr-registration-bar-btn px-5"
       @click="newRegistration(MhrRegistrationType)"
     >
@@ -66,7 +66,7 @@ export default defineComponent({
       // Getters
       getAccountProductSubscriptions,
       isRoleQualifiedSupplier,
-      isRoleStaff,
+      isRoleStaffReg,
       isRoleManufacturer
     } = storeToRefs(useStore())
     const hasRPPR = computed(() => {
@@ -84,7 +84,7 @@ export default defineComponent({
 
     return {
       hasRPPR,
-      isRoleStaff,
+      isRoleStaffReg,
       isRoleManufacturer,
       isRoleQualifiedSupplier,
       newRegistration,

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
@@ -8,6 +8,7 @@ import {
   PartyIF,
   VehicleCollateralIF
 } from '@/interfaces'
+import { b } from 'vitest/dist/reporters-5f784f42'
 
 // Payment (pay-api) reference interface.
 export interface PaymentIF {
@@ -130,6 +131,7 @@ export interface RegistrationSummaryIF {
   lastUpdateDateTime?: string // Included in a successful response. Timestamp of last draft update.
   new?: boolean // used to prevent the collapse of a newly added base reg
   path: string
+  legacy?: boolean // Flag indicating if filing was completed in the legacy system
   registeringName?: string
   registeringParty: string
   registrationDescription?: string // Returned on creation.

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/registration-interfaces.ts
@@ -8,7 +8,6 @@ import {
   PartyIF,
   VehicleCollateralIF
 } from '@/interfaces'
-import { b } from 'vitest/dist/reporters-5f784f42'
 
 // Payment (pay-api) reference interface.
 export interface PaymentIF {

--- a/ppr-ui/src/utils/auth-helper.ts
+++ b/ppr-ui/src/utils/auth-helper.ts
@@ -169,7 +169,7 @@ export async function getRegisteringPartyFromAuth (): Promise<PartyIF> {
     ).catch(
       error => {
         throw new Error('Auth API error getting Registering Party: status code = ' +
-                        error?.response?.status?.toString() || StatusCodes.NOT_FOUND.toString())
+                        error?.response?.status?.toString() || StatusCodes?.NOT_FOUND.toString())
       }
     )
 }

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -196,7 +196,6 @@ export function dateToPacificDate (date: Date, longMonth = false, showWeekday = 
   return dateStr
 }
 
-
 /**
  * Transforms a date string from "YYYY/MM/DD" to "YYYY-MM-DD" format.
  * Useful for modern versions of safari where date functions can return non-iso formats
@@ -231,4 +230,26 @@ export const calendarDates = {
   tomorrow: localTodayDate(new Date(date.setDate(date.getDate() + 2))),
   endOfYear: localTodayDate(new Date(new Date().getFullYear(), 11, 31)),
   startOfNextYear: localTodayDate(new Date(new Date().getFullYear() + 1, 0, 1))
+}
+
+/**
+ * Checks if the provided date and time is within a specified minute differential
+ * compared to the current system time.
+ *
+ * @param {string} createDateTime - The date and time to compare in ISO 8601 format.
+ * @param {number} minuteDifferential - The maximum allowed difference in minutes.
+ * @returns {boolean} Returns true if the provided date and time is within the specified minute differential, otherwise false.
+ */
+export const isWithinMinutes = (createDateTime: string, minuteDifferential: number) => {
+  // Convert the provided createDateTime to a Date object
+  const createTime: Date = new Date(createDateTime)
+
+  // Calculate the difference in milliseconds between the createDateTime and current system time
+  const timeDifference: number = new Date().getTime() - createTime.getTime()
+
+  // Convert the time difference from milliseconds to minutes
+  const minutesDifference: number = Math.abs(timeDifference / (1000 * 60))
+
+  // Check if the time difference is within the specified minute differential
+  return minutesDifference <= minuteDifferential
 }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,13 +10,13 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': false, // Enables MHR table tab
-  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': false,
-  'mhr-transport-permit-enabled': false,
-  'mhr-amend-transport-permit-enabled': false,
-  'mhr-user-access-enabled': false,
+  'mhr-registration-enabled': true, // Enables MHR table tab
+  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': true,
+  'mhr-transport-permit-enabled': true,
+  'mhr-amend-transport-permit-enabled': true,
+  'mhr-user-access-enabled': true,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,13 +10,13 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': true, // Enables MHR table tab
-  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': true,
-  'mhr-transport-permit-enabled': true,
-  'mhr-amend-transport-permit-enabled': true,
-  'mhr-user-access-enabled': true,
+  'mhr-registration-enabled': false, // Enables MHR table tab
+  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': false,
+  'mhr-transport-permit-enabled': false,
+  'mhr-amend-transport-permit-enabled': false,
+  'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -521,6 +521,7 @@
                 :transferType="isChangeLocationActive
                   ? getUiFeeSummaryLocationType(transportPermitLocationType)
                   : getUiTransferType()"
+                :setIsLoading="submitBtnLoading"
                 data-test-id="fee-summary"
                 @cancel="goToDashboard()"
                 @back="isReviewMode = false"
@@ -812,6 +813,7 @@ export default defineComponent({
       enableRoleBasedTransfer: true, // rendering of the transfer/change btn
       disableRoleBaseTransfer: false, // disabled state of transfer/change btn
       disableRoleBaseLocationChange: false, // disabled state of location change/transport permit btn
+      submitBtnLoading: false,
 
       // Transport Permit
       showCancelTransportPermitDialog: false,
@@ -1064,6 +1066,8 @@ export default defineComponent({
 
       // If already in review mode, file the transfer
       if (localState.isReviewMode) {
+        localState.submitBtnLoading = true
+
         // Verify no lien exists prior to submitting filing
         const regSum = !localState.hasLienInfoDisplayed
           ? await getMHRegistrationSummary(getMhrInformation.value.mhrNumber, false)
@@ -1073,12 +1077,14 @@ export default defineComponent({
           await setLienType(regSum.lienRegistrationType)
           await scrollToFirstError(true)
           localState.hasLienInfoDisplayed = true
+          localState.submitBtnLoading = false
           return
         }
 
         // Check if any required fields have errors
         if (localState.isReviewMode && !isValidTransferReview.value) {
           await scrollToFirstError(false)
+          localState.submitBtnLoading = false
           return
         }
 
@@ -1110,6 +1116,7 @@ export default defineComponent({
           }
 
           localState.loading = false
+          localState.submitBtnLoading = false
           return
         }
 
@@ -1133,6 +1140,7 @@ export default defineComponent({
             emitError(transportPermitFilingResp?.error)
           }
           localState.loading = false
+          localState.submitBtnLoading = false
           return
         }
 
@@ -1173,6 +1181,7 @@ export default defineComponent({
           } else goToDashboard()
         } else emitError(mhrTransferFiling?.error)
         localState.loading = false
+        localState.submitBtnLoading = false
       }
 
       // If Transfer or Transport Permit is valid, enter review mode


### PR DESCRIPTION
*Description of changes:*
*Issue #:* /bcgov/entity#20568
- Legacy Tooltip content when legacy flag is true

*Issue #:* /bcgov/entity#20458
- implements loading state into btn to prevent duplicate submissions in for Transfers/Permits when network delay is outside throttle window

*Issue #:* /bcgov/entity#20464
- Hide MHR Registration Button for SBC Staff

*Issue #:* /bcgov/entity#20413
- Unique handling for PDF Downloads for SBC Staff following a filing - Since they are not a submitting party match and not staff who can view all, we allow them to refresh the pdf if the current user is sbc and the filing was very recent.
- This will rarely occur outside the immediate moment an sbc staff returns to their dashboard following a filing.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
