### PR TITLE
MHR improve staff generate legacy reg reports

### DIFF
--- a/mhr_api/report-templates/registrationCoverV2.html
+++ b/mhr_api/report-templates/registrationCoverV2.html
@@ -11,6 +11,7 @@
   </head>
   <body>
     <div class="container ml-3 mt-4">
+      {% if regCover %}        
         {% if regCover.line5 is not defined %}        
           {% if regCover.line3 %}
           <table class="cover-data-table mt-0" role="presentation">
@@ -64,7 +65,8 @@
                 </td>
             </tr>  
           </table> 
-        {% endif %}          
+        {% endif %}
+      {% endif %}
     </div>
     <div class="container mt-11 ml-3">
       {% if nocLocation is not defined or not nocLocation %}    

--- a/mhr_api/src/mhr_api/reports/__init__.py
+++ b/mhr_api/src/mhr_api/reports/__init__.py
@@ -15,10 +15,10 @@ from flask import current_app, jsonify
 from flask_babel import _
 from mhr_api.exceptions import BusinessException, ResourceErrorCodes
 from mhr_api.resources.utils import get_account_name
+from mhr_api.services.authz import STAFF_ROLE
 
 from .report import Report
 from .v2.report import Report as ReportV2
-from .v2.report_utils import ReportTypes
 
 
 REPORT_VERSION_V2 = '2'
@@ -28,7 +28,9 @@ DEFAULT_ERROR_MSG = '{code}: Data related error generating report.'.format(code=
 def get_pdf(report_data, account_id, report_type=None, token=None):
     """Generate a PDF of the provided report type using the provided data."""
     try:
-        account_name = get_account_name(token, account_id)
+        account_name: str = ''
+        if account_id and account_id not in ('0', STAFF_ROLE):
+            account_name = get_account_name(token, account_id)
         if current_app.config.get('REPORT_VERSION', REPORT_VERSION_V2) == REPORT_VERSION_V2:
             return ReportV2(report_data, account_id, report_type, account_name).get_pdf()
         return Report(report_data, account_id, report_type, account_name).get_pdf()

--- a/mhr_api/src/mhr_api/reports/__init__.py
+++ b/mhr_api/src/mhr_api/reports/__init__.py
@@ -19,6 +19,7 @@ from mhr_api.services.authz import STAFF_ROLE
 
 from .report import Report
 from .v2.report import Report as ReportV2
+from .v2.report_utils import ReportTypes
 
 
 REPORT_VERSION_V2 = '2'

--- a/mhr_api/src/mhr_api/resources/v1/documents.py
+++ b/mhr_api/src/mhr_api/resources/v1/documents.py
@@ -22,7 +22,7 @@ from mhr_api.utils.auth import jwt
 from mhr_api.exceptions import BusinessException, DatabaseException
 from mhr_api.models import MhrRegistration
 from mhr_api.models.type_tables import MhrRegistrationTypes
-from mhr_api.services.authz import authorized, is_all_staff_account, is_staff
+from mhr_api.services.authz import authorized, is_all_staff_account, is_staff, get_group
 from mhr_api.reports.v2.report_utils import ReportTypes
 from mhr_api.resources import utils as resource_utils, registration_utils as reg_utils
 from mhr_api.utils import validator_utils as registration_validator
@@ -118,6 +118,8 @@ def get_documents(document_id: str):  # pylint: disable=too-many-return-statemen
         if resource_utils.is_pdf(request):
             rep_type = map_report_type(response_json, is_staff(jwt))
             current_app.logger.info(f'Fetching registration report for doc ID= {document_id} rep_type={rep_type}.')
+            response_json['usergroup'] = get_group(jwt)
+            response_json['username'] = response_json.get('affirmByName', '')
             return reg_utils.get_registration_report(registration,
                                                      response_json,
                                                      rep_type,

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.8'  # pylint: disable=invalid-name
+__version__ = '1.8.9'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_mhr_registration.py
+++ b/mhr_api/tests/unit/models/test_mhr_registration.py
@@ -687,7 +687,7 @@ def test_find_by_mhr_number_note(session, mhr_num, staff, current, has_notes, ac
     assert reg_json.get('hasCaution') == has_caution
     # search version
     reg_json = registration.registration_json
-    if has_notes and mhr_num not in ('000930', '000909'):
+    if has_notes and mhr_num not in ('000930', '000909', '000910'):
         assert reg_json.get('notes')
         has_ncan: bool = False
         for note in reg_json.get('notes'):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20948

*Description of changes:*
- Generate staff reg report when conversion registration has no submitting party.
- Report data setup use current information at the time of the registration
- Map registration type/doc type to the correct report template when creating legacy registration reports. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
