### PR TITLE
Cancel transport permit updates.

### DIFF
--- a/mhr_api/report-templates/adminRegistrationV2.html
+++ b/mhr_api/report-templates/adminRegistrationV2.html
@@ -30,6 +30,12 @@
         </td>
       </tr>
       {% if nocLocation is not defined or not nocLocation %}    
+        {% if documentType is defined and documentType == 'CANCEL_PERMIT' %}
+          <tr>
+            <td>Registration Type:</td>
+            <td>{{ documentDescription|title }}</td>
+          </tr>
+        {% endif %}
         <tr>
           <td>Document Registration Number:</td>
           <td>
@@ -40,37 +46,10 @@
             {% endif %}
           </td>
         </tr>
-        {% if documentType is defined and documentType == 'CANCEL_PERMIT' %}
-          <tr>
-            <td>Transport Permit Number:</td>
-            <td>
-              {% if note is defined and note.cancelledDocumentRegistrationNumber is defined %}
-                {{ note.cancelledDocumentRegistrationNumber }}
-              {% else %}
-                N/A
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td>Transport Permit Date and Time of Issue:</td>
-            <td>
-              {% if note is defined and note.createDateTime is defined %}
-                {{ note.createDateTime }}
-              {% else %}
-                N/A
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td>Expiry Date:</td>
-            <td>N/A</td>
-         </tr>
-        {% else %}
-          <tr>
-            <td>Document Registration Date and Time:</td>
-            <td>{{createDateTime}}</td>
-          </tr>        
-        {% endif %}
+        <tr>
+          <td>Document Registration Date and Time:</td>
+          <td>{{createDateTime}}</td>
+        </tr>        
 
         {% if documentType is not defined or documentType not in ('STAT', 'PUBA', 'REGC_CLIENT', 'REGC_STAFF', 'CANCEL_PERMIT') %}
         <tr>
@@ -178,6 +157,192 @@
       {% if location is defined %}
         [[registration/location.html]]
       {% endif %}
+
+      {% if  documentType is defined and documentType == 'CANCEL_PERMIT' %}
+        <div class="separator mt-5"></div>
+        <div class="section-title mt-5">Cancelled Transport Permit Information</div>
+        <div class="section-data mt-3">
+          Transport permit {{note.cancelledDocumentId}} that was registered on {{note.cancelledDateTime}} was cancelled under 
+          document registration number {{note.cancelledDocumentRegistrationNumber}}.
+        </div>
+        {% if previousLocation is defined %}
+          <div class="section-title mt-5">Location Change <span class="pl-2">&nbsp;</span><span class="section-label">CANCELLED</span> </div>
+
+          <table class="section-data section-data-table-new mt-4" role="presentation">
+            {% if previousLocation.dealerName is defined and previousLocation.dealerName != '' %}
+                <tr class="no-page-break">
+                    <td class="col-33">
+                        <div class="section-sub-title">Dealer/Manufacturer</div>
+                        <div class="pt-2">{{  previousLocation.dealerName }}</div>
+                    </td>
+                    <td class="col-33">
+                        <div class="section-sub-title">Address</div>
+                        <div class="pt-2">{{ previousLocation.address.street }}</div>
+                        <div>{{ previousLocation.address.streetAdditional }}</div>
+                        <div>{{ previousLocation.address.city }} 
+                            {{ previousLocation.address.region }}</div>
+                        <div>
+                            {{ previousLocation.address.country }}
+                        </div>
+                    </td>
+                    <td class="col-33">&nbsp;</td>
+                </tr>
+            {% elif previousLocation.parkName is defined and previousLocation.parkName != '' %}
+                <tr class="no-page-break">
+                    <td class="col-33">
+                        <div class="section-sub-title">Park Name</div>
+                        <div class="pt-2">{{ previousLocation.parkName }}</div>
+                    </td>
+                    <td class="col-33">
+                        <div class="section-sub-title">Address</div>
+                        <div class="pt-2">{{ previousLocation.address.street }}</div>
+                        <div>{{ previousLocation.address.streetAdditional }}</div>
+                        <div>{{ previousLocation.address.city }} 
+                            {{ previousLocation.address.region }}</div>
+                        <div>
+                            {{ previousLocation.address.country }}
+                        </div>
+                    </td>
+                    <td class="col-33">
+                        <div class="section-sub-title">Pad</div>
+                        {% if previousLocation.pad is defined and previousLocation.pad != '' %}
+                            <div class="pt-2">{{ previousLocation.pad }}</div>
+                        {% else %} 
+                            <div class="pt-2">N/A</div>
+                        {% endif %} 
+                    </td>
+                </tr>
+            {% else %} 
+                <tr class="no-page-break">
+                    <td class="col-33">
+                        <div class="section-sub-title">Location Type</div>
+                        <div class="pt-2">
+                            {% if previousLocation.locationType is defined and previousLocation.locationType == 'RESERVE' %}
+                                INDIAN RESERVE
+                            {% elif previousLocation.locationType is defined and previousLocation.locationType == 'STRATA' %}
+                                STRATA
+                            {% elif previousLocation.locationType is defined and previousLocation.locationType == 'OTHER' %}
+                                OTHER
+                            {% else %}
+                                N/A 
+                            {% endif %} 
+                        </div>
+                    </td>
+                    <td class="col-33">
+                        <div class="section-sub-title">Address</div>
+                        <div class="pt-2">{{ previousLocation.address.street }}</div>
+                        <div>{{ previousLocation.address.streetAdditional }}</div>
+                        <div>{{ previousLocation.address.city }} 
+                            {{ previousLocation.address.region }}</div>
+                        <div>
+                            {{ previousLocation.address.country }}
+                        </div>
+                    </td>
+                    <td class="col-33">
+                        {% if (previousLocation.pidNumber is defined and previousLocation.pidNumber != '') or previousLocation.hasLTSAInfo %}
+                            <div class="section-sub-title">Parcel ID Number</div>
+                            {% if previousLocation.pidNumber is defined and previousLocation.pidNumber != '' %}
+                                <div class="pt-2">{{ previousLocation.pidNumber }}</div>
+                            {% else %}
+                                <div class="pt-2">N/A</div>
+                            {% endif %} 
+                        {% endif %} 
+                    </td>
+                </tr>
+            {% endif %}
+        
+            {% if previousLocation.legalDescription is defined and previousLocation.legalDescription != '' %}
+            <tr class="no-page-break">
+                <td class="pt-3 pb-2">
+                    <div class="section-sub-title">Legal Land Description</div>
+                </td>
+            </tr>
+            <tr class="no-page-break">
+                <td colspan="3">
+                    <div>{{ previousLocation.legalDescription }}</div>
+                    <div>
+                        {% if previousLocation.bandName is defined and previousLocation.bandName != '' %}
+                            {{previousLocation.bandName}}&nbsp;
+                        {% endif %}
+                        {% if previousLocation.reserveNumber is defined and previousLocation.reserveNumber != '' %}
+                            RESERVATION #{{previousLocation.reserveNumber}}&nbsp;
+                        {% endif %}
+                        {% if previousLocation.additionalDescription is defined and previousLocation.additionalDescription != '' %}
+                            {{ previousLocation.additionalDescription }}
+                        {% endif %} 
+                    </div>
+                </td>
+            </tr>
+            {% elif previousLocation.hasLTSAInfo or (previousLocation.additionalDescription is defined and previousLocation.additionalDescription != '') %}
+            <tr class="no-page-break">
+                <td class="pt-3 pb-2">
+                    <div class="section-sub-title">Legal Land Description</div>
+                </td>
+            </tr>
+            <tr class="no-page-break">
+                <td class="col-33">
+                    {% if previousLocation.lot is defined and previousLocation.lot != '' %}
+                        <div>{% if previousLocation.locationType is defined and previousLocation.locationType == 'STRATA' %}STRATA {% endif %} LOT: {{ previousLocation.lot }}</div>
+                    {% endif %} 
+                    {% if previousLocation.parcel is defined and previousLocation.parcel != '' %}
+                        <div>PARCEL: {{ previousLocation.parcel }}</div>
+                    {% endif %} 
+                    {% if previousLocation.block is defined and previousLocation.block != '' %}
+                        <div>BLOCK: {{ previousLocation.block }}</div>
+                    {% endif %} 
+                    {% if previousLocation.districtLot is defined and previousLocation.districtLot != '' %}
+                        <div>DISTRICT LOT: {{ previousLocation.districtLot }}</div>
+                    {% endif %} 
+                    {% if previousLocation.partOf is defined and previousLocation.partOf != '' %}
+                        <div>PART OF: {{ previousLocation.partOf }}</div>
+                    {% endif %} 
+                    {% if previousLocation.section is defined and previousLocation.section != '' %}
+                        <div>SECTION: {{ previousLocation.section }}</div>
+                    {% endif %} 
+                    {% if previousLocation.township is defined and previousLocation.township != '' %}
+                        <div>TOWNSHIP: {{ previousLocation.township }}</div>
+                    {% endif %} 
+                    {% if previousLocation.range is defined and previousLocation.range != '' %}
+                        <div>RANGE: {{ previousLocation.range }}</div>
+                    {% endif %} 
+                    {% if previousLocation.meridian is defined and previousLocation.meridian != '' %}
+                        <div>MERIDIAN: {{ previousLocation.meridian }}</div>
+                    {% endif %} 
+                    {% if previousLocation.landDistrict is defined and previousLocation.landDistrict != '' %}
+                        <div>LAND DISTRICT: {{ previousLocation.landDistrict }}</div>
+                    {% endif %} 
+                    {% if previousLocation.plan is defined and previousLocation.plan != '' %}
+                        <div>{% if previousLocation.locationType is defined and previousLocation.locationType == 'STRATA' %}STRATA {% endif %} PLAN: {{ previousLocation.plan }}</div>
+                    {% endif %} 
+                </td>
+                <td colspan="2">
+                    {% if previousLocation.exceptionPlan is defined and previousLocation.exceptionPlan != '' %}
+                        <div>EXCEPT PLAN:</div>
+                        <div class="pb-2">{{ previousLocation.exceptionPlan }}</div>
+                    {% endif %} 
+                    {% if (previousLocation.additionalDescription is defined and previousLocation.additionalDescription != '')  or (previousLocation.bandName is defined and previousLocation.bandName != '') or (previousLocation.reserveNumber is defined and previousLocation.reserveNumber != '') %}
+                        <div>ADDITIONAL DESCRIPTION:</div>
+                        <div>
+                            {% if previousLocation.bandName is defined and previousLocation.bandName != '' %}
+                                {{previousLocation.bandName}}&nbsp;
+                            {% endif %}
+                            {% if previousLocation.reserveNumber is defined and previousLocation.reserveNumber != '' %}
+                                RESERVATION #{{previousLocation.reserveNumber}}&nbsp;
+                            {% endif %}
+                            {% if previousLocation.additionalDescription is defined and previousLocation.additionalDescription != '' %}
+                                {{ previousLocation.additionalDescription }}
+                            {% endif %} 
+                        </div>
+                    {% endif %} 
+                </td>
+            </tr>
+            {% endif %}
+            </table>
+              
+        {% endif %}
+
+        {% endif %}
+
 
       {% if description is defined and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF') %}
         [[registration/details.html]]

--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -7,7 +7,7 @@
     {% elif amendment is defined and amendment %}
         <div class="section-title mt-5">New Registered Location<span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span></div>
     {% elif registrationType not in ('EXEMPTION_RES', 'EXEMPTION_NON_RES') %}
-        {% if documentType is not defined or documentType not in ('CANCEL_PERMIT', 'REGC_STAFF', 'REGC_CLIENT', 'PUBA') %}
+        {% if documentType is not defined or documentType not in ('REGC_STAFF', 'REGC_CLIENT', 'PUBA') %}
             <div class="separator mt-5"></div>
         {% endif %}
         <div class="section-title mt-3">Registered Location
@@ -15,6 +15,8 @@
                 <span class="pl-2">&nbsp;</span><span class="section-label">CORRECTED</span>            
             {% elif documentType is defined and documentType == 'PUBA' %}
                 <span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span>            
+            {% elif documentType is defined and documentType == 'CANCEL_PERMIT' %}
+                <span class="pl-2">&nbsp;</span><span class="section-label">RESTORED</span>            
             {% endif %}
         </div>
     {% endif %}

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -483,9 +483,9 @@ def build_account_query_filter(query_text: str, params: AccountRegistrationParam
 
 def __get_reg_type_filter(filter_value: str, collapse: bool, doc_types) -> dict:
     """Get the legacy document type from the filter value."""
-    new_doc_type: str = 'REG_101'
+    new_doc_type: str = 'missing'
     for doc_rec in doc_types:
-        if filter_value == doc_rec.document_type_desc:
+        if filter_value in (doc_rec.document_type_desc, doc_rec.document_type):
             new_doc_type = doc_rec.document_type
             break
     doc_type: str = TO_LEGACY_DOC_TYPE.get(new_doc_type, new_doc_type)
@@ -667,7 +667,8 @@ def __build_summary(row, add_in_user_list: bool = True, mhr_list=None):
         summary = __get_caution_info(summary, row)
     elif summary['documentType'] in (Db2Document.DocumentTypes.PERMIT,
                                      Db2Document.DocumentTypes.PERMIT_TRIM,
-                                     MhrDocumentTypes.AMEND_PERMIT.value) and row[12]:
+                                     MhrDocumentTypes.AMEND_PERMIT.value) and row[12] and \
+            (not row[11] or str(row[11]) != 'C'):
         expiry = row[12]
         summary['expireDays'] = model_utils.expiry_date_days(expiry)
     summary = __set_frozen_status(summary, row)

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -170,13 +170,10 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 reg_json = reg_json_utils.set_note_json(self, reg_json)
             elif self.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and \
                     (not self.notes or doc_json.get('documentType') in (MhrDocumentTypes.NCAN,
-                                                                        MhrDocumentTypes.CANCEL_PERMIT,
                                                                         MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE)):
                 reg_json['documentType'] = doc_json.get('documentType')
                 del reg_json['declaredValue']
-                if doc_json.get('documentType') in (MhrDocumentTypes.NCAN, MhrDocumentTypes.CANCEL_PERMIT,
-                                                    MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE):
-                    reg_json = reg_json_utils.set_note_json(self, reg_json)
+                reg_json = reg_json_utils.set_note_json(self, reg_json)
             elif self.registration_type == MhrRegistrationTypes.REG_NOTE:
                 reg_json = reg_json_utils.set_note_json(self, reg_json)
                 del reg_json['documentId']
@@ -356,7 +353,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 json_data['newLocation']['address']['region'] == model_utils.PROVINCE_BC:
             self.status_type = MhrRegistrationStatusTypes.ACTIVE
             current_app.logger.info('Amend Transport Permit new location in BC, updating EXEMPT status to ACTIVE.')
-        elif json_data and json_data['newLocation']['address']['region'] != model_utils.PROVINCE_BC:
+        elif json_data and json_data['newLocation']['address']['region'] != model_utils.PROVINCE_BC and \
+                json_data.get('documentType', '') != MhrDocumentTypes.CANCEL_PERMIT:
             self.status_type = MhrRegistrationStatusTypes.EXEMPT
             current_app.logger.info('Transport Permit new location out of province, updating status to EXEMPT.')
         db.session.commit()

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -771,7 +771,8 @@ def __build_summary(row, account_id: str, staff: bool, add_in_user_list: bool = 
         summary = __get_cancel_info(summary, row)
     elif doc_type in (MhrDocumentTypes.CAU, MhrDocumentTypes.CAUC, MhrDocumentTypes.CAUE):
         summary = __get_caution_info(summary, row, doc_type)
-    elif doc_type in (MhrDocumentTypes.REG_103, MhrDocumentTypes.AMEND_PERMIT) and row[12]:
+    elif doc_type in (MhrDocumentTypes.REG_103, MhrDocumentTypes.AMEND_PERMIT) and row[12] and \
+            (not row[11] or row[11] != MhrNoteStatusTypes.CANCELLED):
         expiry = row[12]
         summary['expireDays'] = model_utils.expiry_ts_days(expiry)
     summary = __set_frozen_status(summary, row, staff)
@@ -952,9 +953,9 @@ def build_account_query_filter(query_text: str, params: AccountRegistrationParam
 def __get_reg_type_filter(filter_value: str, collapse: bool) -> dict:
     """Get the document type from the filter value."""
     doc_types = MhrDocumentType.find_all()
-    doc_type: str = MhrDocumentTypes.REG_101
+    doc_type: str = 'missing'
     for doc_rec in doc_types:
-        if filter_value == doc_rec.document_type_desc:
+        if filter_value in (doc_rec.document_type_desc, doc_rec.document_type):
             doc_type = doc_rec.document_type
             break
     if collapse:

--- a/mhr_api/src/mhr_api/resources/utils.py
+++ b/mhr_api/src/mhr_api/resources/utils.py
@@ -283,9 +283,9 @@ def validate_note(registration, json_data, is_staff: bool, group: str):
     return note_validator.validate_note(registration, json_data, is_staff, group)
 
 
-def validate_admin_registration(registration, json_data):
+def validate_admin_registration(registration, json_data, is_staff: bool):
     """Perform non-schema extra validation on an admin registration."""
-    return admin_validator.validate_admin_reg(registration, json_data)
+    return admin_validator.validate_admin_reg(registration, json_data, is_staff)
 
 
 def valid_api_key(req) -> bool:

--- a/mhr_api/src/mhr_api/resources/v1/permits.py
+++ b/mhr_api/src/mhr_api/resources/v1/permits.py
@@ -57,9 +57,10 @@ def post_permits(mhr_number: str):  # pylint: disable=too-many-return-statements
             return verify_error_response
 
         # Not found or not allowed to access throw exceptions.
+        is_all_staff: bool = is_staff(jwt) or is_all_staff_account(account_id)
         current_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number,
                                                                               account_id,
-                                                                              is_all_staff_account(account_id))
+                                                                              is_all_staff)
         request_json = request.get_json(silent=True)
         # Validate request against the schema.
         current_app.logger.debug(f'Extra validation on transport permit json for {mhr_number}')
@@ -76,7 +77,7 @@ def post_permits(mhr_number: str):  # pylint: disable=too-many-return-statements
         # Additional validation not covered by the schema.
         group: str = get_group(jwt)
         request_json = get_qs_location(request_json, group, account_id)
-        extra_validation_msg = resource_utils.validate_permit(current_reg, request_json, is_staff(jwt), group)
+        extra_validation_msg = resource_utils.validate_permit(current_reg, request_json, is_all_staff, group)
         if not valid_format or extra_validation_msg != '':
             return resource_utils.validation_error_response(errors, reg_utils.VAL_ERROR, extra_validation_msg)
         # Set up the registration, pay, and save the data.

--- a/mhr_api/tests/unit/api/test_permits.py
+++ b/mhr_api/tests/unit/api/test_permits.py
@@ -192,7 +192,7 @@ def test_create(session, client, jwt, desc, mhr_num, roles, status, account, own
             assert registration.status_type == MhrRegistrationStatusTypes.EXEMPT
         registration.current_view = True
         reg_json = registration.new_registration_json
-        assert reg_json['ownLand'] == json_data['ownLand'] 
+        assert reg_json['ownLand'] == ownland
         reg_report: MhrRegistrationReport = MhrRegistrationReport.find_by_registration_id(doc.registration_id)
         assert reg_report
         assert reg_report.batch_registration_data
@@ -239,8 +239,8 @@ def test_amend(session, client, jwt, desc, mhr_num, roles, status, account, ownl
         assert resp_json.get('amendment')
         assert resp_json.get('permitRegistrationNumber')
         assert resp_json.get('permitDateTime')
-        assert resp_json.get('permitExpiryDateTime')
         assert resp_json.get('permitStatus')
+        assert resp_json.get('permitExpiryDateTime')
         reg_report: MhrRegistrationReport = MhrRegistrationReport.find_by_registration_id(doc.registration_id)
         assert reg_report
         assert reg_report.batch_registration_data
@@ -248,7 +248,7 @@ def test_amend(session, client, jwt, desc, mhr_num, roles, status, account, ownl
         assert registration
         registration.current_view = True
         reg_json = registration.new_registration_json
-        assert reg_json['ownLand'] == json_data['ownLand'] 
+        assert reg_json['ownLand'] == ownland
 
 
 def get_valid_tax_cert_dt() -> str:

--- a/mhr_api/tests/unit/api/test_registrations.py
+++ b/mhr_api/tests/unit/api/test_registrations.py
@@ -186,7 +186,9 @@ TEST_GET_ACCOUNT_DATA_SORT = [
 # testdata pattern is ({desc}, {roles}, {status}, {filter_name}, {filter_value})
 TEST_GET_ACCOUNT_DATA_FILTER = [
     ('Filter mhr number', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.MHR_NUMBER_PARAM, '000930'),
-    ('Filter reg type', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM, 'REGISTER NEW UNIT'),
+    ('Filter reg type desc', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM,
+     'MANUFACTURED HOME REGISTRATION'),
+    ('Filter reg type doc type', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM, 'REG_101'),
     ('Filter reg status', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.STATUS_PARAM, 'EXEMPT'),
     ('Filter client ref', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.CLIENT_REF_PARAM, 'UT-0029'),
     ('Filter user name', 'PS12345', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.USER_NAME_PARAM, 'TEST USER'),

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -135,13 +135,13 @@ TEST_QUERY_FILTER_DATA_MULTIPLE = [
 ]
 # testdata pattern is ({mhr_num}, {staff}, {current}, {has_notes}, {ncan_doc_id}, {has_search_notes})
 TEST_MHR_NUM_DATA_NOTE = [
-    ('080282', True, True, True, None, False),
+    ('080282', True, True, False, None, False),
     ('080282', False, True, False, None, False),
     ('003936', True, True, False, None, False),
     ('092238', True, True, True, '63116143', False),
     ('092238', False, True, True, '63116143', False),
-    ('022873', True, True, True, '43599221', True),
-    ('022873', False, True, True, '43599221', True)
+    ('022873', True, True, True, None, True),
+    ('022873', False, True, True, None, True)
 ]
 # testdata pattern is ({loc_data}, {desc_data})
 TEST_DATA_NEW_REG = [
@@ -543,7 +543,7 @@ def test_save_new_search(session, loc_data, desc_data):
     """Assert that new MHR search JSON uses the new location and description."""
     if model_utils.is_legacy():
         json_data = copy.deepcopy(REGISTRATION)
-        json_data['documentId'] = '88878888'
+        json_data['documentId'] = '88878889'
         json_data['location'] = copy.deepcopy(loc_data)
         json_data['description'] = copy.deepcopy(desc_data)
         test_reg: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -326,7 +326,8 @@ TEST_PERMIT_DATA = [
 # testdata pattern is ({description}, {valid}, {mhr_num}, {location}, {message content}, {group})
 TEST_PERMIT_DATA_EXTRA = [
     ('Valid location no tax cert', True, '000900', LOCATION_PARK, None, REQUEST_TRANSPORT_PERMIT),
-    ('Valid existing active PERMIT', True, '000931', None, None, REQUEST_TRANSPORT_PERMIT),
+    ('Invalid existing active PERMIT', False, '000931', None, validator_utils.STATE_ACTIVE_PERMIT,
+     REQUEST_TRANSPORT_PERMIT),
     ('Invalid MANUFACTURER no dealer', False, '000900', LOCATION_MANUFACTURER_NO_DEALER,
      validator_utils.LOCATION_DEALER_REQUIRED, REQUEST_TRANSPORT_PERMIT),
     ('Invalid MH_PARK no name', False, '000900', LOCATION_PARK_NO_NAME, validator_utils.LOCATION_PARK_NAME_REQUIRED,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19004

*Description of changes:*
- Implement staff and non-staff cancel transport permit registration.
- Limit non-staff access by account id.
- Prevent transport permit registrations when an active transport permit exists.
- Registrations filter by registration type allow filter criteria to be a document description or a document type.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
