### PR TITLE
21311 21325 api account reg fixes

### DIFF
--- a/mhr_api/report-templates/adminRegistrationV2.html
+++ b/mhr_api/report-templates/adminRegistrationV2.html
@@ -152,6 +152,8 @@
 
       {% if addOwnerGroups is defined and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF') %}
         [[registration/owners.html]]
+      {% elif ownerGroups is defined and documentType is defined and documentType == 'EXRE' %}
+        [[registration/owners.html]]
       {% endif %}
 
       {% if location is defined %}
@@ -344,7 +346,7 @@
         {% endif %}
 
 
-      {% if description is defined and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF') %}
+      {% if description is defined and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF', 'EXRE') %}
         [[registration/details.html]]
         [[registration/sections.html]]
 

--- a/mhr_api/report-templates/template-parts/registration/location.html
+++ b/mhr_api/report-templates/template-parts/registration/location.html
@@ -2,7 +2,7 @@
 <div class="no-page-break">
     {% if nocLocation is defined and nocLocation %}
         <div class="section-title mt-5">New Registered Location as shown on the permit or amended location:</div>
-    {% elif registrationType in ('PERMIT', 'REG_STAFF_ADMIN') and (documentType is not defined or documentType not in ('CANCEL_PERMIT', 'REGC_STAFF', 'REGC_CLIENT', 'PUBA')) %}
+    {% elif registrationType in ('PERMIT', 'REG_STAFF_ADMIN') and (documentType is not defined or documentType not in ('CANCEL_PERMIT', 'REGC_STAFF', 'REGC_CLIENT', 'PUBA', 'EXRE')) %}
         <div class="section-title mt-5">New Registered Location</div>
     {% elif amendment is defined and amendment %}
         <div class="section-title mt-5">New Registered Location<span class="pl-2">&nbsp;</span><span class="section-label">AMENDED</span></div>

--- a/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
+++ b/mhr_api/src/database/postgres_views/mhr_account_reg_vw.sql
@@ -13,12 +13,16 @@ SELECT r.mhr_number, r.status_type, r.registration_ts,
        (SELECT string_agg((CASE WHEN p.business_name IS NOT NULL THEN p.business_name
                                 WHEN p.middle_name IS NOT NULL THEN p.first_name || ' ' || p.middle_name || ' ' || p.last_name
                                 ELSE p.first_name || ' ' || p.last_name END), '\n')
-          FROM mhr_registrations ro, mhr_owner_groups og, mhr_parties p
-         WHERE ro.mhr_number = r.mhr_number 
-           AND ro.id = og.registration_id
+          FROM mhr_registrations r1, mhr_owner_groups og, mhr_parties p
+         WHERE r1.mhr_number = r.mhr_number 
+           AND r1.id = og.registration_id
            AND og.registration_id = p.registration_id
-           AND og.registration_id = d.registration_id
-           AND og.id = p.owner_group_id) AS owner_names,       
+           AND og.id = p.owner_group_id
+           AND r1.registration_ts = (SELECT MAX(r2.registration_ts)
+                                       FROM mhr_registrations r2, mhr_owner_groups og2
+                                      WHERE r2.mhr_number = r.mhr_number
+                                        AND og2.registration_id = r2.id
+                                        AND r2.id <= r.id)) AS owner_names,       
        (SELECT CASE WHEN r.user_id IS NULL THEN ''
                     ELSE (SELECT u.firstname || ' ' || u.lastname
                             FROM users u

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -203,7 +203,8 @@ class Db2Manuhome(db.Model):
                 self.reg_descript.save()
                 self.new_descript.save()
             if self.update_owners and self.reg_owner_groups and \
-                    doc.document_type in (Db2Document.DocumentTypes.AMENDMENT, Db2Document.DocumentTypes.CORRECTION):
+                    doc.document_type in (Db2Document.DocumentTypes.AMENDMENT,
+                                          Db2Document.DocumentTypes.CORRECTION, MhrDocumentTypes.EXRE):
                 for group in self.reg_owner_groups:
                     if group.modified:
                         group.save()

--- a/mhr_api/src/mhr_api/models/db2/queries.py
+++ b/mhr_api/src/mhr_api/models/db2/queries.py
@@ -124,7 +124,14 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE o2.manhomid = mh.manhomid
            AND og2.manhomid = mh.manhomid
            AND og2.owngrpid = o2.owngrpid
-           AND og2.status IN ('3')) as owner_names,
+           AND og2.regdocid IN (SELECT d3.documtid
+                                 FROM document d3, owngroup og3
+                                WHERE d3.mhregnum = mh.mhregnum
+                                  AND mh.manhomid = og3.manhomid
+                                  AND d3.documtid = og3.regdocid
+                                  AND d3.regidate <= d.regidate
+                                 ORDER BY d3.regidate DESC
+                                FETCH FIRST 1 ROWS ONLY)) as owner_names,
        TRIM(d.affirmby),
        d.documtid as document_id,
        d.docuregi as doc_reg_number,
@@ -175,7 +182,14 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE o2.manhomid = mh.manhomid
            AND og2.manhomid = mh.manhomid
            AND og2.owngrpid = o2.owngrpid
-           AND og2.status IN ('3')) as owner_names,
+           AND og2.regdocid IN (SELECT d3.documtid
+                                 FROM document d3, owngroup og3
+                                WHERE d3.mhregnum = mh.mhregnum
+                                  AND mh.manhomid = og3.manhomid
+                                  AND d3.documtid = og3.regdocid
+                                  AND d3.regidate <= d.regidate
+                                 ORDER BY d3.regidate DESC
+                                FETCH FIRST 1 ROWS ONLY)) as owner_names,
        TRIM(d.affirmby),
        d.documtid as document_id,
        d.docuregi as doc_reg_number,
@@ -227,7 +241,14 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE o2.manhomid = mh.manhomid
            AND og2.manhomid = mh.manhomid
            AND og2.owngrpid = o2.owngrpid
-           AND og2.regdocid = d.documtid) as owner_names,
+           AND og2.regdocid IN (SELECT d3.documtid
+                                 FROM document d3, owngroup og3
+                                WHERE d3.mhregnum = mh.mhregnum
+                                  AND mh.manhomid = og3.manhomid
+                                  AND d3.documtid = og3.regdocid
+                                  AND d3.regidate <= d.regidate
+                                 ORDER BY d3.regidate DESC
+                                FETCH FIRST 1 ROWS ONLY)) as owner_names,
        TRIM(d.affirmby),
        d.documtid as document_id,
        d.docuregi as doc_reg_number,
@@ -278,7 +299,14 @@ SELECT mh.mhregnum, mh.mhstatus, d.regidate, TRIM(d.name), TRIM(d.olbcfoli), TRI
          WHERE o2.manhomid = mh.manhomid
            AND og2.manhomid = mh.manhomid
            AND og2.owngrpid = o2.owngrpid
-           AND og2.regdocid = d.documtid) as owner_names,
+           AND og2.regdocid IN (SELECT d3.documtid
+                                 FROM document d3, owngroup og3
+                                WHERE d3.mhregnum = mh.mhregnum
+                                  AND mh.manhomid = og3.manhomid
+                                  AND d3.documtid = og3.regdocid
+                                  AND d3.regidate <= d.regidate
+                                 ORDER BY d3.regidate DESC
+                                FETCH FIRST 1 ROWS ONLY)) as owner_names,
        TRIM(d.affirmby),
        d.documtid as document_id,
        d.docuregi as doc_reg_number,

--- a/mhr_api/src/mhr_api/models/db2/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/registration_utils.py
@@ -390,7 +390,8 @@ def get_notes_json(reg_notes, reg_documents):
                     note.status == Db2Mhomnote.StatusTypes.CANCELLED:
                 for doc in reg_documents:
                     if doc.id == note.can_document_id and doc.document_type in (MhrDocumentTypes.PUBA,
-                                                                                MhrDocumentTypes.REGC):
+                                                                                MhrDocumentTypes.REGC,
+                                                                                MhrDocumentTypes.EXRE):
                         note_json['cancelledDocumentType'] = doc.document_type
                         note_json['cancelledDocumentRegistrationNumber'] = doc.document_reg_id
                         note_json['cancelledDateTime'] = model_utils.format_local_ts(doc.registration_ts)
@@ -447,12 +448,13 @@ def update_location(registration,
                     new_doc_type: str,
                     new_doc_id: str):
     """Update location and conditionally status if location out of province."""
-    if not reg_json or not reg_json.get('location') or not new_doc_type or \
+    if not reg_json or not reg_json.get('location') or not new_doc_type or not registration.locations or \
             new_doc_type not in (MhrDocumentTypes.REGC,
                                  MhrDocumentTypes.REGC_CLIENT,
                                  MhrDocumentTypes.REGC_STAFF,
                                  MhrDocumentTypes.STAT,
                                  MhrDocumentTypes.PUBA,
+                                 MhrDocumentTypes.EXRE,
                                  MhrDocumentTypes.CANCEL_PERMIT):
         return manuhome
     manuhome.new_location = Db2Location.create_from_registration(registration, reg_json, False)
@@ -464,7 +466,7 @@ def update_location(registration,
             manuhome.mh_status == 'E' and manuhome.new_location.province and \
             manuhome.new_location.province == model_utils.PROVINCE_BC:
         manuhome.mh_status = 'R'
-    elif new_doc_type != MhrDocumentTypes.CANCEL_PERMIT and manuhome.new_location and \
+    elif new_doc_type not in (MhrDocumentTypes.CANCEL_PERMIT, MhrDocumentTypes.EXRE) and manuhome.new_location and \
             manuhome.new_location.province and manuhome.new_location.province != model_utils.PROVINCE_BC:
         manuhome.mh_status = 'E'
     return manuhome
@@ -476,9 +478,10 @@ def update_description(registration,
                        new_doc_type: str,
                        new_doc_id: str):
     """Conditionally update description for correction/amendment registrations."""
-    if not reg_json or not reg_json.get('description') or not new_doc_type or \
+    if not reg_json or not reg_json.get('description') or not new_doc_type or not registration.descriptions or \
             new_doc_type not in (MhrDocumentTypes.REGC_CLIENT,
                                  MhrDocumentTypes.REGC_STAFF,
+                                 MhrDocumentTypes.EXRE,
                                  MhrDocumentTypes.PUBA):
         return manuhome
     manuhome.new_descript = Db2Descript.create_from_registration(registration, reg_json)

--- a/mhr_api/src/mhr_api/models/db2/utils.py
+++ b/mhr_api/src/mhr_api/models/db2/utils.py
@@ -238,7 +238,7 @@ def find_summary_by_mhr_number(account_id: str, mhr_number: str, staff: bool):  
             for registration in registrations:
                 if reg_count > 0 or extra_count > 0:
                     registration['inUserList'] = True
-                __update_summary_info(registration, registrations, None, staff, account_id)
+                __update_summary_info(registration, None, staff, account_id)
                 if registration['documentType'] in \
                         (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
                     registration['lienRegistrationType'] = lien_registration_type
@@ -295,7 +295,7 @@ def find_summary_by_doc_reg_number(account_id: str,  # pylint: disable=too-many-
             for registration in registrations:
                 if reg_count > 0 or extra_count > 0:
                     registration['inUserList'] = True
-                __update_summary_info(registration, registrations, None, staff, account_id)
+                __update_summary_info(registration, None, staff, account_id)
                 if registration['documentType'] in \
                         (Db2Document.DocumentTypes.CONV, Db2Document.DocumentTypes.MHREG_TRIM):
                     registration['lienRegistrationType'] = lien_registration_type
@@ -351,7 +351,7 @@ def find_all_by_account_id(params: AccountRegistrationParams):
                 for row in rows:
                     results.append(__build_summary(row, False, mhr_list))
             for result in results:
-                __update_summary_info(result, results, reg_summary_list, params.sbc_staff, params.account_id)
+                __update_summary_info(result, reg_summary_list, params.sbc_staff, params.account_id)
                 if not params.collapse:
                     del result['documentType']  # Not in the schema.
             if results and params.collapse:
@@ -583,11 +583,11 @@ def __get_summary_result(result, reg_summary_list) -> dict:
     return match
 
 
-def __update_summary_info(result, results, reg_summary_list, staff, account_id):  # pylint: disable=too-many-branches
+def __update_summary_info(result, reg_summary_list, staff, account_id):  # pylint: disable=too-many-branches
     """Update summary information with new application matches."""
     # Some registrations may have no owner change: use the previous owner names.
-    if not result.get('ownerNames'):
-        result['ownerNames'] = __get_owner_names(result, results)
+    # if not result.get('ownerNames'):
+    #    result['ownerNames'] = __get_owner_names(result, results)
     summary_result = __get_summary_result(result, reg_summary_list)
     if staff and result.get('statusType') == model_utils.STATUS_FROZEN and \
             result.get('frozenDocumentType', '') != DOCUMENT_TYPE_AFFIDAVIT:

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -164,13 +164,12 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                     doc_json.get('documentType') in (MhrDocumentTypes.STAT, MhrDocumentTypes.REGC,
                                                      MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
                                                      MhrDocumentTypes.PUBA, MhrDocumentTypes.AMEND_PERMIT,
-                                                     MhrDocumentTypes.CANCEL_PERMIT):
+                                                     MhrDocumentTypes.CANCEL_PERMIT, MhrDocumentTypes.EXRE):
                 reg_json['documentType'] = doc_json.get('documentType')
                 del reg_json['declaredValue']
                 reg_json = reg_json_utils.set_note_json(self, reg_json)
             elif self.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and \
-                    (not self.notes or doc_json.get('documentType') in (MhrDocumentTypes.NCAN,
-                                                                        MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE)):
+                    (not self.notes or doc_json.get('documentType') in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED)):
                 reg_json['documentType'] = doc_json.get('documentType')
                 del reg_json['declaredValue']
                 reg_json = reg_json_utils.set_note_json(self, reg_json)
@@ -310,7 +309,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                 (self.registration_type == MhrRegistrationTypes.MHREG or
                  (self.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and
                   self.reg_json.get('description') and
-                  self.reg_json.get('documentType', '') in (MhrDocumentTypes.PUBA,
+                  self.reg_json.get('documentType', '') in (MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE,
                                                             MhrDocumentTypes.REGC_CLIENT,
                                                             MhrDocumentTypes.REGC_STAFF))):
             with db.engines['db2'].connect() as conn:
@@ -821,11 +820,11 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         if json_data.get('note'):
             registration.notes = [MhrNote.create_from_json(json_data.get('note'), registration.id, doc.id,
                                                            registration.registration_ts, registration.id)]
-        if json_data.get('location') and doc.document_type in (MhrDocumentTypes.REGC_CLIENT,
+        if json_data.get('location') and doc.document_type in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.EXRE,
                                                                MhrDocumentTypes.REGC_STAFF, MhrDocumentTypes.STAT,
                                                                MhrDocumentTypes.PUBA, MhrDocumentTypes.CANCEL_PERMIT):
             registration.locations.append(MhrLocation.create_from_json(json_data.get('location'), registration.id))
-        if json_data.get('description') and doc.document_type in (MhrDocumentTypes.REGC_CLIENT,
+        if json_data.get('description') and doc.document_type in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.EXRE,
                                                                   MhrDocumentTypes.REGC_STAFF,
                                                                   MhrDocumentTypes.PUBA):
             description: MhrDescription = MhrDescription.create_from_json(json_data.get('description'), registration.id)
@@ -833,7 +832,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
             registration.sections = MhrRegistration.get_sections(json_data, registration.id)
         if json_data.get('addOwnerGroups') and json_data.get('deleteOwnerGroups') and \
                 doc.document_type in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
-                                      MhrDocumentTypes.PUBA):
+                                      MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE):
             registration.add_new_groups(json_data, reg_utils.get_owner_group_count(base_reg))
         if base_reg:
             registration.manuhome = base_reg.manuhome

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -229,7 +229,7 @@ def set_location_json(registration, reg_json: dict, current: bool) -> dict:
             reg_json['newLocation'] = location.json
         else:
             reg_json['location'] = location.json
-    elif model_utils.is_legacy():
+    elif current and model_utils.is_legacy():
         return legacy_reg_utils.set_location_json(registration, reg_json)
     return reg_json
 
@@ -609,7 +609,7 @@ def set_reg_description_json(current_reg, reg_json: dict, reg_id: int) -> dict:
     return reg_json
 
 
-def set_home_status_json(current_reg, reg_json: dict) -> dict:
+def set_home_status_json(current_reg, reg_json: dict, existing_status: str) -> dict:
     """Set the current home status in the registration JSON ."""
     if model_utils.is_legacy() and current_reg.manuhome:
         home_json = current_reg.manuhome.json
@@ -618,4 +618,6 @@ def set_home_status_json(current_reg, reg_json: dict) -> dict:
             not (current_reg.status_type == MhrRegistrationStatusTypes.ACTIVE and
                  reg_json.get('status') == model_utils.STATUS_FROZEN):
         reg_json['status'] = current_reg.status_type
+    if existing_status != reg_json.get('status'):
+        reg_json['previousStatus'] = existing_status
     return reg_json

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -165,7 +165,7 @@ def is_same_mh_park(registration, reg_json: dict) -> bool:
 
 
 def set_exempt_json(registration, reg_json: dict) -> dict:
-    """Conditinally add exemptDateTime as the timestamp of the registration that set the exempt status."""
+    """Conditionally add exemptDateTime as the timestamp of the registration that set the exempt status."""
     if not registration or not reg_json or not reg_json.get('status') == MhrRegistrationStatusTypes.EXEMPT:
         return reg_json
     exempt_ts = None
@@ -259,7 +259,7 @@ def set_description_json(registration, reg_json, current: bool, doc_type: str = 
         return reg_json
     if not current and registration.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and doc_type and \
             doc_type not in (MhrDocumentTypes.PUBA, MhrDocumentTypes.REGC, MhrDocumentTypes.REGC_CLIENT,
-                             MhrDocumentTypes.REGC_STAFF):
+                             MhrDocumentTypes.REGC_STAFF, MhrDocumentTypes.EXRE):
         return reg_json
     description = None
     if registration.descriptions:
@@ -306,7 +306,8 @@ def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
     if not registration.is_transfer() and registration.registration_type != MhrRegistrationTypes.REG_STAFF_ADMIN:
         return reg_json
     if registration.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN and doc_type and \
-            doc_type not in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF, MhrDocumentTypes.PUBA):
+            doc_type not in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
+                             MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE):
         return reg_json
     add_groups = []
     delete_groups = []
@@ -367,6 +368,7 @@ def update_note_amend_correct(registration, note_json: dict, cancel_reg_id: int)
         return note_json
     for reg in registration.change_registrations:
         if reg.id == cancel_reg_id and reg.documents[0].document_type in (MhrDocumentTypes.PUBA,
+                                                                          MhrDocumentTypes.EXRE,
                                                                           MhrDocumentTypes.REGC_CLIENT,
                                                                           MhrDocumentTypes.REGC_STAFF):
             note_json['cancelledDocumentType'] = reg.documents[0].document_type
@@ -604,4 +606,16 @@ def set_reg_description_json(current_reg, reg_json: dict, reg_id: int) -> dict:
         description_json = description.json
         description_json['sections'] = get_sections_json(current_reg, description.registration_id)
         reg_json['description'] = description_json
+    return reg_json
+
+
+def set_home_status_json(current_reg, reg_json: dict) -> dict:
+    """Set the current home status in the registration JSON ."""
+    if model_utils.is_legacy() and current_reg.manuhome:
+        home_json = current_reg.manuhome.json
+        reg_json['status'] = home_json.get('status')
+    elif current_reg.status_type and current_reg.status_type != reg_json.get('status') and \
+            not (current_reg.status_type == MhrRegistrationStatusTypes.ACTIVE and
+                 reg_json.get('status') == model_utils.STATUS_FROZEN):
+        reg_json['status'] = current_reg.status_type
     return reg_json

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -528,7 +528,8 @@ def save_active(registration):
 def save_admin(registration, json_data: dict, new_reg_id: int):
     """Admin registration updates to existing records."""
     doc_type: str = json_data.get('documentType', '')
-    if doc_type not in (MhrDocumentTypes.STAT,
+    if doc_type not in (MhrDocumentTypes.EXRE,
+                        MhrDocumentTypes.STAT,
                         MhrDocumentTypes.REGC_CLIENT,
                         MhrDocumentTypes.REGC_STAFF,
                         MhrDocumentTypes.PUBA):
@@ -580,7 +581,8 @@ def save_admin_status(registration, json_data: dict, new_reg_id: int, doc_type: 
             json_data['location']['address'].get('region', 'BC') != model_utils.PROVINCE_BC:
         registration.status_type = MhrRegistrationStatusTypes.EXEMPT
         current_app.logger.info('New location out of province, updating status to EXEMPT.')
-    elif json_data.get('status', '') and doc_type in (MhrDocumentTypes.REGC_CLIENT,
+    elif json_data.get('status', '') and doc_type in (MhrDocumentTypes.EXRE,
+                                                      MhrDocumentTypes.REGC_CLIENT,
                                                       MhrDocumentTypes.REGC_STAFF,
                                                       MhrDocumentTypes.PUBA):
         status: str = json_data.get('status')
@@ -866,7 +868,7 @@ def __collapse_results(results):
             registrations.append(result)
     for reg in registrations:
         has_caution: bool = False
-        owner_names = reg.get('ownerNames')
+        # owner_names = reg.get('ownerNames')
         changes = []
         for result in results:
             if result['mhrNumber'] == reg['mhrNumber'] and \
@@ -877,11 +879,11 @@ def __collapse_results(results):
                     has_caution = True
                 changes.append(result)
         if changes:
-            for change_reg in changes:
-                if not change_reg.get('ownerNames'):
-                    change_reg['ownerNames'] = __get_previous_owner_names(changes,
-                                                                          owner_names,
-                                                                          change_reg.get('documentId'))
+            # for change_reg in changes:
+            #    if not change_reg.get('ownerNames'):
+            #        change_reg['ownerNames'] = __get_previous_owner_names(changes,
+            #                                                              owner_names,
+            #                                                              change_reg.get('documentId'))
             reg['changes'] = changes
         reg['hasCaution'] = has_caution
     return registrations

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -528,6 +528,7 @@ def save_active(registration):
 def save_admin(registration, json_data: dict, new_reg_id: int):
     """Admin registration updates to existing records."""
     doc_type: str = json_data.get('documentType', '')
+    current_app.logger.debug(f'save_admin doc type={doc_type}')
     if doc_type not in (MhrDocumentTypes.EXRE,
                         MhrDocumentTypes.STAT,
                         MhrDocumentTypes.REGC_CLIENT,
@@ -581,15 +582,17 @@ def save_admin_status(registration, json_data: dict, new_reg_id: int, doc_type: 
             json_data['location']['address'].get('region', 'BC') != model_utils.PROVINCE_BC:
         registration.status_type = MhrRegistrationStatusTypes.EXEMPT
         current_app.logger.info('New location out of province, updating status to EXEMPT.')
-    elif json_data.get('status', '') and doc_type in (MhrDocumentTypes.EXRE,
-                                                      MhrDocumentTypes.REGC_CLIENT,
+    elif doc_type == MhrDocumentTypes.EXRE:
+        registration.status_type = MhrRegistrationStatusTypes.ACTIVE
+        current_app.logger.debug(f'Doc type {doc_type } updating MH status to ACTIVE.')
+    elif json_data.get('status', '') and doc_type in (MhrDocumentTypes.REGC_CLIENT,
                                                       MhrDocumentTypes.REGC_STAFF,
                                                       MhrDocumentTypes.PUBA):
         status: str = json_data.get('status')
         if registration.status_type == MhrRegistrationStatusTypes.ACTIVE and \
                 status != MhrRegistrationStatusTypes.ACTIVE:
             registration.status_type = status
-            current_app.logger.debug(f'Doc tpe {doc_type } updating ACTIVE status to {status}.')
+            current_app.logger.debug(f'Doc type {doc_type } updating ACTIVE status to {status}.')
         elif registration.status_type != MhrRegistrationStatusTypes.ACTIVE and \
                 status == MhrRegistrationStatusTypes.ACTIVE:
             registration.status_type = status

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -23,7 +23,6 @@ from mhr_api.models import utils as model_utils, batch_utils, registration_json_
 from mhr_api.models.registration_utils import (
     save_admin,
     save_cancel_note,
-    save_active,
     get_registration_description,
     get_document_description
 )
@@ -361,9 +360,8 @@ def pay_and_save_admin(req: request,  # pylint: disable=too-many-arguments
                                                                                            MhrDocumentTypes.NRED,
                                                                                            MhrDocumentTypes.EXRE):
             save_cancel_note(current_reg, request_json, registration.id)
-        if request_json.get('documentType') in (MhrDocumentTypes.EXRE, MhrDocumentTypes.REREGISTER_C):
-            save_active(current_reg)
-        elif request_json.get('documentType') in (MhrDocumentTypes.REGC_CLIENT,
+        elif request_json.get('documentType') in (MhrDocumentTypes.EXRE,
+                                                  MhrDocumentTypes.REGC_CLIENT,
                                                   MhrDocumentTypes.REGC_STAFF,
                                                   MhrDocumentTypes.STAT,
                                                   MhrDocumentTypes.PUBA):

--- a/mhr_api/src/mhr_api/utils/admin_validator.py
+++ b/mhr_api/src/mhr_api/utils/admin_validator.py
@@ -65,8 +65,6 @@ def validate_admin_reg(registration: MhrRegistration, json_data, staff: bool = T
                                                                  MhrRegistrationTypes.REG_STAFF_ADMIN,
                                                                  doc_type)
         error_msg += validator_utils.validate_draft_state(json_data)
-        if doc_type and doc_type == MhrDocumentTypes.REREGISTER_C:
-            return error_msg
         error_msg += validate_giving_notice(json_data, doc_type)
         if doc_type and doc_type == MhrDocumentTypes.NRED:
             error_msg += validate_nred(registration, json_data)
@@ -78,6 +76,7 @@ def validate_admin_reg(registration: MhrRegistration, json_data, staff: bool = T
             error_msg += validator_utils.validate_cancel_permit(registration)
         elif doc_type and doc_type in (MhrDocumentTypes.REGC_CLIENT,
                                        MhrDocumentTypes.REGC_STAFF,
+                                       MhrDocumentTypes.EXRE,
                                        MhrDocumentTypes.PUBA):
             error_msg += validate_location(registration, json_data, False)
             error_msg += validate_description(registration, json_data)

--- a/mhr_api/tests/unit/models/db2/test_manuhome.py
+++ b/mhr_api/tests/unit/models/db2/test_manuhome.py
@@ -468,9 +468,9 @@ def test_notes_sort_order(session):
     if model_utils.is_legacy():
         manuhome: Db2Manuhome = Db2Manuhome.find_by_mhr_number('053341')
         report_json = manuhome.registration_json
-        assert len(report_json['notes']) == 2
-        assert report_json['notes'][0]['documentId'] == '90001986'
-        assert report_json['notes'][1]['documentId'] == '43405528'
+        assert len(report_json['notes']) == 0
+        # assert report_json['notes'][0]['documentId'] == '90001986'
+        # assert report_json['notes'][1]['documentId'] == '43405528'
 
 
 def test_declared_value(session):

--- a/mhr_api/tests/unit/models/db2/test_mhomnote.py
+++ b/mhr_api/tests/unit/models/db2/test_mhomnote.py
@@ -119,16 +119,7 @@ def test_find_by_manuhome_id_active(session, exists, manuhome_id, doc_id, doc_ty
                 else:
                     assert str(reg_json.get('expiryDateTime'))[0:10] == expiry
                 assert reg_json.get('remarks') is not None
-                assert reg_json.get('givingNoticeParty') is not None
-                notice_json = reg_json.get('givingNoticeParty')
-                assert notice_json.get('businessName')
-                assert notice_json.get('phoneNumber')
-                assert notice_json.get('address')
-                assert notice_json['address']['street']
-                assert notice_json['address']['city']
-                assert notice_json['address']['region']
-                assert notice_json['address']['country']
-                assert notice_json['address']['postalCode'] is not None
+                assert reg_json.get('givingNoticeParty') is None
                 assert reg_json.get('status') in (MhrNoteStatusTypes.ACTIVE,
                                                 MhrNoteStatusTypes.CANCELLED,
                                                 MhrNoteStatusTypes.EXPIRED)
@@ -157,11 +148,6 @@ def test_note_json(session):
             'remarks': note.remarks,
             'status': MhrNoteStatusTypes.ACTIVE.value,
             'destroyed': False,
-            'givingNoticeParty': {
-                'businessName': note.name,
-                'address': address_utils.get_address_from_db2(note.legacy_address),
-                'phoneNumber': note.phone_number
-            }
         }
         assert note.json == test_json
 

--- a/mhr_api/tests/unit/models/test_mhr_service_agreement.py
+++ b/mhr_api/tests/unit/models/test_mhr_service_agreement.py
@@ -124,9 +124,9 @@ def test_get_profile(session, account_id, username, has_results, has_agreement):
     if has_results:
         assert agreement_json
         if has_agreement:
-            assert agreement_json.get('acceptAgreementRequired')
-        else:
             assert 'acceptAgreementRequired' in agreement_json and not agreement_json.get('acceptAgreementRequired')
+        else:
+            assert agreement_json.get('acceptAgreementRequired')
         assert agreement_json.get('accepted')
         assert agreement_json.get('version')
         assert agreement_json.get('acceptedDateTime')

--- a/mhr_api/tests/unit/models/test_search_request.py
+++ b/mhr_api/tests/unit/models/test_search_request.py
@@ -675,7 +675,7 @@ def test_search_mhr_number_direct(session, mhr_num, status, city, serial, year, 
         assert result['baseInformation'].get('model') == model
         assert result.get('mhId') == id
         if o_status == 'ACTIVE':
-            assert result.get('activeCount') == 1
+            assert result.get('activeCount') >= 1
         elif o_status == 'EXEMPT':
             assert result.get('exemptCount') == 1
         elif o_status == 'PREVIOUS':
@@ -715,7 +715,7 @@ def test_search_serial_number_direct(session, mhr_num, status, city, serial, yea
         assert result['baseInformation'].get('model') == model
         assert result.get('mhId') == id
         if o_status == 'ACTIVE':
-            assert result.get('activeCount') == 1
+            assert result.get('activeCount') >= 1
         elif o_status == 'EXEMPT':
             assert result.get('exemptCount') == 1
         elif o_status == 'PREVIOUS':
@@ -755,7 +755,7 @@ def test_search_owner_bus_direct(session, mhr_num, status, city, serial, year, i
                 assert result.get('mhId') == id
                 assert result.get('organizationName') == bus_name
                 if o_status == 'ACTIVE':
-                    assert result.get('activeCount') == 1
+                    assert result.get('activeCount') >= 1
                 elif o_status == 'EXEMPT':
                     assert result.get('exemptCount') == 1
                 elif o_status == 'PREVIOUS':
@@ -798,7 +798,7 @@ def test_search_owner_ind_direct(session, mhr_num, status, city, serial, year, i
                 if middle:
                     assert result['ownerName'].get('middle') == middle
                 if o_status == 'ACTIVE':
-                    assert result.get('activeCount') == 1
+                    assert result.get('activeCount') >= 1
                 elif o_status == 'EXEMPT':
                     assert result.get('exemptCount') == 1
                 elif o_status == 'PREVIOUS':

--- a/mhr_api/tests/unit/utils/test_admin_validator.py
+++ b/mhr_api/tests/unit/utils/test_admin_validator.py
@@ -324,7 +324,74 @@ ADD_OG_INVALID_JT = [
       'type': 'JOINT'
     }
 ]
-
+LOCATION_000912 = {
+    'additionalDescription': 'additional',
+    'address': {
+      'city': 'CITY',
+      'country': 'CA',
+      'postalCode': 'V8R 3A5',
+      'region': 'BC',
+      'street': '1234 TEST-0013'
+    },
+    'leaveProvince': False,
+    'legalDescription': 'LOT 24 DISTRICT LOT 497 KAMLOOPS DIVISION YALE DISTRICT PLAN 25437',
+    'locationId': 200000017,
+    'locationType': 'OTHER',
+    'pidNumber': '005509807',
+    'status': 'ACTIVE',
+    'taxCertificate': True,
+    'taxExpiryDate': '2024-04-26T17:46:54+00:00'
+}
+DESCRIPTION_000912 = {
+    'baseInformation': {
+      'circa': True,
+      'make': 'make',
+      'model': 'model',
+      'year': 2015
+    },
+    'csaNumber': '7777700000',
+    'csaStandard': '1234',
+    'engineerDate': '2024-04-26T17:46:54+00:00',
+    'engineerName': 'engineer name',
+    'manufacturer': 'manufacturer',
+    'otherRemarks': 'other',
+    'rebuiltRemarks': 'rebuilt',
+    'sectionCount': 3,
+    'sections': [
+      {
+        'lengthFeet': 60,
+        'lengthInches': 10,
+        'serialNumber': '888888',
+        'widthFeet': 14,
+        'widthInches': 11
+      }
+    ],
+    'status': 'ACTIVE'
+}
+DELETE_OG_000912 =  [
+    {
+      'groupId': 1,
+      'owners': [
+        {
+          'address': {
+            'city': 'CITY',
+            'country': 'CA',
+            'postalCode': 'V8R 3A5',
+            'region': 'BC',
+            'street': '1234 TEST-0013'
+          },
+          'organizationName': 'TEST MHREG EXEMPT',
+          'ownerId': 200000043,
+          'partyType': 'OWNER_BUS',
+          'status': 'ACTIVE',
+          'type': 'SOLE'
+        }
+      ],
+      'status': 'ACTIVE',
+      'tenancySpecified': True,
+      'type': 'SOLE'
+    }
+  ] 
 # testdata pattern is ({description}, {valid}, {doc_type}, {doc_id}, {mhr_num}, {account}, {message content})
 TEST_REG_DATA = [
     ('Invalid missing submitting party', False, 'NRED', DOC_ID_VALID, '000914', 'PS12345',
@@ -354,13 +421,13 @@ TEST_NOTE_DATA_NOTICE = [
     ('Invalid business no address', False, 'NRED', NOTICE_NO_ADDRESS2, '000914', 'PS12345',
      validator.NOTICE_ADDRESS_REQUIRED)
 ]
-# test data pattern is ({description}, {valid}, {update_doc_id}, {mhr_num}, {account}, {message_content})
+# test data pattern is ({description}, {valid}, {mhr_num}, {account}, {message_content})
 TEST_DATA_EXRE = [
-    ('Invalid FROZEN', False, None, '000917', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Invalid ACTIVE', False, 'UT000020', '000914', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Invalid CANCELLED', False, 'UT000018', '000913', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Valid state', True, 'UT000023', '000912', 'PS12345', None),
-    ('Valid no note', True, 'UT000023', '000912', 'PS12345', None)
+    ('Invalid FROZEN', False, '000917', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
+    ('Invalid ACTIVE', False, '000914', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
+    ('Valid CANCELLED', True, '000913', 'PS12345', None),
+    ('Valid EXEMPT', True, '000912', 'PS12345', None),
+    ('Valid no note', True, '000912', 'PS12345', None)
 ]
 # test data pattern is ({description}, {valid}, {update_doc_id}, {mhr_num}, {account}, {message_content})
 TEST_NOTE_DATA_NCAN = [
@@ -407,42 +474,26 @@ TEST_AMEND_CORRECT_DATA = [
     (False, '000919', 'REGC_STAFF', None, None, None, DELETE_OG_VALID, validator.ADD_OWNERS_MISSING),
     (False, '000919', 'REGC_STAFF', None, None, ADD_OG_VALID, None, validator.DELETE_OWNERS_MISSING),
     (False, '000919', 'REGC_STAFF', None, None, ADD_OG_INVALID_JT, DELETE_OG_VALID,
-     validator_utils.OWNERS_JOINT_INVALID)
+     validator_utils.OWNERS_JOINT_INVALID),
+    (True, '000912', 'EXRE', LOCATION_VALID, None, None, None, None),
+    (True, '000912', 'EXRE', LOCATION_VALID_MINIMAL, None, None, None, None),
+    (False, '000912', 'EXRE', LOCATION_000912, None, None, None, validator_utils.LOCATION_INVALID_IDENTICAL),
+    (False, '000912', 'EXRE', None, DESCRIPTION_000912, None, None, validator_utils.DESCRIPTION_INVALID_IDENTICAL),
+    (False, '000912', 'EXRE', None, None, None, DELETE_OG_000912, validator.ADD_OWNERS_MISSING),
+    (False, '000912', 'EXRE', None, None, ADD_OG_VALID, None, validator.DELETE_OWNERS_MISSING),
+    (False, '000912', 'EXRE', None, None, ADD_OG_INVALID_JT, DELETE_OG_000912, validator_utils.OWNERS_JOINT_INVALID),
+    (True, '000912', 'EXRE', None, None, ADD_OG_VALID, DELETE_OG_000912, None),
+    (True, '000912', 'EXRE', None, DESCRIPTION, None, None, None)
 ]
-# test data pattern is ({description}, {valid}, {mhr_num}, {account}, {message_content})
-TEST_DATA_REREGISTER = [
-    ('Valid state', True, '000913', 'PS12345', None),
-    ('Invalid EXEMPT', False, '000912', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Invalid FROZEN', False, '000917', 'PS12345', validator_utils.STATE_NOT_ALLOWED),
-    ('Invalid ACTIVE', False, '000914', 'PS12345', validator_utils.STATE_NOT_ALLOWED)
-]
 
 
-@pytest.mark.parametrize('desc,valid,mhr_num,account,message_content', TEST_DATA_REREGISTER)
-def test_validate_reregister(session, desc, valid, mhr_num, account, message_content):
-    """Assert that REREGISTER_C document type validation works as expected."""
-    # setup
-    json_data = get_valid_registration()
-    json_data['documentType'] = MhrDocumentTypes.REREGISTER_C
-    del json_data['note']
-    registration: MhrRegistration = MhrRegistration.find_by_mhr_number(mhr_num, account)
-    error_msg = validator.validate_admin_reg(registration, json_data)
-    # current_app.logger.debug(error_msg)
-    if valid:
-        assert error_msg == ''
-    else:
-        assert error_msg != ''
-        if message_content:
-            assert error_msg.find(message_content) != -1
-
-
-@pytest.mark.parametrize('desc,valid,update_doc_id,mhr_num,account,message_content', TEST_DATA_EXRE)
-def test_validate_exre(session, desc, valid, update_doc_id, mhr_num, account, message_content):
+@pytest.mark.parametrize('desc,valid,mhr_num,account,message_content', TEST_DATA_EXRE)
+def test_validate_exre(session, desc, valid, mhr_num, account, message_content):
     """Assert that EXRE document type validation works as expected."""
     # setup
     json_data = get_valid_registration()
-    if update_doc_id:
-        json_data['updateDocumentId'] = update_doc_id
+    if json_data.get('updateDocumentId'):
+        del json_data['updateDocumentId']
     json_data['documentType'] = MhrDocumentTypes.EXRE
     if desc == 'Valid no note':
         del json_data['note']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21325

*Description of changes:*
- Fix to set the active owners at the time of the registration in the account registrations API response when no owners are changes as part of the registration.


*Issue #:* /bcgov/entity#21244

*Description of changes:*
- Implement MHR API re-registration.
- Example report attached to ticket.
- Fix legacy configuration correction including location in the report setup when location not changed.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
