### PR TITLE
Fix legacy setting of amend permit expiry date.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -789,14 +789,13 @@ class Db2Manuhome(db.Model):
         note: Db2Mhomnote = Db2Mhomnote.create_from_registration(note_json, doc, manuhome.id)
         if doc_type == Db2Document.DocumentTypes.CORRECTION:
             note.document_type = Db2Document.DocumentTypes.PERMIT  # Match legacy registration behaviour.
-            permit_ts = None
-            for existing_doc in manuhome.reg_documents:
-                if existing_doc.document_type in (Db2Document.DocumentTypes.PERMIT,
-                                                  Db2Document.DocumentTypes.PERMIT_TRIM) and \
-                        (not permit_ts or permit_ts < existing_doc.registration_ts):
-                    for existing_note in manuhome.reg_notes:
-                        if existing_doc.id == existing_note.reg_document_id:
-                            note.expiry_date = existing_note.expiry_date  # Use the original expiry date.
+            for existing_note in manuhome.reg_notes:
+                if existing_note.reg_document_id != doc.id and \
+                        existing_note.document_type in (Db2Document.DocumentTypes.PERMIT,
+                                                        Db2Document.DocumentTypes.PERMIT_TRIM) and \
+                        existing_note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
+                        (not note.expiry_date or note.expiry_date < existing_note.expiry_date):
+                    note.expiry_date = existing_note.expiry_date  # Use the original expiry date.
         else:
             note.expiry_date = model_utils.date_offset(manuhome.update_date, 30, True)
         manuhome.reg_notes.append(note)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21002

*Description of changes:*
- Fix to set the expiry date correctly in DB2 for an amend transport permit registration when there are multiple previous permits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
