### PR TITLE
Save transfer date as a timestamp.

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_document.py
+++ b/mhr_api/src/mhr_api/models/mhr_document.py
@@ -170,5 +170,6 @@ class MhrDocument(db.Model):  # pylint: disable=too-many-instance-attributes
         if reg_json.get('affirmByName'):
             doc.affirm_by = str(reg_json['affirmByName']).upper()
         if registration.is_transfer() and reg_json.get('transferDate'):
-            doc.transfer_date = model_utils.ts_from_iso_format(reg_json['transferDate'])
+            #  Set to end of day in the local time zone.
+            doc.transfer_date = model_utils.expiry_datetime(reg_json['transferDate'])
         return doc


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21323

*Description of changes:*
- Set the transfer date as the end of the day local time to display correctly in reports.
- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
