### PR TITLE
Mixed Owner Roles Validation

### DIFF
--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -200,10 +200,17 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
 
   const hasMixedOwnersInGroup = (groupId: number): boolean => {
     if (isMhrCorrection) return false
+
     const owners = getGroupById(groupId)?.owners
     if (owners?.length < 2) return false
+
+    // Verify there is at least one unique owner type in the group, as business and individuals can be mixed
+    const hasAdminExecOrTrustee = owners?.some(owner =>
+      [HomeOwnerPartyTypes.TRUSTEE, HomeOwnerPartyTypes.EXECUTOR, HomeOwnerPartyTypes.ADMINISTRATOR]
+        .includes(owner.partyType))
+
     const partyType = owners?.[0].partyType
-    return owners?.some(owner => owner.partyType !== partyType)
+    return hasAdminExecOrTrustee && owners?.some(owner => owner.partyType !== partyType)
   }
   // WORKING WITH GROUPS
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- Small fix to Home Owner Mixed Roles validation in MHR
- Previously fixed an issue where business owners were assigned individual owner partyTypes, this exposed an issue with some validation logic.

![Screenshot 2024-04-17 at 2 01 05 PM](https://github.com/bcgov/ppr/assets/53542131/32883f27-a50f-4ef2-aa70-3320099fcd7f)
![Screenshot 2024-04-17 at 2 00 49 PM](https://github.com/bcgov/ppr/assets/53542131/47388da9-c565-4fc0-81de-d5a770d275f5)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
