### PR TITLE
Fix Tenancy Type for Business and Individual roles

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -96,7 +96,9 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
       // git first group since there is only one group in this case
       const ownerTypes = getTransferOrRegistrationHomeOwnerGroups()[0].owners
         .filter(owner => owner.action !== ActionTypes.REMOVED)
-        .map(owner => owner.partyType)
+        .map(owner => owner.partyType ===
+          // treat BUsiness Owner as Individual, so it does not trigger mixed owner condition
+          HomeOwnerPartyTypes.OWNER_BUS ? HomeOwnerPartyTypes.OWNER_IND : owner.partyType)
 
       const hasMixedOwners = (isMhrCorrection || ownerTypes.length === 1)
         ? false


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#18733

*Description of changes:*
- Fix Home Tenancy Type by treating Business and Individual home owners as the same type

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
