### PR TITLE
Unit note conditionally include person giving notice.

### DIFF
--- a/mhr_api/tests/unit/api/test_admin_registrations.py
+++ b/mhr_api/tests/unit/api/test_admin_registrations.py
@@ -404,18 +404,23 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account):
             assert note_json.get('documentId')
             assert note_json.get('createDateTime')
             assert note_json.get('remarks') is not None
-            assert note_json.get('givingNoticeParty')
-            notice_json = note_json.get('givingNoticeParty')
-            assert notice_json.get('personName')
-            assert notice_json['personName'].get('first')
-            assert notice_json['personName'].get('last')
-            assert notice_json.get('phoneNumber')
-            assert notice_json.get('address')
-            assert notice_json['address']['street']
-            assert notice_json['address']['city']
-            assert notice_json['address']['region']
-            assert notice_json['address']['country']
-            assert notice_json['address']['postalCode'] is not None
+            if note_json.get('documentType') in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC,
+                                                 MhrDocumentTypes.CAUE, MhrDocumentTypes.REG_102, MhrDocumentTypes.NPUB,
+                                                 MhrDocumentTypes.NCON, MhrDocumentTypes.TAXN):
+                assert note_json.get('givingNoticeParty')
+                notice_json = note_json.get('givingNoticeParty')
+                assert notice_json.get('personName')
+                assert notice_json['personName'].get('first')
+                assert notice_json['personName'].get('last')
+                assert notice_json.get('phoneNumber')
+                assert notice_json.get('address')
+                assert notice_json['address']['street']
+                assert notice_json['address']['city']
+                assert notice_json['address']['region']
+                assert notice_json['address']['country']
+                assert notice_json['address']['postalCode'] is not None
+            else:
+                assert 'givingNoticeParty' not in note_json
             assert reg_json.get('documentType')
             assert reg_json.get('documentDescription')
         if json_data['documentType'] in (MhrDocumentTypes.STAT,

--- a/mhr_api/tests/unit/models/test_mhr_note.py
+++ b/mhr_api/tests/unit/models/test_mhr_note.py
@@ -39,6 +39,25 @@ TEST_EXNR_DATA = [
     (True, 'DILAPIDATED', None),
     (True, 'OTHER', 'Some other reason')
  ]
+# testdata pattern is ({doc_type}, {include})
+TEST_GIVING_NOTICE_DATA = [
+    (MhrDocumentTypes.CAU.value, True),
+    (MhrDocumentTypes.CAUC.value, True),
+    (MhrDocumentTypes.CAUE.value, True),
+    (MhrDocumentTypes.NPUB.value, True),
+    (MhrDocumentTypes.NCON.value, True),
+    (MhrDocumentTypes.REG_102.value, True),
+    (MhrDocumentTypes.TAXN.value, True),
+    (MhrDocumentTypes.EXNR.value, False),
+    (MhrDocumentTypes.NCAN.value, False),
+    (MhrDocumentTypes.NRED.value, False),
+    (MhrDocumentTypes.STAT.value, False),
+    (MhrDocumentTypes.REST.value, False),
+    (MhrDocumentTypes.REGC.value, False),
+    (MhrDocumentTypes.EXRS.value, False),
+    (MhrDocumentTypes.REG_103.value, False),
+    (MhrDocumentTypes.REG_103E.value, False)
+]
 
 TEST_NOTE = MhrNote(id=1,
     status_type='ACTIVE',
@@ -118,6 +137,19 @@ def test_find_by_change_registration_id(session, id, has_results):
         assert not note.expiry_date
     else:
         assert not notes
+ 
+
+@pytest.mark.parametrize('doc_type, include', TEST_GIVING_NOTICE_DATA)
+def test_include_giving_notice(session, doc_type, include):
+    """Assert that including person giving notice by doc type works as expected."""
+    notes= MhrNote.find_by_registration_id(200000011)
+    note: MhrNote = notes[0]
+    note.document_type = doc_type
+    note_json = note.json
+    if include:
+        assert note_json.get('givingNoticeParty')
+    else:
+        assert 'givingNoticeParty' not in note_json
 
 
 def test_note_json(session):

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -653,7 +653,14 @@ def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, ac
                 assert note.get('createDateTime')
                 assert note.get('status')
                 assert 'remarks' in note
-                assert note.get('givingNoticeParty')
+                if note.get('documentType') in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC,
+                                                MhrDocumentTypes.CAUE,
+                                                MhrDocumentTypes.REG_102, MhrDocumentTypes.NPUB,
+                                                MhrDocumentTypes.NCON,
+                                                MhrDocumentTypes.TAXN):
+                    assert note.get('givingNoticeParty')
+                else:
+                    assert 'givingNoticeParty' not in note
             else:
                 assert note.get('documentType')
                 assert note.get('documentDescription')
@@ -686,7 +693,12 @@ def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, ac
             assert note.get('createDateTime')
             assert note.get('status')
             assert 'remarks' in note
-            assert note.get('givingNoticeParty')
+            if note.get('documentType') in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC,
+                                            MhrDocumentTypes.CAUE,
+                                            MhrDocumentTypes.REG_102, MhrDocumentTypes.NPUB,
+                                            MhrDocumentTypes.NCON,
+                                            MhrDocumentTypes.TAXN):
+                assert note.get('givingNoticeParty')
         if ncan_doc_id:
             assert has_ncan
     else:

--- a/mhr_api/tests/unit/models/test_search_result.py
+++ b/mhr_api/tests/unit/models/test_search_result.py
@@ -26,6 +26,7 @@ import pytest
 from flask import current_app
 
 from mhr_api.models import SearchResult, SearchRequest
+from mhr_api.models.type_tables import MhrDocumentTypes
 from mhr_api.exceptions import BusinessException
 from mhr_api.resources.v1.search_results import get_payment_details
 
@@ -474,7 +475,10 @@ def test_search_notes(session, mhr_num, has_notes, ncan_doc_id):
             assert note.get('createDateTime')
             assert note.get('status')
             assert 'remarks' in note
-            assert note.get('givingNoticeParty')
+            if note.get('documentType') in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE,
+                                            MhrDocumentTypes.REG_102, MhrDocumentTypes.NPUB, MhrDocumentTypes.NCON,
+                                            MhrDocumentTypes.TAXN):
+                assert note.get('givingNoticeParty')
         if ncan_doc_id:
             assert has_ncan
     else:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20615

*Description of changes:*
- Unit note registration/search json conditionally include by document type the person giving notice information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
