### PR TITLE
EXEMPTION_RES reg type QS validation rule update.

### DIFF
--- a/mhr_api/src/mhr_api/utils/validator_utils.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils.py
@@ -41,7 +41,7 @@ DOC_ID_REQUIRED = 'Document ID is required for staff registrations. '
 DOC_ID_EXISTS = 'Document ID must be unique: provided value already exists. '
 DOC_ID_INVALID_CHECKSUM = 'Document ID is invalid: checksum failed. '
 STATE_NOT_ALLOWED = 'The MH registration is not in a state where changes are allowed. '
-STATE_FROZEN_AFFIDAVIT = 'A transfer to a benificiary is pending after an AFFIDAVIT transfer. '
+STATE_FROZEN_AFFIDAVIT = 'A transfer to a beneficiary is pending after an AFFIDAVIT transfer. '
 STATE_FROZEN_NOTE = 'Registration not allowed: this manufactured home has an active TAXN, NCON, or REST unit note. '
 STATE_FROZEN_PERMIT = 'Registration not allowed: this manufactured home has an active transport permit. '
 STATE_FROZEN_EXEMPT = 'Registration not allowed: this manufactured home has an active exemption registration. '
@@ -66,7 +66,7 @@ DELETE_GROUP_ID_INVALID = 'The owner group with ID {group_id} is not active and 
 DELETE_GROUP_ID_NONEXISTENT = 'No owner group with ID {group_id} exists. '
 DELETE_GROUP_TYPE_INVALID = 'The owner group tenancy type with ID {group_id} is invalid. '
 GROUP_INTEREST_MISMATCH = 'The owner group interest numerator sum does not equal the interest common denominator. '
-MHR_NUMBER_INVALID = 'MHR nubmer {mhr_num} either is greater than the existng maximum MHR number or already exists. '
+MHR_NUMBER_INVALID = 'MHR number {mhr_num} either is greater than the existng maximum MHR number or already exists. '
 LOCATION_INVALID_IDENTICAL = 'The new location cannot be identical to the existing location. '
 LOCATION_DEALER_REQUIRED = 'Location dealer/manufacturer name is required for this registration. '
 LOCATION_PARK_NAME_REQUIRED = 'Location park name is required for this registration. '
@@ -404,8 +404,11 @@ def check_state_note(registration: MhrRegistration,
                                                   MhrDocumentTypes.REST) and \
                         reg.notes[0].status_type == MhrNoteStatusTypes.ACTIVE:
                     error_msg += STATE_FROZEN_NOTE
+                # STATE_FROZEN_PERMIT rule removed for QS residential exemptions 21424.
                 elif reg.registration_type in (MhrRegistrationTypes.PERMIT, MhrRegistrationTypes.PERMIT_EXTENSION) and \
-                        reg_type not in (MhrRegistrationTypes.PERMIT, MhrRegistrationTypes.PERMIT_EXTENSION) and \
+                        reg_type not in (MhrRegistrationTypes.PERMIT,
+                                         MhrRegistrationTypes.PERMIT_EXTENSION,
+                                         MhrRegistrationTypes.EXEMPTION_RES) and \
                         reg.notes[0].status_type == MhrNoteStatusTypes.ACTIVE and \
                         not model_utils.is_transfer(reg_type) and \
                         not reg.notes[0].is_expired():

--- a/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
+++ b/mhr_api/src/mhr_api/utils/validator_utils_legacy.py
@@ -209,7 +209,8 @@ def check_state_note(manuhome: Db2Manuhome, staff: bool, error_msg: str, reg_typ
                     reg_type not in (MhrRegistrationTypes.PERMIT, MhrRegistrationTypes.PERMIT_EXTENSION) and \
                     note.status == Db2Mhomnote.StatusTypes.ACTIVE and note.expiry_date and \
                     note.expiry_date > model_utils.today_local().date():
-                if not model_utils.is_transfer(reg_type) and \
+                # STATE_FROZEN_PERMIT rule removed for QS residential exemptions 21424.
+                if not model_utils.is_transfer(reg_type) and MhrRegistrationTypes.EXEMPTION_RES != reg_type and \
                         (not doc_type or doc_type != MhrDocumentTypes.CANCEL_PERMIT):
                     error_msg += STATE_FROZEN_PERMIT
     return error_msg

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.11'  # pylint: disable=invalid-name
+__version__ = '1.8.12'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/utils/test_registration_validator.py
+++ b/mhr_api/tests/unit/utils/test_registration_validator.py
@@ -252,6 +252,7 @@ TEST_EXEMPTION_DATA = [
     (DESC_VALID, True, True, DOC_ID_VALID, None, 'PS12345', '000916'),
     ('Valid no doc id not staff', True, False, None, None, 'PS12345', '000916'),
     ('Valid staff PERMIT', True, True, DOC_ID_VALID, None, 'PS12345', '000931'),
+    ('Valid non-staff active transport permit', True, False, None, None, 'PS12345', '000931'),
     ('Invalid no doc id staff', False, True, None, validator_utils.DOC_ID_REQUIRED, 'PS12345', '000916'),
     ('Invalid EXEMPT', False, False, None, validator_utils.EXEMPT_EXRS_INVALID, 'PS12345', '000912'),
     ('Invalid CANCELLED', False, False, None, validator_utils.STATE_NOT_ALLOWED, 'PS12345', '000913'),
@@ -259,7 +260,6 @@ TEST_EXEMPTION_DATA = [
     ('Invalid FROZEN TAXN', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000914'),
     ('Invalid FROZEN NCON', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000918'),
     ('Invalid FROZEN REST', False, False, None, validator_utils.STATE_FROZEN_NOTE, 'PS12345', '000915'),
-    ('Invalid FROZEN PERMIT', False, False, None, validator_utils.STATE_FROZEN_PERMIT, 'PS12345', '000926'),
     ('Invalid existing location staff', False, True, DOC_ID_VALID, validator.LOCATION_NOT_ALLOWED, 'PS12345',
      '000900'),
     ('Invalid existing location QS', False, False, None, validator.LOCATION_NOT_ALLOWED, 'PS12345', '000900')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21425

*Description of changes:*
- Non-staff allow residential exemption registrations when an active transport permit exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
