### PR TITLE
Locked QS Flows

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.79",
+  "version": "3.0.80",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.79",
+      "version": "3.0.80",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.79",
+  "version": "3.0.80",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -440,7 +440,8 @@ export default defineComponent({
           ? getUserSettings.value[SettingOptions.REGISTRATION_TABLE]?.columns
           : [...registrationTableHeaders] // Default to all selections for initialization
       } else if (props.isMhr) {
-        localState.myRegHeadersSelected = getUserSettings.value[SettingOptions.REGISTRATION_TABLE]?.mhrColumns?.length >= 1
+        localState.myRegHeadersSelected =
+          getUserSettings.value[SettingOptions.REGISTRATION_TABLE]?.mhrColumns?.length >= 1
           ? getUserSettings.value[SettingOptions.REGISTRATION_TABLE]?.mhrColumns
           : [...mhRegistrationTableHeaders] // Default to all selections for initialization
       } else {

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -578,6 +578,7 @@ export default defineComponent({
       }
     } else {
       defaultHomeOwner.organizationName = props.editHomeOwner?.organizationName || ''
+      defaultHomeOwner.partyType = HomeOwnerPartyTypes.OWNER_BUS
     }
 
     // Transfers flow: Pre-fill suffix and type for new owners (not when editing existing owner)
@@ -586,7 +587,7 @@ export default defineComponent({
       TransToExec.prefillOwnerAsExecOrAdmin(defaultHomeOwner)
     }
 
-    if (isFrozenMhr.value && !isFrozenMhrDueToAffidavit) {
+    if (isFrozenMhr.value && !isFrozenMhrDueToAffidavit.value) {
       defaultHomeOwner.partyType = HomeOwnerPartyTypes.OWNER_IND
     }
 

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -93,7 +93,7 @@
               class="owner-row"
             >
               <!-- Transfer scenario: Display error for groups that 'removed' all owners
-          but they still exist in the table -->
+               but they still exist in the table -->
               <div v-if="isGroupWithNoOwners(item.groupId, index) || isTransferGroupInvalid(group.groupId, index)">
                 <div
                   class="py-1 bottom-border"

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -38,7 +38,8 @@
           </v-btn>
         </v-col>
         <v-col
-          v-if="isChild && hasFrozenParentReg(item) && (isTransAffi(item.registrationType) || isDraft(item))"
+          v-if="isRoleStaffReg && isChild && hasFrozenParentReg(item) &&
+            (isTransAffi(item.registrationType) || isDraft(item))"
           cols="2"
         >
           <v-icon
@@ -60,7 +61,8 @@
           <!-- child drafts will sometimes show outside their base reg during the sort -->
           <div
             v-if="isChild || (isDraft(item) && item.baseRegistrationNumber)"
-            :class="!(isChild && hasFrozenParentReg(item) && (isTransAffi(item.registrationType) || isDraft(item)))
+            :class="!(isRoleStaffReg && isChild && hasFrozenParentReg(item) &&
+              (isTransAffi(item.registrationType) || isDraft(item)))
               ? 'pl-9'
               : 'pl-1'"
           >
@@ -104,7 +106,7 @@
 
       <!-- Caution message for Frozen MHR state -->
       <v-row
-        v-if="hasRequiredTransfer(item)"
+        v-if="isRoleStaffReg && hasRequiredTransfer(item)"
         :class="item.changes && 'pt-4'"
       >
         <v-col>
@@ -944,7 +946,8 @@ export default defineComponent({
         item.mhrNumber && getMhRegTableBaseRegs.value?.find(reg => reg.mhrNumber === item.mhrNumber)
       // For QS status will be frozen, but for Staff it will be Active, so no locked state would be shown
       return (isRoleQualifiedSupplier.value && parentReg?.statusType === MhApiStatusTypes.FROZEN) &&
-        QSLockedStateUnitNoteTypes.includes(parentReg?.frozenDocumentType)
+        (QSLockedStateUnitNoteTypes.includes(parentReg?.frozenDocumentType) ||
+          parentReg?.frozenDocumentType === MhApiFrozenDocumentTypes.TRANS_AFFIDAVIT)
     }
 
     const isDischarged = (item: RegistrationSummaryIF): boolean => {

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -219,10 +219,11 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     if (enableAllActions) return true
 
     switch (getMhrTransferType.value?.transferType) {
-      case ApiTransferTypes.SALE_OR_GIFT:
       case ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL:
       case ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL:
       case ApiTransferTypes.TO_ADMIN_NO_WILL:
+        return !groupHasAllBusinesses(getCurrentGroupById(owner.groupId))
+      case ApiTransferTypes.SALE_OR_GIFT:
         return true // Always enable for above transfer types
       case ApiTransferTypes.SURVIVING_JOINT_TENANT:
         // Check for joint tenancy (at least two owners who are not executors, trustees or admins)
@@ -762,6 +763,11 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     return group?.owners?.every(owner => owner.action === ActionTypes.ADDED)
   }
 
+  /** Return true if all owners in the group are Businesses **/
+  const groupHasAllBusinesses = (group: MhrHomeOwnerGroupIF) => {
+    return group?.owners?.every(owner => owner.partyType === HomeOwnerPartyTypes.OWNER_BUS)
+  }
+
   return {
     isAddedHomeOwnerGroup,
     isRemovedHomeOwnerGroup,
@@ -798,6 +804,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     isJointTenancyStructure,
     getCurrentOwnerStateById,
     groupHasAllAddedOwners,
+    groupHasAllBusinesses,
     groupHasRemovedAllCurrentOwners,
     getCurrentOwnerGroupIdByOwnerId,
     hasCurrentOwnerChanges,

--- a/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
@@ -30,7 +30,7 @@
             class=""
             color="primary"
             :ripple="false"
-            :disabled="false"
+            :disabled="disable"
             data-test-id="amend-transport-permit-btn"
             @click="toggleAmendLocationChange()"
           >

--- a/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
+++ b/ppr-ui/src/views/newMhrRegistration/MhrReviewConfirm.vue
@@ -226,7 +226,7 @@ export default defineComponent({
     } = useMhrValidations(toRefs(getMhrRegistrationValidationModel.value))
 
     const { setShowGroups, isGlobalEditingMode } = useHomeOwners()
-    const { hasMadeMhrCorrections, isMhrCorrection, isStaffCorrection } = useMhrCorrections()
+    const { hasMadeMhrCorrections, isMhrCorrection, isStaffCorrection, isPublicAmendment } = useMhrCorrections()
 
     const localState = reactive({
       authorizationValid: false,
@@ -259,13 +259,16 @@ export default defineComponent({
         return isMhrCorrection.value &&
           deepChangesComparison(getMhrBaseline.value?.statusType, getMhrStatusType.value)
       }),
+      correctionAmendmentLabel: computed((): string => {
+        return isPublicAmendment.value ? 'amendment' : 'correction'
+      }),
       mhrStatusCorrectionMsg: computed((): string => {
         return getMhrStatusType.value === MhApiStatusTypes.EXEMPT
           ? `Registration status for this home was changed to <b>Exempt</b>. This will be effective after registering
-             this correction.`
+             this ${localState.correctionAmendmentLabel}.`
           : `Registration status for this home was changed to <b>Active</b>. If applicable, any Exemption Orders on
              this home will be cancelled and Exemption Unit Notes removed from search results. This will be effective
-             after registering this correction.`
+             after registering this ${localState.correctionAmendmentLabel}.`
       }),
       paymentOption: StaffPaymentOptions.NONE,
       staffPaymentValid: false,

--- a/ppr-ui/tests/unit/TableRow.spec.ts
+++ b/ppr-ui/tests/unit/TableRow.spec.ts
@@ -15,7 +15,7 @@ import {
   mockedRegistration3,
   mockedResidentialExemptionMhRegistration
 } from './test-data'
-import { createComponent, getLastEvent, getTestId } from './utils'
+import { createComponent, getLastEvent, getTestId, setupMockStaffUser } from './utils'
 import { TableRow } from '@/components/tables/common'
 import { mhRegistrationTableHeaders, registrationTableHeaders } from '@/resources'
 import flushPromises from 'flush-promises'
@@ -432,6 +432,7 @@ describe('Mhr TableRow tests', () => {
   defaultFlagSet['mhr-exemption-enabled'] = true
 
   beforeEach(async () => {
+    setupMockStaffUser()
     wrapper = await createComponent(
       TableRow,
       {


### PR DESCRIPTION
*Description of changes:*
*Issue #:* /bcgov/entity#15848
- Display Locked badge for QS when MHR is frozen due to affi
- Include disabled states and prevent pre-populated SOG Transfer flow (for QS)

*Issue #:* /bcgov/entity#15848
- Bug fix for setting business partyType
- Include net-new validation to prevent action on HomeOwner groups in Death Transfers when the Whole Group/SO/JT are all businesses. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
