### PR TITLE
Update Unit Note dropdown for Exempt MHRs

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.84",
+  "version": "3.0.85",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.0.84",
+      "version": "3.0.85",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.0.84",
+  "version": "3.0.85",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -868,7 +868,8 @@ export default defineComponent({
         }
       }
       ),
-      hasActiveExemption: computed((): boolean => !!getActiveExemption()),
+      hasActiveExemption: computed((): boolean => !!getActiveExemption() ||
+        getMhrInformation.value.statusType === MhApiStatusTypes.EXEMPT),
       transferRequiredDialogOptions: computed((): DialogOptionsIF => {
         transferRequiredDialog.text =
           transferRequiredDialog.text.replace('mhr_number', getMhrInformation.value.mhrNumber)


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#19180

*Description of changes:*
- Show correct Unit Note dropdown for Exempt MHRs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
