### PR TITLE
Security Act Notice Framework

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.18",
+  "version": "3.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.18",
+      "version": "3.1.19",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.18",
+  "version": "3.1.19",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -178,9 +178,13 @@ a {
   }
 }
 
-.generic-label {
+.generic-label, .sub-header {
   @extend %generic-label;
   font-size: 1rem;
+}
+
+.sub-header-info {
+  @extend p
 }
 
 .generic-label-14 {

--- a/ppr-ui/src/components/collateral/generalCollateral/factories/useGeneralCollateral.ts
+++ b/ppr-ui/src/components/collateral/generalCollateral/factories/useGeneralCollateral.ts
@@ -4,6 +4,7 @@ export const useGeneralCollateral = () => {
   const hasGeneralCollateral = (registrationType: APIRegistrationTypes): boolean => {
     const ghArray = [
       APIRegistrationTypes.SECURITY_AGREEMENT,
+      APIRegistrationTypes.SECURITY_ACT_NOTICE,
       APIRegistrationTypes.SALE_OF_GOODS,
       APIRegistrationTypes.FORESTRY_CONTRACTOR_LIEN,
       APIRegistrationTypes.FORESTRY_CONTRACTOR_CHARGE,

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -176,7 +176,7 @@ export default defineComponent({
         return isRoleStaffSbc.value as boolean
       }),
       isStaffClientPayment: computed(() => {
-        return getIsStaffClientPayment
+        return getIsStaffClientPayment.value
       }),
       isNoFeePayment: computed(() => {
         return getStaffPayment.value?.option === 0

--- a/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
+++ b/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
@@ -88,6 +88,7 @@ import { APIRegistrationTypes } from '@/enums'
 import { RegistrationTypeIF } from '@/interfaces'
 import { RegistrationTypes } from '@/resources'
 import { registrationOtherDialog } from '@/resources/dialogOptions'
+import { usePprRegistration } from '@/composables'
 
 export default defineComponent({
   name: 'RegistrationBarTypeAheadList',
@@ -118,6 +119,7 @@ export default defineComponent({
   },
   emits: ['selected'],
   setup (props, { emit }) {
+    const { isSecurityActNoticeEnabled } = usePprRegistration()
     const localState = reactive({
       displayGroup: {
         1: false,
@@ -133,7 +135,10 @@ export default defineComponent({
         return !props.isLightBackGround ? 'filled' : 'plain'
       }),
       displayItems: computed(() => {
-        return filterListByGroupStatus(RegistrationTypes, localState.displayGroup)
+        const registrationTypes = !isSecurityActNoticeEnabled.value
+          ? RegistrationTypes.filter(item => item?.registrationTypeAPI !== APIRegistrationTypes.SECURITY_ACT_NOTICE)
+          : RegistrationTypes
+        return filterListByGroupStatus(registrationTypes, localState.displayGroup)
       })
     })
     const dialogSubmit = (proceed: boolean) => {

--- a/ppr-ui/src/components/registration/length-trust/RegistrationLengthTrust.vue
+++ b/ppr-ui/src/components/registration/length-trust/RegistrationLengthTrust.vue
@@ -306,7 +306,8 @@ export default defineComponent({
         APIRegistrationTypes.PROPERTY_TRANSFER_TAX,
         APIRegistrationTypes.SCHOOL_ACT,
         APIRegistrationTypes.TOBACCO_TAX,
-        APIRegistrationTypes.SPECULATION_VACANCY_TAX
+        APIRegistrationTypes.SPECULATION_VACANCY_TAX,
+        APIRegistrationTypes.SECURITY_ACT_NOTICE
       ]
       return ipArray.includes(registrationType)
     }

--- a/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
+++ b/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
@@ -35,7 +35,8 @@ export const hasNoCharge = (val: UIRegistrationTypes): boolean => {
     UIRegistrationTypes.SCHOOL_ACT,
     UIRegistrationTypes.TOBACCO_TAX,
     UIRegistrationTypes.SPECULATION_VACANCY_TAX,
-    UIRegistrationTypes.MHR_CORRECTION
+    UIRegistrationTypes.MHR_CORRECTION,
+    UIRegistrationTypes.SECURITY_ACT_NOTICE
   ]
   // it will not be in the UIRegistrationTypes enum list if 'Other' was selected
   return hfArray.includes(val) || !Object.values(UIRegistrationTypes).includes(val)

--- a/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
+++ b/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
@@ -6,6 +6,8 @@ import {
 import { AllRegistrationTypes } from '@/resources'
 import { useStore } from '@/store/store'
 import { cloneDeep } from 'lodash'
+import { computed, ComputedRef } from 'vue'
+import { getFeatureFlag } from '@/utils'
 
 export const usePprRegistration = () => {
   const {
@@ -133,7 +135,13 @@ export const usePprRegistration = () => {
     }
   }
 
+  /** Returns true when Security Act Notice Feature Flag is enabled **/
+  const isSecurityActNoticeEnabled: ComputedRef<boolean> = computed((): boolean => {
+    return getFeatureFlag('ppr-sa-notice-enabled')
+  })
+
   return {
-    initPprUpdateFilling
+    initPprUpdateFilling,
+    isSecurityActNoticeEnabled
   }
 }

--- a/ppr-ui/src/enums/registrationTypes.ts
+++ b/ppr-ui/src/enums/registrationTypes.ts
@@ -1,6 +1,7 @@
 export enum APIRegistrationTypes {
   // standard
   SECURITY_AGREEMENT = 'SA',
+  SECURITY_ACT_NOTICE = 'SE',
   REPAIRERS_LIEN = 'RL',
   MARRIAGE_MH = 'FR',
   SALE_OF_GOODS = 'SG',
@@ -9,7 +10,7 @@ export enum APIRegistrationTypes {
   FORESTRY_CONTRACTOR_LIEN = 'FL',
   FORESTRY_CONTRACTOR_CHARGE = 'FA',
   FORESTRY_SUBCONTRACTOR_LIEN = 'FS',
-  // miscelaneous registration cc
+  // miscellaneous registration cc
   CARBON_TAX = 'CT',
   EXCISE_TAX = 'ET',
   FOREST = 'FO',
@@ -60,6 +61,7 @@ export enum APIRegistrationTypes {
 export enum UIRegistrationTypes {
   // standard
   SECURITY_AGREEMENT = 'Security Agreement',
+  SECURITY_ACT_NOTICE = 'Security Act Notice',
   REPAIRERS_LIEN = 'Repairers Lien',
   MARRIAGE_MH = 'Marriage / Separation Agreement affecting Manufactured Home under Family Law Act',
   SALE_OF_GOODS = 'Possession under S.30 of the Sale of Goods Act',

--- a/ppr-ui/src/resources/registrationTypes.ts
+++ b/ppr-ui/src/resources/registrationTypes.ts
@@ -177,6 +177,15 @@ export const RegistrationTypesMiscellaneousOT: Array<RegistrationTypeIF> = [
     disabled: false,
     divider: false,
     group: 2,
+    registrationTypeUI: UIRegistrationTypes.SECURITY_ACT_NOTICE,
+    registrationTypeAPI: APIRegistrationTypes.SECURITY_ACT_NOTICE,
+    text: `${UIRegistrationTypes.SECURITY_ACT_NOTICE}`
+  },
+  {
+    class: 'registration-list-item',
+    disabled: false,
+    divider: false,
+    group: 2,
     registrationTypeUI: UIRegistrationTypes.LIEN_UNPAID_WAGES,
     registrationTypeAPI: APIRegistrationTypes.LIEN_UNPAID_WAGES,
     text: `${UIRegistrationTypes.LIEN_UNPAID_WAGES}`

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -372,6 +372,9 @@ export const useStore = defineStore('assetsStore', () => {
     if (regType?.registrationTypeAPI === APIRegistrationTypes.SECURITY_AGREEMENT) {
       lengthTrustText = 'Length and<br />Trust Indenture'
     }
+    if (regType?.registrationTypeAPI === APIRegistrationTypes.SECURITY_ACT_NOTICE) {
+      lengthTrustText = 'Registration<br />Details'
+    }
     if (regType?.registrationTypeAPI === APIRegistrationTypes.REPAIRERS_LIEN) {
       lengthTrustText = 'Amount and Date<br /> of Surrender'
     }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -5,7 +5,8 @@ import { initialize, LDClient, LDFlagSet, LDOptions, LDUser } from 'launchdarkly
  */
 export const defaultFlagSet: LDFlagSet = {
   'financing-statement': false,
-  'ppr-ui-enabled': true, // PPR Search -  default true: Should remove from codebase
+  'ppr-ui-enabled': true, // PPR Search -  default true: Should remove from codebase,
+  'ppr-sa-notice-enabled': false, // PPR Security Act Notice
   'bcregistry-ui-mhr-enabled': true,
   'search-registration-number': true,
   'search-serial-number': true,

--- a/ppr-ui/src/views/newRegistration/LengthTrust.vue
+++ b/ppr-ui/src/views/newRegistration/LengthTrust.vue
@@ -138,6 +138,8 @@ export default defineComponent({
         switch (localState.registrationType) {
           case APIRegistrationTypes.SECURITY_AGREEMENT:
             return 'Registration Length and Trust Indenture'
+          case APIRegistrationTypes.SECURITY_ACT_NOTICE:
+            return 'Registration Details'
           case APIRegistrationTypes.REPAIRERS_LIEN:
             return 'Terms of Repairers Lien'
           default:
@@ -179,6 +181,7 @@ export default defineComponent({
           case APIRegistrationTypes.MINERAL_LAND_TAX:
           case APIRegistrationTypes.TOBACCO_TAX:
           case APIRegistrationTypes.SPECULATION_VACANCY_TAX:
+          case APIRegistrationTypes.SECURITY_ACT_NOTICE:
             return (
               'The registration length for this registration is automatically set to infinite. ' +
               'There is no fee for this registration.'

--- a/ppr-ui/tests/unit/LengthTrust.spec.ts
+++ b/ppr-ui/tests/unit/LengthTrust.spec.ts
@@ -118,6 +118,8 @@ describe('Length and Trust Indenture new registration component', () => {
         expect(wrapper.find(title).text()).toContain('Registration Length and Trust Indenture')
       } else if (RegistrationTypes[i].registrationTypeAPI === APIRegistrationTypes.REPAIRERS_LIEN) {
         expect(wrapper.find(title).text()).toContain('Terms of Repairers Lien')
+      } else if (RegistrationTypes[i].registrationTypeAPI === APIRegistrationTypes.SECURITY_ACT_NOTICE) {
+        expect(wrapper.find(title).text()).toContain('Registration Details')
       } else {
         expect(wrapper.find(title).text()).toContain('Registration Length')
       }
@@ -151,6 +153,8 @@ describe('Length and Trust Indenture new registration component', () => {
         expect(wrapper.find(titleInfo).text()).toContain('Enter the amount of the Lien and the date the vehicle')
       } else if (RegistrationTypes[i].registrationTypeAPI === APIRegistrationTypes.MARRIAGE_MH) {
         expect(wrapper.find(titleInfo).text()).toContain('infinite. There is a $10.00 fee for this registration.')
+      } else if (RegistrationTypes[i].registrationTypeAPI === APIRegistrationTypes.SECURITY_ACT_NOTICE) {
+        expect(wrapper.find(titleInfo).text()).toContain('infinite. There is no fee for this registration.')
       } else if (infiniteDefaultFree.includes(RegistrationTypes[i].registrationTypeAPI)) {
         expect(wrapper.find(titleInfo).text()).toContain('infinite. There is no fee for this registration.')
       } else {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21103

*Description of changes:*
- For now leveraging Feature Flag to Identify SC Users (Can't code in restriction by specific Account ID for Dev/Test: Development)
- Set up new registration type (specific code from API ticket)
- Insert option to launch from dropdown (SC Users only and FF)
- Create Feature Flag - `ppr-sa-notice-enabled`
- Fee Summary Updates ($0 Fee)
- Title, Stepper and small text changes

*Note:*
- These Security Act accounts will also need RPPR Product Potentially?


![Screenshot 2024-05-10 at 9 21 40 AM](https://github.com/bcgov/ppr/assets/53542131/8be1af12-76b4-422b-8f29-400a19258091)

![Screenshot 2024-05-10 at 9 21 46 AM](https://github.com/bcgov/ppr/assets/53542131/1d1ff365-044f-4e41-8ced-b1d40c6ba755)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
