### PR TITLE
Add modal for failed Admin Registrations

### DIFF
--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -476,6 +476,10 @@ export default defineComponent({
           localState.errorOptions = authAssetsError
           localState.errorDisplay = true
           break
+        case ErrorCategories.ADMIN_REGISTRATION:
+          localState.errorOptions = registrationCompleteError
+          localState.errorDisplay = true
+          break
         case ErrorCategories.REGISTRATION_TRANSFER:
         case ErrorCategories.REGISTRATION_CREATE:
           handleErrorRegCreate(error)


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#19622

*Description of changes:*
- Add generic UI modal when Admin Registration submission calls fail

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
