### PR TITLE
Notice/Order Panel Orders and Optional Date Format

### DIFF
--- a/ppr-ui/src/components/registration/securities-act-notices/NoticePanel.vue
+++ b/ppr-ui/src/components/registration/securities-act-notices/NoticePanel.vue
@@ -392,7 +392,7 @@ const handleAddEditOrder = (order: CourtOrderIF): void => {
     getSecuritiesActNotices.value[props.noticeIndex].securitiesActOrders[editOrderIndex.value] = order
   } else {
     // Set add Court Order
-    getSecuritiesActNotices.value[props.noticeIndex].securitiesActOrders.unshift(order)
+    getSecuritiesActNotices.value[props.noticeIndex].securitiesActOrders.push(order)
   }
   setAndCloseNotice()
   showOrders.value = true

--- a/ppr-ui/src/components/registration/securities-act-notices/SecuritiesActNotices.vue
+++ b/ppr-ui/src/components/registration/securities-act-notices/SecuritiesActNotices.vue
@@ -76,7 +76,7 @@ const disableAddNotice = ref(false)
 const handleAddNotice = (notice: AddEditSaNoticeIF) => {
   openAddNotice.value = false
   // Set add edit notices
-  setSecuritiesActNotices([notice, ...getSecuritiesActNotices.value])
+  setSecuritiesActNotices([...getSecuritiesActNotices.value, notice])
 }
 </script>
 <style lang="scss" scoped>

--- a/ppr-ui/src/utils/registration-helper.ts
+++ b/ppr-ui/src/utils/registration-helper.ts
@@ -391,9 +391,7 @@ const formatSecuritiesActNotices = (notices: Array<AddEditSaNoticeIF>): Array<Ad
     }),
     securitiesActOrders: notice.securitiesActOrders?.map(order => ({
       ...removeEmptyProperties(order),
-      ...(!!notice.effectiveDateTime && {
-        orderDate: convertToISO8601LastMinute(order.orderDate)
-      })
+      orderDate: convertToISO8601LastMinute(order.orderDate)
     }))
   }))
 }

--- a/ppr-ui/src/utils/registration-helper.ts
+++ b/ppr-ui/src/utils/registration-helper.ts
@@ -386,10 +386,14 @@ export async function saveFinancingStatementDraft (stateModel:StateModelIF): Pro
 const formatSecuritiesActNotices = (notices: Array<AddEditSaNoticeIF>): Array<AddEditSaNoticeIF> => {
   return cloneDeep(notices).map(notice => ({
     ...removeEmptyProperties(notice),
-    effectiveDateTime: convertToISO8601LastMinute(notice.effectiveDateTime),
+    ...(!!notice.effectiveDateTime && {
+      effectiveDateTime: convertToISO8601LastMinute(notice.effectiveDateTime)
+    }),
     securitiesActOrders: notice.securitiesActOrders?.map(order => ({
       ...removeEmptyProperties(order),
-      orderDate: convertToISO8601LastMinute(order.orderDate)
+      ...(!!notice.effectiveDateTime && {
+        orderDate: convertToISO8601LastMinute(order.orderDate)
+      })
     }))
   }))
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21212

*Description of changes:*
- Reverse Notice and Orders arrangement in the panels back to Top Down
- Format the Optional EffectiveDateTime conditionally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
