### PR TITLE
Mhr Correction/Amend Button States

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.10",
+      "version": "3.1.11",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -33,7 +33,10 @@
           icon=" "
         />
         <Breadcrumb v-if="haveData" />
-        <Tombstone v-if="haveData" />
+        <Tombstone
+          v-if="haveData"
+          :actionInProgress="actionInProgress"
+        />
         <v-container class="py-0">
           <v-row noGutters>
             <v-col cols="12">
@@ -45,6 +48,7 @@
                 @profileReady="profileReady = true"
                 @error="handleError($event)"
                 @haveData="haveData = $event"
+                @actionInProgress="actionInProgress = $event"
               />
             </v-col>
           </v-row>
@@ -156,6 +160,7 @@ export default defineComponent({
       haveData: false,
       loggedOut: false,
       tokenService: false,
+      actionInProgress: false,
       registryUrl: computed((): string => {
         // if REGISTRY_URL does not exist this will return 'undefined'. Needs to be null or str
         const configRegistryUrl = sessionStorage.getItem('REGISTRY_URL')

--- a/ppr-ui/src/components/tombstone/Tombstone.vue
+++ b/ppr-ui/src/components/tombstone/Tombstone.vue
@@ -4,6 +4,7 @@
       <TombstoneDynamic
         v-if="displayTombstoneDynamic"
         :isMhrInformation="displayMhrInformation"
+        :actionInProgress="actionInProgress"
       />
       <TombstoneDefault v-else />
     </v-container>
@@ -22,6 +23,12 @@ export default defineComponent({
   components: {
     TombstoneDefault,
     TombstoneDynamic
+  },
+  props: {
+    actionInProgress: {
+      type: Boolean,
+      default: false
+    }
   },
   setup () {
     const route = useRoute()

--- a/ppr-ui/src/components/tombstone/TombstoneDynamic.vue
+++ b/ppr-ui/src/components/tombstone/TombstoneDynamic.vue
@@ -91,7 +91,7 @@
 
     <!-- Mhr Amend/Correct Btns -->
     <v-row
-      v-if="isMhrInformation && isMhrChangesEnabled && !isNonResExemption"
+      v-if="isMhrChangesEnabled && isRouteName(RouteNames.MHR_INFORMATION)"
       noGutters
       class="mt-2 mb-n4"
     >
@@ -102,6 +102,7 @@
         color="primary"
         variant="plain"
         :ripple="false"
+        :disabled="actionInProgress"
         @click="initMhrCorrection(MhrPublicAmendment)"
       >
         <v-icon
@@ -125,6 +126,7 @@
             variant="plain"
             v-bind="props"
             :ripple="false"
+            :disabled="actionInProgress"
           >
             <v-icon
               color="primary"
@@ -141,6 +143,7 @@
             class="ml-n3 px-0"
             v-bind="props"
             :ripple="false"
+            :disabled="actionInProgress"
           >
             <v-icon v-if="isActive">
               mdi-menu-up
@@ -178,8 +181,8 @@ import { computed, defineComponent, reactive, toRefs } from 'vue'
 import { useStore } from '@/store/store'
 import { formatExpiryDate, pacificDate } from '@/utils'
 import { RegistrationTypeIF } from '@/interfaces'
-import { MhApiStatusTypes, MhUIStatusTypes } from '@/enums'
-import { useExemptions, useMhrCorrections, useMhrInformation, useTransportPermits } from '@/composables'
+import { MhApiStatusTypes, MhUIStatusTypes, RouteNames } from '@/enums'
+import { useMhrCorrections, useMhrInformation, useNavigation, useTransportPermits } from '@/composables'
 import { storeToRefs } from 'pinia'
 import { MhrCorrectionClient, MhrCorrectionStaff, MhrPublicAmendment } from '@/resources'
 import MhrStatusCorrection from '@/components/mhrRegistration/MhrStatusCorrection.vue'
@@ -190,6 +193,10 @@ export default defineComponent({
   components: { MhrStatusCorrection, UpdatedBadge },
   props: {
     isMhrInformation: {
+      type: Boolean,
+      default: false
+    },
+    actionInProgress: {
       type: Boolean,
       default: false
     }
@@ -203,8 +210,8 @@ export default defineComponent({
       getMhrInformation,
       getMhrOriginalTransportPermitRegStatus
     } = storeToRefs(useStore())
+    const { isRouteName } = useNavigation()
     const { isFrozenMhr } = useMhrInformation()
-    const { isNonResExemption } = useExemptions()
     const { initMhrCorrection, isMhrChangesEnabled, isMhrCorrection } = useMhrCorrections()
 
     const { isAmendLocationActive } = useTransportPermits()
@@ -255,8 +262,9 @@ export default defineComponent({
     })
 
     return {
+      RouteNames,
+      isRouteName,
       isMhrCorrection,
-      isNonResExemption,
       initMhrCorrection,
       isMhrChangesEnabled,
       MhrCorrectionStaff,

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,14 +10,14 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': true, // Enables MHR table tab
-  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': true,
-  'mhr-non-res-exemption-enabled': true, // Enables Non-Residential Exemption for Staff
-  'mhr-transport-permit-enabled': true,
-  'mhr-amend-transport-permit-enabled': true,
-  'mhr-user-access-enabled': true,
+  'mhr-registration-enabled': false, // Enables MHR table tab
+  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': false,
+  'mhr-non-res-exemption-enabled': false, // Enables Non-Residential Exemption for Staff
+  'mhr-transport-permit-enabled': false,
+  'mhr-amend-transport-permit-enabled': false,
+  'mhr-user-access-enabled': false,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -10,14 +10,14 @@ export const defaultFlagSet: LDFlagSet = {
   'search-registration-number': true,
   'search-serial-number': true,
   'mhr-ui-enabled': true, // Mhr Search - default true: Should remove from codebase
-  'mhr-registration-enabled': false, // Enables MHR table tab
-  'mhr-staff-correction-enabled': false, // Enables access to staff mhr correction
-  'mhr-transfer-enabled': false, // Enables changes to base MHR HomeOwners within the MHR Information flow
-  'mhr-exemption-enabled': false,
-  'mhr-non-res-exemption-enabled': false, // Enables Non-Residential Exemption for Staff
-  'mhr-transport-permit-enabled': false,
-  'mhr-amend-transport-permit-enabled': false,
-  'mhr-user-access-enabled': false,
+  'mhr-registration-enabled': true, // Enables MHR table tab
+  'mhr-staff-correction-enabled': true, // Enables access to staff mhr correction
+  'mhr-transfer-enabled': true, // Enables changes to base MHR HomeOwners within the MHR Information flow
+  'mhr-exemption-enabled': true,
+  'mhr-non-res-exemption-enabled': true, // Enables Non-Residential Exemption for Staff
+  'mhr-transport-permit-enabled': true,
+  'mhr-amend-transport-permit-enabled': true,
+  'mhr-user-access-enabled': true,
   'sentry-enable': false, // by default, no sentry logs
   'banner-text': '' // by default, there is no banner text
 }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -702,7 +702,8 @@ export default defineComponent({
   },
   emits: [
     'error',
-    'emitHaveData'
+    'emitHaveData',
+    'actionInProgress'
   ],
   setup (props, context) {
     const router = useRouter()
@@ -1455,9 +1456,9 @@ export default defineComponent({
     })
 
     watch(() => getMhrInformation.value.frozenDocumentType,
-      val => {
-        localState.hasAlertMsg = QSLockedStateUnitNoteTypes.includes(val)
-      })
+    val => {
+      localState.hasAlertMsg = QSLockedStateUnitNoteTypes.includes(val)
+    })
 
     watch(() => localState.transportPermitLocationType, val => {
       if (val === LocationChangeTypes.TRANSPORT_PERMIT_SAME_PARK) {
@@ -1465,6 +1466,11 @@ export default defineComponent({
         setUnsavedChanges(false)
       }
     })
+
+    /** Inform root level components when there is an MHR action in Progress **/
+    watch(() => [localState.showTransferType, isChangeLocationActive.value], (watchedConditions) => {
+      context.emit('actionInProgress', watchedConditions.includes(true))
+    }, { immediate: true })
 
     return {
       isRoleStaffSbc,

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1455,8 +1455,7 @@ export default defineComponent({
       onSave()
     })
 
-    watch(() => getMhrInformation.value.frozenDocumentType,
-    val => {
+    watch(() => getMhrInformation.value.frozenDocumentType, val => {
       localState.hasAlertMsg = QSLockedStateUnitNoteTypes.includes(val)
     })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20832

*Description of changes:*
- Hide Amend/Correction Mhr buttons outside MHR view
- Disable Btns when active transfers/permits: Used generic prop to be reused in tombstones in the event we have other instances down the road, with different tombstone buttons

![Screenshot 2024-05-01 at 12 00 30 PM](https://github.com/bcgov/ppr/assets/53542131/6a92fe4b-2180-4a5b-8323-12e3200bb26d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
