### PR TITLE
SAN: Amendment Tracking UX

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.10",
+  "version": "3.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.10",
+      "version": "3.2.9",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.8",
+  "version": "3.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.8",
+      "version": "3.2.10",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.8",
+  "version": "3.2.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.10",
+  "version": "3.2.9",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
+++ b/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
@@ -53,8 +53,14 @@ export const usePprRegistration = () => {
 
     // Conditionally parse Securities Act Notices
     if (!!statement?.securitiesActNotices){
-      setSecuritiesActNotices(statement.securitiesActNotices)
-      setOriginalSecuritiesActNotices(cloneDeep(statement.securitiesActNotices) as Array<AddEditSaNoticeIF>)
+      // Map the notices to include an empty array for Orders when there is no pre-existing orders on the notice
+      const mappedNotices = statement.securitiesActNotices.map(notice => ({
+        ...notice,
+        securitiesActOrders: notice.securitiesActOrders || []
+      }))
+
+      setSecuritiesActNotices(mappedNotices)
+      setOriginalSecuritiesActNotices(cloneDeep(mappedNotices))
     }
 
     const collateral = {

--- a/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
+++ b/ppr-ui/src/composables/pprRegistration/usePprRegistration.ts
@@ -1,6 +1,6 @@
 import { APIRegistrationTypes, RegistrationFlowType } from '@/enums'
 import {
-  AddCollateralIF, AddEditSaNoticeIF,
+  AddCollateralIF,
   AddPartiesIF,
   CertifyIF,
   CourtOrderIF,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15189

*Description of changes:*
- Improve state tracking on Parent Notice when Child Order have changes/additions/removals
- Updated mapping to include empty orders array when no orders returned from api (ie no pre-existing orders)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
