### PR TITLE
MHR API reregister a cancelled home.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -854,11 +854,15 @@ class Db2Manuhome(db.Model):
             current_app.logger.info(f'registration id={registration.id} no manuhome: nothing to save.')
             return None
         manuhome: Db2Manuhome = registration.manuhome
+        new_doc = registration.documents[0]
+        if new_doc.document_type == MhrDocumentTypes.REREGISTER_C:
+            manuhome.mh_status = Db2Manuhome.StatusTypes.REGISTERED
+            current_app.logger.info(f'Setting cancelled MH status to R for manhomid={manuhome.id}')
+            return manuhome
         now_local = model_utils.to_local_timestamp(registration.registration_ts)
         manuhome.update_date = now_local.date()
         manuhome.update_time = now_local.time()
         manuhome.update_count = manuhome.update_count + 1
-        new_doc = registration.documents[0]
         if new_doc.document_type == MhrDocumentTypes.EXRE:
             manuhome.mh_status = Db2Manuhome.StatusTypes.REGISTERED
             current_app.logger.info(f'Setting MH status to R for manhomid={manuhome.id}')

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -220,6 +220,7 @@ class MhrDocumentTypes(BaseEnum):
     CANCEL_PERMIT = 'CANCEL_PERMIT'
     REGC_STAFF = 'REGC_STAFF'
     REGC_CLIENT = 'REGC_CLIENT'
+    REREGISTER_C = 'REREGISTER_C'
 
 
 class MhrLocationTypes(BaseEnum):

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -359,7 +359,7 @@ def pay_and_save_admin(req: request,  # pylint: disable=too-many-arguments
                                                                                            MhrDocumentTypes.NRED,
                                                                                            MhrDocumentTypes.EXRE):
             save_cancel_note(current_reg, request_json, registration.id)
-        if request_json.get('documentType') == MhrDocumentTypes.EXRE:
+        if request_json.get('documentType') in (MhrDocumentTypes.EXRE, MhrDocumentTypes.REREGISTER_C):
             save_active(current_reg)
         elif request_json.get('documentType') in (MhrDocumentTypes.REGC_CLIENT,
                                                   MhrDocumentTypes.REGC_STAFF,
@@ -543,9 +543,9 @@ def get_registration_report(registration: MhrRegistration,  # pylint: disable=to
             if not model_utils.report_retry_elapsed(report_info.create_ts):
                 current_app.logger.info(f'Pending report generation for reg id={registration_id}.')
                 return report_data, HTTPStatus.ACCEPTED, {'Content-Type': 'application/json'}
-
+            rep_data = report_info.report_data if report_info.report_data else report_data
             current_app.logger.info(f'Retrying report generation for reg id={registration_id}.')
-            raw_data, status_code, headers = get_pdf(report_data,
+            raw_data, status_code, headers = get_pdf(rep_data,
                                                      registration.account_id,
                                                      report_type,
                                                      token)

--- a/mhr_api/src/mhr_api/utils/admin_validator.py
+++ b/mhr_api/src/mhr_api/utils/admin_validator.py
@@ -62,6 +62,9 @@ def validate_admin_reg(registration: MhrRegistration, json_data) -> str:
                                                                  True,
                                                                  MhrRegistrationTypes.REG_STAFF_ADMIN,
                                                                  doc_type)
+        error_msg += validator_utils.validate_draft_state(json_data)
+        if doc_type and doc_type == MhrDocumentTypes.REREGISTER_C:
+            return error_msg
         error_msg += validate_giving_notice(json_data, doc_type)
         if doc_type and doc_type == MhrDocumentTypes.NRED:
             error_msg += validate_nred(registration, json_data)

--- a/mhr_api/src/mhr_api/utils/validator_utils.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils.py
@@ -169,8 +169,8 @@ def validate_registration_state(registration: MhrRegistration, staff: bool, reg_
         return error_msg
     if is_legacy():
         return validator_utils_legacy.validate_registration_state(registration, staff, reg_type, doc_type)
-    if doc_type and doc_type == MhrDocumentTypes.EXRE:
-        return validate_registration_state_exre(registration)
+    if doc_type and doc_type in (MhrDocumentTypes.EXRE, MhrDocumentTypes.REREGISTER_C):
+        return validate_registration_state_reregister(registration, doc_type)
     if reg_type and reg_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
         return validate_registration_state_exemption(registration, reg_type, staff)
     if registration.status_type != MhrRegistrationStatusTypes.ACTIVE:
@@ -199,13 +199,15 @@ def validate_registration_state(registration: MhrRegistration, staff: bool, reg_
     return check_state_note(registration, staff, error_msg, reg_type)
 
 
-def validate_registration_state_exre(registration: MhrRegistration):
-    """Validate registration state for rescind exemption requests."""
+def validate_registration_state_reregister(registration: MhrRegistration, doc_type: str):
+    """Validate registration state for re-register a cancelled/exempt home requests."""
     error_msg = ''
-    if registration.status_type:
-        if registration.status_type == MhrRegistrationStatusTypes.EXEMPT:
-            return error_msg
-        error_msg += STATE_NOT_ALLOWED
+    if not doc_type or not registration.status_type:
+        return error_msg
+    if doc_type == MhrDocumentTypes.EXRE and registration.status_type != MhrRegistrationStatusTypes.EXEMPT:
+        return STATE_NOT_ALLOWED
+    if doc_type == MhrDocumentTypes.REREGISTER_C and registration.status_type != MhrRegistrationStatusTypes.CANCELLED:
+        return STATE_NOT_ALLOWED
     return error_msg
 
 

--- a/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
@@ -45,6 +45,8 @@ def validate_registration_state(registration, staff: bool, reg_type: str, doc_ty
     manuhome: Db2Manuhome = registration.manuhome
     if doc_type and doc_type == MhrDocumentTypes.EXRE:
         return validate_registration_state_exre(manuhome)
+    if doc_type and doc_type == MhrDocumentTypes.REREGISTER_C:
+        return validate_registration_state_reregister(manuhome)
     if reg_type and reg_type in (MhrRegistrationTypes.EXEMPTION_NON_RES, MhrRegistrationTypes.EXEMPTION_RES):
         return validate_registration_state_exemption(manuhome, reg_type, staff)
     if manuhome.mh_status != manuhome.StatusTypes.REGISTERED:
@@ -78,6 +80,14 @@ def validate_registration_state_exre(manuhome: Db2Manuhome):
     """Validate registration state for rescind exemption requests."""
     error_msg = ''
     if manuhome.mh_status == manuhome.StatusTypes.EXEMPT:
+        return error_msg
+    return STATE_NOT_ALLOWED
+
+
+def validate_registration_state_reregister(manuhome: Db2Manuhome):
+    """Validate registration state for re-register a cancelled home requests."""
+    error_msg = ''
+    if manuhome.mh_status == manuhome.StatusTypes.CANCELLED:
         return error_msg
     return STATE_NOT_ALLOWED
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.7'  # pylint: disable=invalid-name
+__version__ = '1.8.8'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_types.py
+++ b/mhr_api/tests/unit/models/test_types.py
@@ -48,7 +48,8 @@ TEST_DOC_TYPES = [
     (MhrDocumentTypes.ABAN.value, True),
     (MhrDocumentTypes.COU.value, True),
     (MhrDocumentTypes.REGC_STAFF.value, True),
-    (MhrDocumentTypes.REGC_CLIENT.value, True)
+    (MhrDocumentTypes.REGC_CLIENT.value, True),
+    (MhrDocumentTypes.REREGISTER_C.value, True)
 ]
 
 

--- a/mhr_api/tests/unit/utils/test_admin_validator.py
+++ b/mhr_api/tests/unit/utils/test_admin_validator.py
@@ -414,6 +414,31 @@ TEST_AMEND_CORRECT_DATA = [
     (False, '000919', 'REGC_STAFF', None, None, ADD_OG_INVALID_JT, DELETE_OG_VALID,
      validator_utils.OWNERS_JOINT_INVALID)
 ]
+# test data pattern is ({description}, {valid}, {mhr_num}, {account}, {message_content})
+TEST_DATA_REREGISTER = [
+    ('Valid state', True, '000913', 'PS12345', None),
+    ('Invalid EXEMPT', False, '000912', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
+    ('Invalid FROZEN', False, '000917', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
+    ('Invalid ACTIVE', False, '000914', 'PS12345', validator_utils.STATE_NOT_ALLOWED)
+]
+
+
+@pytest.mark.parametrize('desc,valid,mhr_num,account,message_content', TEST_DATA_REREGISTER)
+def test_validate_reregister(session, desc, valid, mhr_num, account, message_content):
+    """Assert that REREGISTER_C document type validation works as expected."""
+    # setup
+    json_data = get_valid_registration()
+    json_data['documentType'] = MhrDocumentTypes.REREGISTER_C
+    del json_data['note']
+    registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account)
+    error_msg = validator.validate_admin_reg(registration, json_data)
+    # current_app.logger.debug(error_msg)
+    if valid:
+        assert error_msg == ''
+    else:
+        assert error_msg != ''
+        if message_content:
+            assert error_msg.find(message_content) != -1
 
 
 @pytest.mark.parametrize('desc,valid,update_doc_id,mhr_num,account,message_content', TEST_DATA_EXRE)
@@ -430,7 +455,7 @@ def test_validate_exre(session, desc, valid, update_doc_id, mhr_num, account, me
         json_data['note']['documentType'] = MhrDocumentTypes.EXRE
     registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account)
     error_msg = validator.validate_admin_reg(registration, json_data)
-    current_app.logger.debug(error_msg)
+    # current_app.logger.debug(error_msg)
     if valid:
         assert error_msg == ''
     else:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20898

*Description of changes:*
- Add admin registration data validation check on a stale draft.

*Issue #:* /bcgov/entity#20899
- Add new doc type, new staff admin re-register a cancelled home. 
- Staff legacy registrations generate registration report update. 

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
