### PR TITLE
Fix permit registration report location missing legal description

### DIFF
--- a/mhr_api/report-templates/exemptionV2.html
+++ b/mhr_api/report-templates/exemptionV2.html
@@ -90,15 +90,26 @@
 
     <div class="separator mt-5"></div>
     <div class="section-data mt-3">
-      Exempted pursuant to section 21 of the Manufactured Home Act by an order of the Registrar dated {{createDateTime}} on Document Registration Number {{documentRegistrationNumber}}.
+      {% if registrationType == 'EXEMPTION_NON_RES' %}
+        Exempted pursuant to section 21 of the Manufactured Home Act by an order of the Registrar dated {{createDateTime}} 
+        on Document Registration Number {{documentRegistrationNumber}}.
+      {% else %}
+        Pursuant to section 21 of the Manufactured Home Act, this manufactured home is exempted from the act except section 32 by an order of the Registrar 
+        dated {{createDateTime}} on Document Registration Number {{documentRegistrationNumber}}.
+      {% endif %}  
     </div>
 
     <p style="page-break-before: always" ></p>
     <div class="no-page-break">
       <div class="section-title mt-5">Exemption Order</div>
       <div class="section-data mt-3">
-        <span class="bold">I ORDER,</span> under section 21 of the Manufactured Home Act, that the manufactured home registered 
-        under number {{mhrNumber}} be exempt from the Act. The exemption was processed under document registration number {{documentRegistrationNumber}}.
+        {% if registrationType == 'EXEMPTION_NON_RES' %}
+          <span class="bold">I ORDER,</span> under section 21 of the Manufactured Home Act, that the manufactured home registered 
+          under number {{mhrNumber}} be exempt from the Act. The exemption was processed under document registration number {{documentRegistrationNumber}}.
+        {% else %}
+          <span class="bold">I ORDER,</span> under section 21 of the Manufactured Home Act, that the manufactured home registered 
+            under number {{mhrNumber}} be exempt from the Act except section 32. The exemption was processed under document registration number {{documentRegistrationNumber}}.
+        {% endif %}
       </div>
       <div class="section-data mt-3">
         {% if registrationType == 'EXEMPTION_NON_RES' %}

--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -115,7 +115,7 @@
                     {{location.bandName}}&nbsp;
                 {% endif %}
                 {% if location.reserveNumber is defined and location.reserveNumber != '' %}
-                    {{location.reserveNumber}}&nbsp;
+                    RESERVATION #{{location.reserveNumber}}&nbsp;
                 {% endif %}
                 {% if location.additionalDescription is defined and location.additionalDescription != '' %}
                     {{ location.additionalDescription }}
@@ -177,7 +177,7 @@
                         {{location.bandName}}&nbsp;
                     {% endif %}
                     {% if location.reserveNumber is defined and location.reserveNumber != '' %}
-                        {{location.reserveNumber}}&nbsp;
+                        RESERVATION #{{location.reserveNumber}}&nbsp;
                     {% endif %}
                     {% if location.additionalDescription is defined and location.additionalDescription != '' %}
                         {{ location.additionalDescription }}

--- a/mhr_api/report-templates/template-parts/search-result/location.html
+++ b/mhr_api/report-templates/template-parts/search-result/location.html
@@ -100,7 +100,7 @@
                         {{detail.location.bandName}}&nbsp;
                     {% endif %}
                     {% if detail.location.reserveNumber is defined and detail.location.reserveNumber != '' %}
-                        {{detail.location.reserveNumber}}&nbsp;
+                        RESERVATION #{{detail.location.reserveNumber}}&nbsp;
                     {% endif %}
                     {% if detail.location.additionalDescription is defined and detail.location.additionalDescription != '' %}
                         {{ detail.location.additionalDescription }}
@@ -165,7 +165,7 @@
                             {{detail.location.bandName}}&nbsp;
                         {% endif %}
                         {% if detail.location.reserveNumber is defined and detail.location.reserveNumber != '' %}
-                            {{detail.location.reserveNumber}}&nbsp;
+                            RESERVATION #{{detail.location.reserveNumber}}&nbsp;
                         {% endif %}
                         {% if detail.location.additionalDescription is defined and detail.location.additionalDescription != '' %}
                             {{ detail.location.additionalDescription }}

--- a/mhr_api/report-templates/template-parts/v2/search-result/registration.html
+++ b/mhr_api/report-templates/template-parts/v2/search-result/registration.html
@@ -87,18 +87,21 @@
           Registration of this home was cancelled under Section 11(1) of the Manufactured Home Act by the Registrar of Manufactured Homes.
         {% elif message.messageType == 'WIDTH' %}
           SPECIAL TRANSPORT RESTRICTIONS APPLY TO THIS HOME DUE TO THE WIDTH. PLEASE CONTACT PROVINCIAL PERMIT CENTRE 1-800-559-9688 FOR FURTHER DETAILS.
-        {% elif message.messageType in ('EXNR', 'EXRS') %}
-          Exempted pursuant to section 21 of the Manufactured Home Act by an order of the Registrar dated {{message.messageDate}} on Document Registration Number {{message.messageId}}.
+        {% elif message.messageType ==  'EXRS' %}
+          Pursuant to section 21 of the Manufactured Home Act, this manufactured home is exempted from the Act except section 32 
+          by an order of the Registrar dated {{message.messageDate}} on Document Registration Number {{message.messageId}}.
           <div class="pt-5">
-            {% if message.messageType == 'EXRS' %}
               If this manufactured home is to be moved from the land to which it is attached, or a person buying it wishes to reflect their name on the 
               ownership in the Manufactured Home Registry, this exemption order expires. The manufactured home will be subject to the   
               Manufactured Home Act, and the registration of this manufactured home must be restored.
-            {% else %}
+          </div>
+        {% elif message.messageType == 'EXNR' %}
+          Exempted pursuant to section 21 of the Manufactured Home Act by an order of the Registrar dated {{message.messageDate}} 
+          on Document Registration Number {{message.messageId}}.
+          <div class="pt-5">
               If this manufactured home returned to use for residential accommodation, or a person buying it wishes to reflect their name on the 
               ownership in the Manufactured Home Registry, this exemption order expires. The manufactured home will be subject to the   
               Manufactured Home Act, and the registration of this manufactured home must be restored.
-            {% endif %}
           </div>
         {% elif message.messageType == 'EXEMPT' %}
           Exempted pursuant to Section 21 of the Manufactured Home Act by an order of the Registrar of the Manufactured Home Registry.

--- a/mhr_api/src/mhr_api/models/db2/location.py
+++ b/mhr_api/src/mhr_api/models/db2/location.py
@@ -381,7 +381,7 @@ class Db2Location(db.Model):
             if new_info.get('bandName'):
                 additional_desc += str(new_info.get('bandName')).strip().upper() + ' '
             if new_info.get('reserveNumber'):
-                additional_desc += str(new_info.get('reserveNumber')).strip() + ' '
+                additional_desc += 'RESERVATION #' + str(new_info.get('reserveNumber')).strip() + ' '
         if new_info.get('additionalDescription'):
             additional_desc += new_info.get('additionalDescription')
         if additional_desc:

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -484,7 +484,8 @@ class Report:  # pylint: disable=too-few-public-methods
 
     def _set_location(self):
         """Set up report location information."""
-        if self._report_key in (ReportTypes.MHR_REGISTRATION, ReportTypes.MHR_EXEMPTION):
+        if self._report_key in (ReportTypes.MHR_REGISTRATION, ReportTypes.MHR_EXEMPTION,
+                                ReportTypes.MHR_ADMIN_REGISTRATION, ReportTypes.MHR_TRANSPORT_PERMIT):
             location = self._report_data.get('location')
             if location.get('lot') or location.get('parcel') or location.get('block') or location.get('districtLot') or\
                     location.get('partOf') or location.get('section') or location.get('township') or \


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20833

*Description of changes:*
- Fix conditional inclusion of the location legal description sub-section in the permit registration report.
- Update the legacy location additional description text when location type is reserve.


*Issue #:* /bcgov/entity#20831

*Description of changes:*
- Distinct exemption text in registration, search reports for residential and non-residential exemptions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
