### PR TITLE
Legacy MHR: Year Prop Conversion

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
@@ -339,7 +339,13 @@ export const useMhrCorrections = () => {
         status: getMhrStatusType.value
       }),
       ...(getCorrectionsList().some(value => descriptionGroup.includes(value)) && {
-        description: mhrState.description
+        description: {
+          ...mhrState.description,
+          baseInformation: {
+          ...mhrState.description.baseInformation,
+            year: Number(mhrState.description.baseInformation.year)
+          }
+        }
       }),
       ...(getCorrectionsList().includes('ownerGroups') && {
         addOwnerGroups: mhrState.ownerGroups

--- a/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
@@ -342,8 +342,8 @@ export const useMhrCorrections = () => {
         description: {
           ...mhrState.description,
           baseInformation: {
-          ...mhrState.description.baseInformation,
-            year: Number(mhrState.description.baseInformation.year)
+            ...mhrState.description.baseInformation,
+            year: Number(mhrState.description.baseInformation.year) // Cast to number to support legacy strings
           }
         }
       }),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21410

*Description of changes:*
- Small bug fix to manually cast MHR Year property to a number at point of submission.
- This is to support legacy MHRs where the year property was stored and returned as a string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
