### PR TITLE
Use doc type description in pay details for new transfer types.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -103,6 +103,13 @@ TO_LEGACY_DOC_TYPE = {
     'MHREG': '101 ',
     'CONV': 'CONV',
     'TRANS': 'TRAN',
+    'TRANS_LAND_TITLE': 'TRAN',
+    'TRANS_FAMILY_ACT': 'TRAN',
+    'TRANS_INFORMAL_SALE': 'TRAN',
+    'TRANS_QUIT_CLAIM': 'TRAN',
+    'TRANS_SEVER_GRANT': 'TRAN',
+    'TRANS_RECEIVERSHIP': 'TRAN',
+    'TRANS_WRIT_SEIZURE': 'TRAN',
     'TRAND': 'DEAT',
     'TRANS_AFFIDAVIT': 'AFFE',
     'TRANS_ADMIN': 'LETA',
@@ -478,6 +485,7 @@ def build_account_query_filter(query_text: str, params: AccountRegistrationParam
                     elif filter_type != reg_utils.START_TS_PARAM:
                         filter_clause = filter_clause.replace('?', filter_value)
                     query_text += filter_clause
+    # current_app.logger.info(query_text)
     return query_text
 
 
@@ -489,6 +497,7 @@ def __get_reg_type_filter(filter_value: str, collapse: bool, doc_types) -> dict:
             new_doc_type = doc_rec.document_type
             break
     doc_type: str = TO_LEGACY_DOC_TYPE.get(new_doc_type, new_doc_type)
+    current_app.logger.info(f'filter_value={filter_value} new_doc_type={new_doc_type} legacy={doc_type}')
     if len(doc_type) == 3:
         doc_type += ' '
     if collapse:

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -102,6 +102,8 @@ def pay(req: request, request_json: dict, account_id: str, trans_type: str, tran
     pay_ref = None
     client_ref: str = request_json.get('clientReferenceId', '')
     details: dict = get_pay_details(request_json.get('registrationType'), trans_id)
+    if request_json.get('transferDocumentType'):
+        details = get_pay_details_doc(request_json.get('transferDocumentType'), trans_id)
     if not is_reg_staff_account(account_id):
         payment = Payment(jwt=jwt.get_token_auth_header(), account_id=account_id, details=details)
         pay_ref = payment.create_payment(trans_type, 1, trans_id, client_ref, False)

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.9'  # pylint: disable=invalid-name
+__version__ = '1.8.10'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/db2/test_db2_utils.py
+++ b/mhr_api/tests/unit/models/db2/test_db2_utils.py
@@ -107,7 +107,9 @@ TEST_QUERY_FILTER_DATA = [
     ('2523', True, reg_utils.SUBMITTING_NAME_PARAM, 'LINDA', "'098487'", db2_utils.REG_FILTER_SUBMITTING_NAME_COLLAPSE),
     ('2523', True, reg_utils.CLIENT_REF_PARAM, 'A000873', "'098487'", db2_utils.REG_FILTER_CLIENT_REF_COLLAPSE),
     ('2523', True, reg_utils.STATUS_PARAM, 'EXEMPT', "'098487'", db2_utils.REG_FILTER_STATUS),
-    ('2523', True, reg_utils.USER_NAME_PARAM, 'BCREG2', "'098487'", db2_utils.REG_FILTER_USERNAME_COLLAPSE)
+    ('2523', True, reg_utils.USER_NAME_PARAM, 'BCREG2', "'098487'", db2_utils.REG_FILTER_USERNAME_COLLAPSE),
+    ('2523', True, reg_utils.REG_TYPE_PARAM, 'TRANS_LAND_TITLE', "'098487'", db2_utils.REG_FILTER_REG_TYPE_COLLAPSE),
+    ('2523', True, reg_utils.REG_TYPE_PARAM, 'TRAN', "'098487'", db2_utils.REG_FILTER_REG_TYPE_COLLAPSE)
 ]
 
 # testdata pattern is ({account_id}, {collapse}, {start_value}, {end_value}, {mhr_numbers}, {expected_clause})
@@ -124,6 +126,10 @@ TEST_QUERY_FILTER_DATA_MULTIPLE = [
      '098487', "'dgfhdgf'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_MHR),
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.REG_TYPE_PARAM,
      'TRANSFER DUE TO SALE OR GIFT', "'098487'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_REG_TYPE),
+    ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.REG_TYPE_PARAM,
+     'TRANS_FAMILY_ACT', "'098487'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_REG_TYPE),
+    ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.REG_TYPE_PARAM,
+     'TRAN', "'098487'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_REG_TYPE),
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.SUBMITTING_NAME_PARAM,
      'LINDA', "'098487'", db2_utils.REG_FILTER_DATE, db2_utils.REG_FILTER_SUBMITTING_NAME),
     ('2523', False, '2021-10-14T09:53:57-07:53', '2021-10-17T09:53:57-07:53', reg_utils.CLIENT_REF_PARAM,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21222

*Description of changes:*
- Update payment transaction to use the document type description with the new transfer types.
- When filtering by reg type with the legacy configuration map the new transfer document types to the legacy TRAN doc type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
