### PR TITLE
Allow Amend and Cancel Transport Permit for Exempt MHR

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.29",
+  "version": "3.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.29",
+      "version": "3.1.30",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.29",
+  "version": "3.1.30",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -826,6 +826,7 @@ export default defineComponent({
       isCancelChangeLocationActive,
       isTransportPermitDisabled,
       isRegisteredLocationChange,
+      isExemptMhrTransportPermitChangesEnabled,
       setLocationChange,
       getUiFeeSummaryLocationType,
       getUiLocationType,
@@ -833,7 +834,7 @@ export default defineComponent({
       setLocationChangeType,
       initTransportPermit,
       populateLocationInfoForSamePark,
-      buildAndSubmitTransportPermit,
+      buildAndSubmitTransportPermit
     } = useTransportPermits()
 
     // Refs
@@ -890,7 +891,7 @@ export default defineComponent({
       showCancelTransportPermitDialog: false,
       isTransportPermitDisabled: computed((): boolean =>
         localState.showTransferType ||
-        isExemptMhr.value ||
+        (isExemptMhr.value && !isExemptMhrTransportPermitChangesEnabled.value) ||
         isTransportPermitDisabled.value ||
         (!isRoleStaffReg.value && isFrozenMhrDueToAffidavit.value)
       ),

--- a/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
@@ -30,7 +30,7 @@
             class=""
             color="primary"
             :ripple="false"
-            :disabled="disable"
+            :disabled="disable || !getTransportPermitChangeAllowed"
             data-test-id="amend-transport-permit-btn"
             @click="toggleAmendLocationChange()"
           >

--- a/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
+++ b/ppr-ui/tests/unit/test-data/mock-mhr-registration.ts
@@ -35,6 +35,14 @@ export const mockedAddressAlt: AddressIF = {
   deliveryInstructions: 'Front Door'
 }
 
+export const mockedAddressOutsideBC: AddressIF = {
+  city: 'TORONTO',
+  country: 'CA',
+  postalCode: 'M5E1E5',
+  region: 'ON',
+  street: '1 YONGE ST, SUITE 100'
+}
+
 export const mockedEmptyGroup: MhrRegistrationHomeOwnerGroupIF = {
   groupId: 100,
   owners: [],

--- a/ppr-ui/tests/unit/utils/helper-functions.ts
+++ b/ppr-ui/tests/unit/utils/helper-functions.ts
@@ -131,4 +131,5 @@ export async function setupActiveTransportPermit (): Promise<void> {
   await store.setMhrTransportPermit({ key: 'newLocation', value: mockTransportPermitNewLocation })
   await store.setMhrTransportPermit({ key: 'ownLand', value: true })
   await store.setMhrTransportPermitPreviousLocation(mockTransportPermitPreviousLocation)
+  await store.setTransportPermitChangeAllowed(true)
 }


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#21218

*Description of changes:*
- Enable Amend Cancel Permits for Exempt MHRs
- Disable Amend Transport Permit if not allowed by API
- Unit tests updates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
