### PR TITLE
PPR BusinessLookup fix and Checkbox Styling

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.9",
+      "version": "3.1.10",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/DeathCertificate.vue
@@ -77,7 +77,7 @@
             label="I have an original or certified copy of the death certificate, and confirm
               that it was issued from Canada or the United States, and the name on
               the death certificate matches the name displayed above exactly."
-            class="mt-0 pt-0 has-certificate-checkbox"
+            class="has-certificate-checkbox"
             :error="validate && !hasDeathCertificate"
             data-test-id="has-certificate-checkbox"
             hideDetails
@@ -198,13 +198,16 @@ export default defineComponent({
 .row {
   height: 90px;
 }
+:deep(.v-selection-control) {
+  align-items: flex-start;
+}
+:deep(.v-selection-control .v-label) {
+  margin-top: 6px;
+}
 :deep(.death-certificate) {
   .has-certificate-checkbox {
     label {
       line-height: 22px;
-    }
-    .v-input__slot {
-      align-items: flex-start;
     }
   }
 }

--- a/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
+++ b/ppr-ui/src/components/search/BusinessSearchAutocomplete.vue
@@ -39,6 +39,7 @@
                 <v-tooltip
                   location="right"
                   contentClass="start-tooltip py-5"
+                  :disabled="isPPR"
                 >
                   <template #activator="{ props }">
                     <v-icon

--- a/ppr-ui/src/components/search/SearchBar.vue
+++ b/ppr-ui/src/components/search/SearchBar.vue
@@ -99,7 +99,7 @@
 
         <BusinessSearchAutocomplete
           v-click-outside="setCloseAutoComplete"
-          isPpr
+          isPPR
           nilSearchText
           :searchValue="autoCompleteSearchValue"
           :setAutoCompleteIsActive="autoCompleteIsActive"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20939

*Description of changes:*
- PPR business search prop had wrong title case and was causing unwanted labels and tooltip
- Adjusted styling on Death Certificate Checkbox

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
