### PR TITLE
All outputs TC add owner tenancy type.

### DIFF
--- a/mhr_api/report-templates/template-parts/registration/owners.html
+++ b/mhr_api/report-templates/template-parts/registration/owners.html
@@ -37,16 +37,24 @@
 {% if ownerGroups is defined %}
     {% for group in ownerGroups %}
         {% if ownerGroups|length > 1 %}
-        <div class="mt-3">
-            <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
-            {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|capitalize }}
-                    {% if group.interestNumerator is defined and group.interestDenominator is defined %}
-                        {{ group.interestNumerator }}/{{ group.interestDenominator }}
-                    {% endif %}
-                </span>
-            {% endif %}
-        </div>
+            <table class="section-data section-data-table-new mt-3" role="presentation">
+                <tr class="no-page-break">
+                    <td class="col-45">
+                        <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
+                        {% if group.interest is defined and group.interest != '' %}
+                            <span class="section-data">Interest {{ group.interest|capitalize }}
+                                {% if group.interestNumerator is defined and group.interestDenominator is defined %}
+                                    {{ group.interestNumerator }}/{{ group.interestDenominator }}
+                                {% endif %}
+                            </span>
+                        {% endif %}
+                    </td>
+                    <td class="col-55">
+                        <span class="section-sub-title">Group Tenancy Type:&nbsp;</span>
+                        {% if group.owners|length > 1 %}Joint Tenancy{% else %}N/A{% endif %}
+                    </td>
+                </tr>
+            </table>
         {% endif %}
         <table class="section-data section-data-table-new mt-4" role="presentation">
             {% for party in group.owners %}
@@ -99,16 +107,24 @@
     {% for group in addOwnerGroups %}
         {% if group.type == 'COMMON' or (group.interestNumerator is defined and group.interestDenominator is defined and
               group.interestNumerator > 0 and group.interestDenominator > 0) %}
-        <div class="mt-3">
-            <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
-            {% if group.interest is defined and group.interest != '' %}
-                <span class="section-data">Interest {{ group.interest|capitalize }}
-                    {% if group.interestNumerator is defined and group.interestDenominator is defined %}
-                        {{ group.interestNumerator }}/{{ group.interestDenominator }}
-                    {% endif %}
-                </span>
-            {% endif %}
-        </div>
+            <table class="section-data section-data-table-new mt-3" role="presentation">
+                <tr class="no-page-break">
+                    <td class="col-45">
+                        <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
+                        {% if group.interest is defined and group.interest != '' %}
+                            <span class="section-data">Interest {{ group.interest|capitalize }}
+                                {% if group.interestNumerator is defined and group.interestDenominator is defined %}
+                                    {{ group.interestNumerator }}/{{ group.interestDenominator }}
+                                {% endif %}
+                            </span>
+                        {% endif %}
+                    </td>
+                    <td class="col-55">
+                        <span class="section-sub-title">Group Tenancy Type:&nbsp;</span>
+                        {% if group.owners|length > 1 %}Joint Tenancy{% else %}N/A{% endif %}
+                    </td>
+                </tr>
+            </table>
         {% endif %}
     <table class="section-data section-data-table-new mt-4" role="presentation">
         {% for party in group.owners %}

--- a/mhr_api/report-templates/template-parts/search-result/owners.html
+++ b/mhr_api/report-templates/template-parts/search-result/owners.html
@@ -20,17 +20,24 @@
     {% endif %}
     {% for group in detail.ownerGroups %}
         {% if detail.ownerGroups|length > 1 %}
-        <div class="mt-3">
-            <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
-            <span class="section-data">Interest 
-                {% if group.interest is defined and group.interest != '' %}
-                    {{ group.interest|capitalize }}
-                {% endif %}
-                {% if group.interestNumerator is defined and group.interestDenominator is defined %}
-                    {{ group.interestNumerator }}/{{ group.interestDenominator }}
-                {% endif %}
-            </span>
-        </div>
+        <table class="section-data section-data-table-new mt-3" role="presentation">
+            <tr class="no-page-break">
+                <td class="col-45">
+                    <span class="section-sub-title">Group {{ group.groupId }}:&nbsp;</span>
+                    {% if group.interest is defined and group.interest != '' %}
+                        <span class="section-data">Interest {{ group.interest|capitalize }}
+                            {% if group.interestNumerator is defined and group.interestDenominator is defined %}
+                                {{ group.interestNumerator }}/{{ group.interestDenominator }}
+                            {% endif %}
+                        </span>
+                    {% endif %}
+                </td>
+                <td class="col-55">
+                    <span class="section-sub-title">Group Tenancy Type:&nbsp;</span>
+                    {% if group.owners|length > 1 %}Joint Tenancy{% else %}N/A{% endif %}
+                </td>
+            </tr>
+        </table>
         {% endif %}
         <table class="section-data section-data-table-new mt-4" role="presentation">
             {% for party in group.owners %}

--- a/mhr_api/report-templates/template-parts/v2/style.html
+++ b/mhr_api/report-templates/template-parts/v2/style.html
@@ -774,6 +774,8 @@
 	td.col-50 { width: 50%; }
 	td.col-40 { width: 40%; }
 	td.col-60 { width: 60%; }
+	td.col-45 { width: 45%; }
+	td.col-55 { width: 55%; }
 
 	.director-former-name {
 		font-family: 'BC Sans', sans-serif !important;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20879

*Description of changes:*
- In all reports with a tenant in common owner structure, display the owner group tenancy type.
- Example reports attached to ticket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
