### PR TITLE
Staff misc transfer data validation updates.

### DIFF
--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -92,6 +92,7 @@ EXNR_DESTROYED_INVALID = 'Non-residential exemption destroyed reason (note nonRe
     'Allowed values are BURNT, DISMANTLED, DILAPIDATED, or OTHER. '
 EXNR_CONVERTED_INVALID = 'Non-residential exemption converted reason (note nonResidentialReason) is invalid. ' + \
     'Allowed values are OFFICE, STORAGE_SHED, BUNKHOUSE, or OTHER. '
+TRANS_DOC_TYPE_NOT_ALLOWED = 'The transferDocumentType is only allowed with BC Registries staff TRANS registrations. '
 
 PPR_SECURITY_AGREEMENT = ' SA TA TG TM '
 
@@ -163,6 +164,8 @@ def validate_transfer(registration: MhrRegistration,  # pylint: disable=too-many
                 error_msg += TRAN_QUALIFIED_DELETE
         if reg_type != MhrRegistrationTypes.TRANS and json_data.get('transferDocumentType'):
             error_msg += TRANS_DOC_TYPE_INVALID
+        elif not staff and json_data.get('transferDocumentType'):
+            error_msg += TRANS_DOC_TYPE_NOT_ALLOWED
         if reg_utils.is_transfer_due_to_death(json_data.get('registrationType')):
             error_msg += validate_transfer_death(registration, json_data, group, active_group_count)
     except Exception as validation_exception:   # noqa: B902; eat all errors
@@ -596,7 +599,7 @@ def validate_owner_party_type(json_data,  # pylint: disable=too-many-branches
                         party_type in (MhrPartyTypes.ADMINISTRATOR, MhrPartyTypes.EXECUTOR,
                                        MhrPartyTypes.TRUST, MhrPartyTypes.TRUSTEE):
                     error_msg += OWNER_DESCRIPTION_REQUIRED
-                if not new and not owner_death and party_type and \
+                if not new and not owner_death and not json_data.get('transferDocumentType') and party_type and \
                         party_type in (MhrPartyTypes.ADMINISTRATOR, MhrPartyTypes.EXECUTOR,
                                        MhrPartyTypes.TRUST, MhrPartyTypes.TRUSTEE):
                     error_msg += TRANSFER_PARTY_TYPE_INVALID

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.6'  # pylint: disable=invalid-name
+__version__ = '1.8.7'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20810

*Description of changes:*
- If a staff TRANS registration includes a valid transferDocumentType, allow new owners to be any party type (ADMINISTRATOR, EXECUTOR, TRUSTEE).
- Only allow TRANS registrations to include a transferDocumentType for registries staff.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
