### PR TITLE
Commission Orders and Expansion Functionality

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.1.30",
+      "version": "3.1.31",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/collateral/vehicleCollateral/factories/useVehicle.ts
+++ b/ppr-ui/src/components/collateral/vehicleCollateral/factories/useVehicle.ts
@@ -160,7 +160,8 @@ export const useVehicle = (props, context) => {
       APIRegistrationTypes.PETROLEUM_NATURAL_GAS_TAX,
       APIRegistrationTypes.RURAL_PROPERTY_TAX,
       APIRegistrationTypes.TOBACCO_TAX,
-      APIRegistrationTypes.SPECULATION_VACANCY_TAX
+      APIRegistrationTypes.SPECULATION_VACANCY_TAX,
+      APIRegistrationTypes.SECURITY_ACT_NOTICE
     ]
     return vhArray.includes(registrationType)
   }

--- a/ppr-ui/src/components/common/FormCard.vue
+++ b/ppr-ui/src/components/common/FormCard.vue
@@ -6,7 +6,10 @@
     :class="{ 'border-error-left': showErrors }"
   >
     <v-row noGutters>
-      <v-col cols="3">
+      <v-col
+        cols="3"
+        class="pr-8"
+      >
         <label
           class="generic-label"
           :class="{ 'error-text': showErrors }"

--- a/ppr-ui/src/components/registration/securities-act-notices/AddEditNotice.vue
+++ b/ppr-ui/src/components/registration/securities-act-notices/AddEditNotice.vue
@@ -52,6 +52,8 @@
               class="mt-8 mr-3"
               :title="'Effective Date (Optional)'"
               :initialValue="effectiveDate"
+              :minDate="null"
+              :maxDate="localTodayDate(new Date(), true)"
               @emitCancel="effectiveDate = ''"
               @emitDate="effectiveDate = $event"
             />
@@ -90,6 +92,7 @@ import { FormCard, InputFieldDatePicker } from '@/components/common'
 import { AddEditSaNoticeIF, FormIF } from '@/interfaces'
 import { SaNoticeTypes } from '@/enums'
 import { useInputRules } from '@/composables'
+import { localTodayDate } from '@/utils'
 
 /** Composables **/
 const { required } = useInputRules()

--- a/ppr-ui/src/components/registration/securities-act-notices/CourtCommissionOrderReview.vue
+++ b/ppr-ui/src/components/registration/securities-act-notices/CourtCommissionOrderReview.vue
@@ -1,22 +1,22 @@
 <template>
-  <v-expand-transition>
-    <v-row
-      id="court-commission-order-review"
-      class="pa-4"
-      noGuttters
+  <v-row
+    id="court-commission-order-review"
+    class="pa-4"
+    noGuttters
+  >
+    <v-col
+      cols="3"
+      class="py-0"
     >
-      <v-col
-        cols="3"
-        class="py-0"
-      >
-        <h4>{{ courtCommissionLabel }}</h4>
-      </v-col>
-      <v-col
-        cols="9"
-        class="py-0 px-0 mx-0 mt-n1"
-      >
-        <slot name="actions" />
-      </v-col>
+      <h4>{{ courtCommissionLabel }} Order</h4>
+    </v-col>
+    <v-col
+      cols="9"
+      class="py-0 px-0 mx-0 mt-n1"
+    >
+      <slot name="actions" />
+    </v-col>
+    <template v-if="props.order?.courtOrder">
       <v-col
         cols="3"
         class="pt-1 pb-0 mb-0"
@@ -41,44 +41,46 @@
       >
         <p>{{ order.courtRegistry }}</p>
       </v-col>
-      <v-col
-        cols="3"
-        class="pt-1 pb-0 mb-0"
-      >
-        <h4>Court File Number</h4>
-      </v-col>
-      <v-col
-        cols="9"
-        class="pt-1 pb-0 mb-0"
-      >
-        <p>{{ order.fileNumber }}</p>
-      </v-col>
-      <v-col
-        cols="3"
-        class="pt-1 pb-0 mb-0"
-      >
-        <h4>Date of Order</h4>
-      </v-col>
-      <v-col
-        cols="9"
-        class="pt-1 pb-0 mb-0"
-      >
-        <p>{{ yyyyMmDdToPacificDate(order.orderDate, true) }}</p>
-      </v-col>
-      <v-col
-        cols="3"
-        class="pt-1 pb-0 mb-0"
-      >
-        <h4>Effect of Order</h4>
-      </v-col>
-      <v-col
-        cols="9"
-        class="pt-1 pb-0 mb-0"
-      >
-        <p>{{ order.effectOfOrder || '(Not Entered)' }}</p>
-      </v-col>
-    </v-row>
-  </v-expand-transition>
+    </template>
+    <v-col
+      cols="3"
+      class="pt-1 pb-0 mb-0"
+    >
+      <h4>{{ courtCommisionNumberLabel }} Number</h4>
+    </v-col>
+    <v-col
+      cols="9"
+      class="pt-1 pb-0 mb-0"
+    >
+      <p>{{ order.fileNumber }}</p>
+    </v-col>
+    <v-col
+      cols="3"
+      class="pt-1 pb-0 mb-0"
+    >
+      <h4>Date of Order</h4>
+    </v-col>
+    <v-col
+      cols="9"
+      class="pt-1 pb-0 mb-0"
+    >
+      <p>{{ yyyyMmDdToPacificDate(order.orderDate, true) }}</p>
+    </v-col>
+    <v-col
+      cols="3"
+      class="pt-1 pb-0 mb-0"
+    >
+      <h4>Effect of Order</h4>
+    </v-col>
+    <v-col
+      cols="9"
+      class="pt-1 pb-0 mb-0"
+    >
+      <p class="effect-of-order-text">
+        {{ order.effectOfOrder || '(Not Entered)' }}
+      </p>
+    </v-col>
+  </v-row>
 </template>
 
 <script setup lang="ts">
@@ -94,7 +96,9 @@ const props = withDefaults(defineProps<{
 })
 
 /** Local Properties **/
-const courtCommissionLabel = computed(() => props.order?.courtOrder ? 'Court Order' : 'Commission Order')
+const courtCommissionLabel = computed(() => props.order?.courtOrder ? 'Court' : 'Securities Commission')
+const courtCommisionNumberLabel = computed(() => props.order?.courtOrder ? 'Court File' : 'Commission Order')
+
 
 </script>
 <style lang="scss" scoped>
@@ -102,6 +106,9 @@ const courtCommissionLabel = computed(() => props.order?.courtOrder ? 'Court Ord
 p {
   font-size: .875rem;
   line-height: 2.25rem;
+}
+.effect-of-order-text {
+  line-height: 22px;
 }
 #court-commission-order-review {
   background-color: #F2F6FB;

--- a/ppr-ui/src/components/registration/securities-act-notices/SecuritiesActNoticesPanels.vue
+++ b/ppr-ui/src/components/registration/securities-act-notices/SecuritiesActNoticesPanels.vue
@@ -21,7 +21,9 @@
           :noticeIndex="index"
           :isActivePanel="activePanels.includes(index)"
           :disableActions="!!activePanels.length || isAddingNotice"
+          :closeOrders="activeOrderPanel !== index"
           @togglePanel="togglePanel"
+          @activeOrderIndex="activeOrderPanel = $event"
         />
       </v-expansion-panels>
       <v-col
@@ -60,6 +62,7 @@ const props = withDefaults(defineProps<{
 
 /** Local Properties **/
 const activePanels = ref([])
+const activeOrderPanel = ref(null)
 
 /** Local Functions **/
 /** Open or close panel by index **/

--- a/ppr-ui/src/interfaces/ppr-api-interfaces/court-order-interface.ts
+++ b/ppr-ui/src/interfaces/ppr-api-interfaces/court-order-interface.ts
@@ -3,10 +3,10 @@ import { ActionTypes } from '@/enums'
 // Existing court order information may not be altered. All elements are required.
 export interface CourtOrderIF {
   courtOrder?: boolean // Optional property indicating court order otherwise commission order
-  courtName: string, // Max length 250.
-  courtRegistry: string, // Max length 60.
+  courtName?: string, // Max length 250.
+  courtRegistry?: string, // Max length 60.
   fileNumber: string, // Max length 20.
   orderDate: string, // UTC ISO 8601 datetime format YYYY-MM-DDThh:mm:ssTZD.
-  effectOfOrder: string, // Max length 500.
+  effectOfOrder?: string, // Max length 500.
   action?: ActionTypes // Optional action type for amendments
 }

--- a/ppr-ui/tests/unit/AddEditCommissionOrder.spec.ts
+++ b/ppr-ui/tests/unit/AddEditCommissionOrder.spec.ts
@@ -1,35 +1,31 @@
 import { nextTick } from 'vue'
 import { createComponent } from './utils'
-import { AddEditCourtOrder } from '@/components/registration'
+import { AddEditCommissionOrder } from '@/components/registration'
 import { beforeEach } from 'vitest'
 import flushPromises from 'flush-promises'
 
-describe('AddEditCourtOrder', () => {
+describe('AddEditCommissionOrder', () => {
   let wrapper
   beforeEach(async () => {
     // Mount the component
-    wrapper = await createComponent(AddEditCourtOrder, {
+    wrapper = await createComponent(AddEditCommissionOrder, {
       props: {
         isEditing: false,
-        courtOrderProp: null
+        commissionOrderProp: null
       }
     })
   })
 
   it('renders the form and input fields', () => {
-    expect(wrapper.findComponent(AddEditCourtOrder).exists()).toBe(true)
-    expect(wrapper.find('#txt-court-name').exists()).toBe(true)
-    expect(wrapper.find('#txt-court-registry').exists()).toBe(true)
-    expect(wrapper.find('#txt-court-file-number').exists()).toBe(true)
+    expect(wrapper.findComponent(AddEditCommissionOrder).exists()).toBe(true)
+    expect(wrapper.find('#commission-order-number').exists()).toBe(true)
     expect(wrapper.find('#court-date-text-field').exists()).toBe(true)
     expect(wrapper.find('#effect-of-order').exists()).toBe(true)
   })
 
   it('emits done event with data when submit button is clicked and form is valid', async () => {
-    wrapper.find('#txt-court-name').setValue('Test Court')
-    wrapper.find('#txt-court-registry').setValue('Test Registry')
-    wrapper.find('#txt-court-file-number').setValue('Test File Number')
-    wrapper.vm.courtOrderData.orderDate = '2021-10-07'
+    wrapper.find('#commission-order-number').setValue('1231235')
+    wrapper.vm.commissionOrderData.orderDate = '2021-10-07'
     wrapper.find('#effect-of-order').setValue('Test Effect')
 
     // Wait for Vue to update the DOM
@@ -46,10 +42,8 @@ describe('AddEditCourtOrder', () => {
     expect(wrapper.emitted().done).toBeTruthy()
     expect(wrapper.emitted().done.length).toBe(1)
     expect(wrapper.emitted().done[0][0]).toEqual({
-      courtOrder: true,
-      courtName: 'Test Court',
-      courtRegistry: 'Test Registry',
-      fileNumber: 'Test File Number',
+      courtOrder: false,
+      fileNumber: '1231235',
       orderDate: '2021-10-07',
       effectOfOrder: 'Test Effect'
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21111

*Description of changes:*
- Commission Order Form and implementation
- Updates expansion functionalities to hide show orders, only 1 panel at a time
- Smooths out the expansion transitions
- Include optional vehicle collateral in SAN flow
- Update Order Review component to accommodate Commission Orders
- Unit tests

![Screenshot 2024-05-22 at 11 58 50 AM](https://github.com/bcgov/ppr/assets/53542131/19a1009d-b138-4451-a176-e8677a391e9e)
![Screenshot 2024-05-22 at 11 58 35 AM](https://github.com/bcgov/ppr/assets/53542131/cc971288-37e9-4d6b-a618-89aa376394c8)
![Screenshot 2024-05-22 at 11 57 50 AM](https://github.com/bcgov/ppr/assets/53542131/0ceae0fd-fb43-4e91-91d1-fa2003de5cbe)
![Screenshot 2024-05-22 at 11 57 35 AM](https://github.com/bcgov/ppr/assets/53542131/05f2f093-3e75-487a-bfbf-ea27fc4f7a0d)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
