### PR TITLE
QS amend permit skip location type validation.

### DIFF
--- a/mhr_api/report-templates/adminRegistrationV2.html
+++ b/mhr_api/report-templates/adminRegistrationV2.html
@@ -51,7 +51,7 @@
           <td>{{createDateTime}}</td>
         </tr>        
 
-        {% if documentType is not defined or documentType not in ('STAT', 'PUBA', 'REGC_CLIENT', 'REGC_STAFF', 'CANCEL_PERMIT') %}
+        {% if documentType is not defined or documentType not in ('STAT', 'PUBA', 'REGC_CLIENT', 'REGC_STAFF', 'CANCEL_PERMIT', 'EXRE') %}
         <tr>
           <td>
               {% if note is defined and note.documentType is defined and note.documentType in ('NCAN', 'NRED') %}
@@ -150,7 +150,7 @@
       </div>
       {% endif %}
 
-      {% if addOwnerGroups is defined and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF') %}
+      {% if (addOwnerGroups is defined or ownerGroups is defined) and documentType is defined and documentType in ('PUBA', 'REGC_CLIENT', 'REGC_STAFF') %}
         [[registration/owners.html]]
       {% elif ownerGroups is defined and documentType is defined and documentType == 'EXRE' %}
         [[registration/owners.html]]

--- a/mhr_api/src/mhr_api/models/mhr_draft.py
+++ b/mhr_api/src/mhr_api/models/mhr_draft.py
@@ -326,6 +326,11 @@ class MhrDraft(db.Model):
         if draft:
             draft.update_ts = model_utils.now_ts()
             draft.draft = request_json.get('registration')
+            if request_json.get('type'):
+                reg_type: str = request_json.get('type')
+                if reg_type != draft.registration_type:
+                    current_app.logger.debug(f'Updating draft reg type from {draft.registration_type} to {reg_type}')
+                    draft.registration_type = reg_type
         return draft
 
     @staticmethod

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -63,6 +63,7 @@ def set_current_misc_json(registration, reg_json: dict, search: bool = False) ->
                                                                        MhrDocumentTypes.REGC,
                                                                        MhrDocumentTypes.PUBA):
                 own_land = bool(doc.own_land and doc.own_land == 'Y')
+                # current_app.logger.debug(f'doc type={doc.document_type} own land={doc.own_land}')
             if reg.is_transfer() and doc.declared_value and doc.declared_value > 0 and \
                     (dec_ts is None or reg.registration_ts > dec_ts):
                 dec_value = doc.declared_value

--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -215,17 +215,17 @@ def validate_permit(registration: MhrRegistration, json_data, staff: bool = Fals
         elif registration:
             error_msg += validator_utils.validate_ppr_lien(registration.mhr_number, MhrRegistrationTypes.PERMIT, staff)
         current_location = validator_utils.get_existing_location(registration)
-        if registration and group_name and group_name == MANUFACTURER_GROUP and not json_data.get('amendment'):
-            error_msg += validate_manufacturer_permit(registration.mhr_number, json_data, current_location)
-        if registration and group_name and group_name == DEALERSHIP_GROUP and current_location and \
-                current_location.get('locationType', '') != MhrLocationTypes.MANUFACTURER:
-            error_msg += MANUFACTURER_DEALER_INVALID
         error_msg += validator_utils.validate_submitting_party(json_data)
         if json_data.get('amendment'):
             error_msg += validator_utils.validate_registration_state(registration, staff, MhrRegistrationTypes.PERMIT,
                                                                      MhrDocumentTypes.AMEND_PERMIT)
         else:
             error_msg += validator_utils.validate_registration_state(registration, staff, MhrRegistrationTypes.PERMIT)
+            if registration and group_name and group_name == MANUFACTURER_GROUP:
+                error_msg += validate_manufacturer_permit(registration.mhr_number, json_data, current_location)
+            if registration and group_name and group_name == DEALERSHIP_GROUP and current_location and \
+                    current_location.get('locationType', '') != MhrLocationTypes.MANUFACTURER:
+                error_msg += MANUFACTURER_DEALER_INVALID
         error_msg += validator_utils.validate_draft_state(json_data)
         error_msg += validate_permit_location(json_data, current_location, staff)
         error_msg += validate_amend_permit(registration, json_data)
@@ -308,7 +308,7 @@ def validate_permit_location(json_data: dict, current_location: dict, staff: boo
             error_msg += validator_utils.validate_tax_certificate(location, current_location, staff)
         elif not json_data.get('amendment'):
             error_msg += validator_utils.validate_tax_certificate(location, current_location, staff)
-        if not json_data.get('landStatusConfirmation'):
+        if not json_data.get('amendment') and not json_data.get('landStatusConfirmation'):
             if location.get('locationType') and \
                     location['locationType'] in (MhrLocationTypes.STRATA,
                                                  MhrLocationTypes.RESERVE,

--- a/mhr_api/tests/unit/api/test_permits.py
+++ b/mhr_api/tests/unit/api/test_permits.py
@@ -248,7 +248,7 @@ def test_amend(session, client, jwt, desc, mhr_num, roles, status, account, ownl
         assert registration
         registration.current_view = True
         reg_json = registration.new_registration_json
-        assert reg_json['ownLand'] == ownland
+        assert 'ownLand' in reg_json
 
 
 def get_valid_tax_cert_dt() -> str:

--- a/mhr_api/tests/unit/models/test_mhr_draft.py
+++ b/mhr_api/tests/unit/models/test_mhr_draft.py
@@ -118,6 +118,7 @@ TEST_SAVE_DRAFT_DATA = [
 TEST_UPDATE_DRAFT_DATA = [
     (HTTPStatus.OK, 'T500000', MhrRegistrationTypes.MHREG, REGISTRATION, 'TEST-001'),
     (HTTPStatus.OK, 'T500002', MhrRegistrationTypes.TRANS, DRAFT_TRANSFER, 'TEST-002'),
+    (HTTPStatus.OK, 'T500002', MhrRegistrationTypes.TRANS_WILL.value, DRAFT_TRANSFER, 'TEST-003'),
     (HTTPStatus.NOT_FOUND, None, None, None, None),
     (HTTPStatus.BAD_REQUEST, 'T500001', None, None, None)
 ]
@@ -245,6 +246,7 @@ def test_update(session, status, draft_num, reg_type, draft_data, client_ref):
             'registration': copy.deepcopy(draft_data)
         }
         json_data['registration']['clientReferenceId'] = client_ref
+        json_data['registration']['registrationType'] = reg_type
         updated = MhrDraft.update(json_data, draft_num)
         # current_app.logger.info(updated.draft)
         updated_json = updated.save()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21002

*Description of changes:*
- QS amend transport permit skip location checking validation rules.
- Also UXA updates to re-register report.
- Also MHR drafts allow change of registration type without deleting/creating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
