### PR TITLE
Fix Tax Certificate date on Transport Permit Review page

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.28",
+  "version": "3.1.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.28",
+      "version": "3.1.29",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.28",
+  "version": "3.1.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -561,7 +561,7 @@
               <h3>Tax Certificate <br>Expiry Date</h3>
             </v-col>
             <v-col cols="9">
-              <p>{{ shortPacificDate(homeLocationInfo.taxExpiryDate) }}</p>
+              <p>{{ convertDateToLongFormat(homeLocationInfo.taxExpiryDate) }}</p>
             </v-col>
           </v-row>
         </template>
@@ -584,7 +584,7 @@ import {
 import { storeToRefs } from 'pinia'
 import { useCountriesProvinces } from '@/composables/address/factories'
 import { FormIF, MhrRegistrationHomeLocationIF } from '@/interfaces'
-import { shortPacificDate } from '@/utils/date-helper'
+import { convertDateToLongFormat } from '@/utils/date-helper'
 import { TransportPermitDetails } from '@/components/mhrTransportPermit'
 import { InfoChip, UpdatedBadge } from '@/components/common'
 
@@ -790,7 +790,7 @@ export default defineComponent({
       MhrSectVal,
       getStepValidation,
       isMhrManufacturerRegistration,
-      shortPacificDate,
+      convertDateToLongFormat,
       getMhrRegistrationLocation,
       ...countryProvincesHelpers,
       hasActiveTransportPermit,

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -53,6 +53,24 @@ export function convertDate (date: Date|string, includeTime: boolean, includeTz:
   else return moment(date).format('MMMM D, Y') + ` ${datetime}`
 }
 
+/**
+ * Converts a date string in 'YYYY-MM-DD' format to a long date format, ignoring the timezone.
+ *
+ * @example "2024-05-20" -> "May 20, 2024"
+ * @param dateString - A string representing a date in 'YYYY-MM-DD' format.
+ * @returns A string representing the date in long format.
+ * @throws Will throw an error if the date string is not in 'YYYY-MM-DD' format.
+ */
+export function convertDateToLongFormat (dateString: string): string {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(dateString)) {
+    throw new Error("Invalid date format. Expected format is 'YYYY-MM-DD'");
+  }
+  const [year, month, day] = dateString.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
 // Converts date to string and pacific date string
 // Example Output: August 11, 2023
 export function shortPacificDate (date: Date | string): string {

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -59,7 +59,6 @@ export function convertDate (date: Date|string, includeTime: boolean, includeTz:
  * @example "2024-05-20" -> "May 20, 2024"
  * @param dateString - A string representing a date in 'YYYY-MM-DD' format.
  * @returns A string representing the date in long format.
- * @throws Will throw an error if the date string is not in 'YYYY-MM-DD' format.
  */
 export function convertDateToLongFormat (dateString: string): string {
   const [year, month, day] = dateString.split('-').map(Number);

--- a/ppr-ui/src/utils/date-helper.ts
+++ b/ppr-ui/src/utils/date-helper.ts
@@ -62,10 +62,6 @@ export function convertDate (date: Date|string, includeTime: boolean, includeTz:
  * @throws Will throw an error if the date string is not in 'YYYY-MM-DD' format.
  */
 export function convertDateToLongFormat (dateString: string): string {
-  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-  if (!dateRegex.test(dateString)) {
-    throw new Error("Invalid date format. Expected format is 'YYYY-MM-DD'");
-  }
   const [year, month, day] = dateString.split('-').map(Number);
   const date = new Date(year, month - 1, day);
   return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });

--- a/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
@@ -3,7 +3,7 @@ import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 
 import { createComponent, getTestId, setupActiveTransportPermit, setupMockStaffUser } from './utils'
-import { calendarDates, shortPacificDate } from '@/utils'
+import { calendarDates, convertDateToLongFormat } from '@/utils'
 import { defaultFlagSet } from '@/utils/feature-flags'
 import { mockTransportPermitNewLocation, mockTransportPermitPreviousLocation, mockedMhRegistration } from './test-data'
 
@@ -472,7 +472,7 @@ describe('Mhr Information Transport Permit', async () => {
 
     expect(homeLocationReviewText).toContain('The manufactured home is located on land')
     expect(homeLocationReviewText).toContain('Tax Certificate Expiry Date')
-    expect(homeLocationReviewText).toContain(shortPacificDate(calendarDates.tomorrow))
+    expect(homeLocationReviewText).toContain(convertDateToLongFormat(calendarDates.tomorrow))
 
     // staff should see PPR Party Search
     expect(wrapper.findComponent(ContactInformation).findComponent(PartySearch)).toBeTruthy()
@@ -521,7 +521,7 @@ describe('Mhr Information Transport Permit', async () => {
     await nextTick()
 
     // set tax certificate expiry date (future date)
-    locationChange.findComponent(TaxCertificate).findComponent(InputFieldDatePicker).vm.$emit('emitDate', '05-05-2024')
+    locationChange.findComponent(TaxCertificate).findComponent(InputFieldDatePicker).vm.$emit('emitDate', '2024-05-05')
     wrapper.vm.validate = true
     await nextTick()
 
@@ -550,7 +550,7 @@ describe('Mhr Information Transport Permit', async () => {
 
     expect(homeLocationReviewText).toContain('The manufactured home is not located on land')
     expect(homeLocationReviewText).toContain('Tax Certificate Expiry Date')
-    expect(homeLocationReviewText).toContain(shortPacificDate('05-05-2024'))
+    expect(homeLocationReviewText).toContain(convertDateToLongFormat('2024-05-05'))
 
     const confirmCompletionReviewText = wrapper.findComponent(ConfirmCompletion).text()
 


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#20934

*Description of changes:*
- Fix Tax Certificate date on Transport Permit Review page.
- Add a new date util function to convert date string to long date ignoring the timezone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
