### PR TITLE
Fix regc, puba report generation no location change.

### DIFF
--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -485,7 +485,8 @@ class Report:  # pylint: disable=too-few-public-methods
     def _set_location(self):
         """Set up report location information."""
         if self._report_key in (ReportTypes.MHR_REGISTRATION, ReportTypes.MHR_EXEMPTION,
-                                ReportTypes.MHR_ADMIN_REGISTRATION, ReportTypes.MHR_TRANSPORT_PERMIT):
+                                ReportTypes.MHR_ADMIN_REGISTRATION, ReportTypes.MHR_TRANSPORT_PERMIT) and \
+                self._report_data.get('location'):
             location = self._report_data.get('location')
             if location.get('lot') or location.get('parcel') or location.get('block') or location.get('districtLot') or\
                     location.get('partOf') or location.get('section') or location.get('township') or \


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20833

*Description of changes:*
Fix a recent change to report generation location information for REGC, PUBA registrations where there is no location change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
