### PR TITLE
QS Submission: include accepted terms flag

### DIFF
--- a/ppr-ui/src/composables/userAccess/useUserAccess.ts
+++ b/ppr-ui/src/composables/userAccess/useUserAccess.ts
@@ -405,6 +405,7 @@ export const useUserAccess = () => {
     const payload: MhrQsPayloadIF = {
       ...cleanEmpty(getMhrQsInformation.value) as MhrQsPayloadIF,
       authorizationName: getMhrQsAuthorization.value.authorizationName,
+      termsAccepted: true,
       phoneNumber: fromDisplayPhone(getMhrQsInformation.value.phoneNumber)
     }
 
@@ -448,6 +449,7 @@ export const useUserAccess = () => {
     return {
       authorizationName: getMhrQsAuthorization.value.authorizationName,
       dbaName: getMhrQsInformation.value.dbaName,
+      termsAccepted: true,
       submittingParty: {
         businessName: getMhrQsSubmittingParty.value.name,
         address: getMhrQsSubmittingParty.value.mailingAddress,

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrManufacturerInfoIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrManufacturerInfoIF.ts
@@ -3,6 +3,7 @@ import { MhrRegistrationHomeLocationIF, MhrRegistrationHomeOwnerGroupIF, Submitt
 export interface MhrManufacturerInfoIF {
   authorizationName?: string
   dbaName?: string
+  termsAccepted: boolean
   description: {
     manufacturer: string
   }

--- a/ppr-ui/src/interfaces/mhr-user-access-interfaces/MhrQsPayloadIF.ts
+++ b/ppr-ui/src/interfaces/mhr-user-access-interfaces/MhrQsPayloadIF.ts
@@ -3,6 +3,7 @@ import { AddressIF } from '@/interfaces'
 export interface MhrQsPayloadIF {
   authorizationName: string
   businessName: string
+  termsAccepted: boolean
   dbaName?: string
   address: AddressIF
   phoneNumber: string


### PR DESCRIPTION
*Description of changes:*
- Include `termsAccepted` flag in payload submission. 
- Property is always implied `true` on new applications, as confirmation of accepted terms is validated prior to submission. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
