### PR TITLE
Handle Exemptions with active Transport Permit present

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.11",
+      "version": "3.2.12",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/InfoChip.vue
+++ b/ppr-ui/src/components/common/InfoChip.vue
@@ -39,6 +39,7 @@ export default defineComponent({
           case 'DECEASED':
           case 'HISTORICAL':
           case 'CANCELLED':
+          case 'VOID':
             return { bgColor: 'grey-lighten-2' }
           case 'LIEN':
           case 'LOCKED':

--- a/ppr-ui/src/components/dialogs/BaseDialog.vue
+++ b/ppr-ui/src/components/dialogs/BaseDialog.vue
@@ -39,6 +39,21 @@
           </v-btn>
         </v-col>
       </v-row>
+      <v-row v-if="setConfirmActionLabel">
+        <v-col>
+          <v-checkbox
+            id="confirm-action-checkbox"
+            v-model="isActionConfirmed"
+            class="confirm-action-checkbox"
+            :error="showConfirmedError && !isActionConfirmed"
+            :label="setConfirmActionLabel"
+            :ripple="false"
+            density="compact"
+            hideDetails
+            data-test-id="confirm-action-checkbox"
+          />
+        </v-col>
+      </v-row>
       <v-row v-if="showDismissDialogCheckbox">
         <v-col>
           <v-checkbox
@@ -106,6 +121,10 @@ export default defineComponent({
     showDismissDialogCheckbox: { // display the checkbox to dismiss dialog for all future sessions
       type: Boolean,
       default: false
+    },
+    setConfirmActionLabel: { // label for checkbox to confirm and proceed
+      type: String,
+      default: ''
     }
   },
   emits: ['proceed'],
@@ -120,11 +139,18 @@ export default defineComponent({
       options: computed(() => {
         return props.setOptions
       }),
-      isDismissDialogChecked: false
+      isDismissDialogChecked: false,
+      isActionConfirmed: false,
+      showConfirmedError: false
     })
 
     const proceed = (val: boolean) => {
-      emit('proceed', val)
+      if (props.setConfirmActionLabel && !localState.isActionConfirmed && val) {
+        localState.showConfirmedError = true
+      } else {
+        localState.showConfirmedError = false
+        emit('proceed', val)
+      }
     }
 
     watch(
@@ -154,5 +180,9 @@ export default defineComponent({
   right: 20px;
   top: 35px;
 }
-
+:deep(.confirm-action-checkbox) {
+  .v-label {
+    margin-left: 5px;
+  }
+}
 </style>

--- a/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
+++ b/ppr-ui/src/components/mhrRegistration/ReviewConfirm/HomeLocationReview.vue
@@ -63,7 +63,7 @@
       <section
         v-if="(!!homeLocationInfo.locationType || hasAddress || isOwnLand !== null)"
         id="review-home-location-section"
-        class="pt-5 pb-9"
+        class="pb-9"
       >
         <v-row
           v-if="isCancelChangeLocationActive && isPrevTransportPermitLocation"
@@ -87,6 +87,8 @@
             !isPrevTransportPermitLocation &&
             !isCancelTransportPermitReview"
           :isCancelledLocation="isCancelledTransportPermitDetails"
+          :isVoidPermit="isExemptionWithActiveTransportPermit"
+          :infoText="exemptionWithActivePermitText"
           class="mt-5"
         />
 
@@ -96,7 +98,7 @@
         >
           <v-row
             noGutters
-            class="px-8"
+            class="pt-5 px-8"
           >
             <v-col
               cols="3"
@@ -596,6 +598,7 @@ import { computed, defineComponent, onMounted, reactive, ref, toRefs, watch } fr
 import { HomeLocationTypes, LocationChangeTypes, RouteNames } from '@/enums'
 import { useStore } from '@/store/store'
 import {
+  useExemptions,
   useInputRules,
   useMhrCorrections,
   useMhrInfoValidation,
@@ -688,6 +691,7 @@ export default defineComponent({
     } = useTransportPermits()
     const { correctionState, isMhrCorrection } = useMhrCorrections()
     const { showUpdatedBadge } = useUpdatedBadges()
+    const { isExemptionWithActiveTransportPermit, exemptionLabel } = useExemptions()
 
     const homeLocationInfo: MhrRegistrationHomeLocationIF =
       (props.isPrevTransportPermitLocation || props.isCancelTransportPermitReview)
@@ -732,6 +736,11 @@ export default defineComponent({
         homeLocationInfo.address?.streetAdditional ||
         homeLocationInfo.address?.city)
       }),
+      exemptionWithActivePermitText: computed((): string =>
+        isExemptionWithActiveTransportPermit.value
+          ? `The transport permit on this home will no longer be valid upon filing this ${exemptionLabel.value}`
+          : ''
+      ),
       displayPid: computed((): string => {
         return homeLocationInfo.pidNumber?.replace(/(\d{3})(\d{3})(\d{3})/, '$1-$2-$3')
       }),
@@ -826,6 +835,7 @@ export default defineComponent({
       isMhrCorrection,
       isMhrReRegistration,
       showUpdatedBadge,
+      isExemptionWithActiveTransportPermit,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/mhrTransportPermit/TransportPermitDetails.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/TransportPermitDetails.vue
@@ -1,20 +1,39 @@
 <template>
   <article
     id="transport-permit-details"
-    class="px-8"
-    :class="{ 'cancelled-transport-permit-details': isCancelledLocation }"
+    class="px-8 pt-5"
+    :class="[
+      { 'cancelled-transport-permit-details': isCancelledLocation },
+      { 'void-transport-permit-details': isVoidPermit }
+    ]"
   >
     <v-row noGutters>
       <v-col
-        cols="3"
         class="transport-details-header"
       >
+        <InfoChip
+          v-if="isVoidPermit"
+          class="ml-2"
+          action="VOID"
+          style="float: left; margin-left: 0 !important;"
+          data-test-id="void-transport-permit-badge"
+        />
         <h3>Transport Permit Details</h3>
         <InfoChip
           v-if="isCancelledLocation"
           class="ml-2"
           action="CANCELLED"
         />
+      </v-col>
+    </v-row>
+
+    <v-row
+      v-if="infoText"
+      class="mt-0"
+      data-test-id="permit-details-info-text"
+    >
+      <v-col>
+        {{ infoText }}
       </v-col>
     </v-row>
 
@@ -53,7 +72,7 @@
         <p>{{ shortPacificDate(getMhrInformation.permitExpiryDateTime) }}</p>
       </v-col>
     </v-row>
-    <v-divider class="my-6" />
+    <v-divider class="transport-permit-divider my-6" />
   </article>
 </template>
 
@@ -66,9 +85,13 @@ const { getMhrInformation } = storeToRefs(useStore())
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const props = withDefaults(defineProps<{
-  isCancelledLocation?: boolean
+  isCancelledLocation?: boolean,
+  isVoidPermit?: boolean,
+  infoText?: string
 }>(), {
-  isCancelledLocation: false
+  isCancelledLocation: false,
+  isVoidPermit: false,
+  infoText: ''
 })
 
 </script>
@@ -86,6 +109,20 @@ h3 {
   }
   .v-row:not(:first-child), .transport-details-header h3 {
     opacity: 0.4;
+  }
+}
+
+.void-transport-permit-details {
+  background-color: #FAFAFA;
+  margin-top: 0px !important;
+  padding-top: 40px !important;
+
+  border-bottom: 1px solid $gray3;
+  margin-bottom: 28px;
+  padding-bottom: 31px;
+
+  .transport-permit-divider {
+    display: none;
   }
 }
 </style>

--- a/ppr-ui/src/composables/exemption/useExemptions.ts
+++ b/ppr-ui/src/composables/exemption/useExemptions.ts
@@ -10,13 +10,7 @@ import {
   parseAccountToSubmittingParty,
   removeEmptyProperties
 } from '@/utils'
-import {
-  ExemptionIF,
-  IndividualNameIF,
-  MhRegistrationSummaryIF,
-  PartyIF,
-  UnitNoteIF
-} from '@/interfaces'
+import { ExemptionIF, IndividualNameIF, MhRegistrationSummaryIF, PartyIF, UnitNoteIF } from '@/interfaces'
 import {
   APIMhrDescriptionTypes,
   MhApiStatusTypes,
@@ -37,7 +31,8 @@ export const useExemptions = () => {
     isRoleStaffReg,
     isRoleQualifiedSupplier,
     isRoleQualifiedSupplierLawyersNotaries,
-    getMhrUnitNotes
+    getMhrUnitNotes,
+    getMhrInformation
   } = storeToRefs(useStore())
 
   /** Returns true when staff or qualified supplier(Lawyers and Notaries) and the feature flag is enabled **/
@@ -54,6 +49,19 @@ export const useExemptions = () => {
   /** Returns true when current exemption type is non-residential **/
   const isNonResExemption: ComputedRef<boolean> = computed((): boolean => {
     return getMhrExemption.value?.note?.documentType === UnitNoteDocTypes.NON_RESIDENTIAL_EXEMPTION
+  })
+
+  /** Returns true when current exemption type is residential **/
+  const isResExemption: ComputedRef<boolean> = computed((): boolean => {
+    return getMhrExemption.value?.note?.documentType === UnitNoteDocTypes.RESIDENTIAL_EXEMPTION_ORDER
+  })
+
+  /** Returns true if in Exemptions flow with active Transport Permit **/
+  const isExemptionWithActiveTransportPermit: ComputedRef<boolean> = computed((): boolean => {
+    return (
+      getMhrInformation.value.permitStatus === MhApiStatusTypes.ACTIVE &&
+      (isResExemption.value || isNonResExemption.value)
+    )
   })
 
   /** Returns Exemption type label **/
@@ -199,6 +207,8 @@ export const useExemptions = () => {
     isExemptionEnabled,
     isNonResExemptionEnabled,
     isNonResExemption,
+    isResExemption,
+    isExemptionWithActiveTransportPermit,
     exemptionLabel,
     goToExemptions,
     updateValidation,

--- a/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/confirmationDialogs.ts
@@ -124,3 +124,14 @@ export const confirmRemoveNoticeDialog: DialogOptionsIF = {
   title: 'Remove Notice and Orders Attached',
   text: `Removing this notice will also remove all orders attached.`
 }
+
+export const manufacturedHomeDeliveredDialogOptions = (exemptionType: string = ''): DialogOptionsIF => {
+  return {
+    acceptText: `Continue with ${exemptionType}`,
+    cancelText: 'Cancel',
+    title: 'Active Transport Permit',
+    text: `To continue with this ${exemptionType}, the manufactured home <b>MUST have been delivered</b>
+      to the location specified in the permit and the transport permit on this manufactured home will be void
+      upon filing the ${exemptionType}.`
+  }
+}

--- a/ppr-ui/src/views/exemption/ExemptionReview.vue
+++ b/ppr-ui/src/views/exemption/ExemptionReview.vue
@@ -47,6 +47,22 @@
     </ReviewCard>
 
     <section
+      v-if="isExemptionWithActiveTransportPermit"
+      data-test-id="exemption-active-permit-section"
+      class="mt-15"
+    >
+      <CautionBox
+        class="mb-8"
+        :setMsg="`The transport permit on this home will be void upon filing this ${exemptionLabel}`"
+      />
+
+      <TransportPermitDetails
+        isVoidPermit
+        class="mt-5 void-transport-permit-details-review"
+      />
+    </section>
+
+    <section
       v-if="isRoleQualifiedSupplier"
       id="exemptions-qs-submitting-party"
       class="mt-10"
@@ -209,6 +225,8 @@ import {
 } from '@/components/common'
 import { useExemptions, usePayment } from '@/composables'
 import { parseSubmittingPartyToAccountInfo, yyyyMmDdToPacificDate } from '@/utils'
+import { TransportPermitDetails } from '@/components/mhrTransportPermit'
+import CautionBox from '@/components/common/CautionBox.vue'
 
 export default defineComponent({
   name: 'ExemptionReview',
@@ -224,7 +242,9 @@ export default defineComponent({
     PartyForm,
     ReviewCard,
     StaffPayment,
-    LienAlert
+    LienAlert,
+    TransportPermitDetails,
+    CautionBox
   },
   props: { showErrors: { type: Boolean, default: false } },
   setup () {
@@ -241,7 +261,12 @@ export default defineComponent({
       isRoleQualifiedSupplier,
       hasLien
     } = storeToRefs(useStore())
-    const { exemptionLabel, isNonResExemption, updateValidation } = useExemptions()
+    const {
+      exemptionLabel,
+      isNonResExemption,
+      updateValidation,
+      isExemptionWithActiveTransportPermit
+    } = useExemptions()
     const { onStaffPaymentDataUpdate } = usePayment()
 
     const localState = reactive({
@@ -322,6 +347,7 @@ export default defineComponent({
       parseSubmittingPartyToAccountInfo,
       attentionExemptionConfig,
       hasLien,
+      isExemptionWithActiveTransportPermit,
       ...toRefs(localState)
     }
   }
@@ -333,5 +359,10 @@ export default defineComponent({
 
 .hint-message{
   font-size: 16px !important;
+}
+
+.void-transport-permit-details-review {
+  border-radius: 4px;
+  border: 1px solid $gray3;
 }
 </style>

--- a/ppr-ui/tests/unit/BaseDialog.spec.ts
+++ b/ppr-ui/tests/unit/BaseDialog.spec.ts
@@ -8,14 +8,17 @@ import {
   tableDeleteDialog,
   tableRemoveDialog,
   unsavedChangesDialog,
-  manufacturerRegSuccessDialogOptions
+  manufacturerRegSuccessDialogOptions,
+  manufacturedHomeDeliveredDialogOptions
 } from '@/resources/dialogOptions'
-import { createComponent, getLastEvent } from './utils'
+import { createComponent, getLastEvent, getTestId } from './utils'
 import { BaseDialog } from '@/components/dialogs'
 import { DialogOptionsIF } from '@/interfaces'
 import flushPromises from 'flush-promises'
 import { DialogButtons, DialogContent } from '@/components/dialogs/common'
 import { nextTick } from 'vue'
+import { UnitNoteDocTypes } from '@/enums'
+import { UnitNotesInfo } from '@/resources'
 
 // emitted events
 const proceed = 'proceed'
@@ -116,6 +119,33 @@ describe('Base Dialog tests', () => {
 
     expect(wrapper.findComponent(BaseDialog).isVisible()).toBe(true)
     expect(wrapper.find('#dismiss-dialog-checkbox').isVisible()).toBe(true)
+  })
+
+  it('renders manufactured home delivered base dialog with a confirm checkbox', async () => {
+    const dialogOptions = manufacturedHomeDeliveredDialogOptions(
+      UnitNotesInfo[UnitNoteDocTypes.NON_RESIDENTIAL_EXEMPTION].header
+    )
+
+    wrapper = await createComponent(BaseDialog, {
+      setAttach: '',
+      setDisplay: true,
+      setConfirmActionLabel: 'I confirm this selection',
+      setOptions: dialogOptions,
+      showDismissDialogCheckbox: true
+    })
+
+    expect(wrapper.findComponent(BaseDialog).isVisible()).toBe(true)
+    expect(wrapper.find('h2').text()).toBe(dialogOptions.title)
+    expect(wrapper.find('.dialog-text').text()).toBe(dialogOptions.text.replace(/<[^>]*>/g, '')) // replace html tags
+
+    const confirmActionCheckbox = wrapper.find(getTestId('confirm-action-checkbox'))
+    expect(confirmActionCheckbox.exists()).toBe(true)
+    expect(confirmActionCheckbox.text()).toBe('I confirm this selection')
+
+    expect(confirmActionCheckbox.classes('v-input--error')).toBeFalsy() // checkbox should not be in error state
+    wrapper.findComponent(DialogButtons).vm.$emit(proceed, true) // click the primary button in dialog
+    await nextTick()
+    expect(confirmActionCheckbox.classes('v-input--error')).toBeTruthy() // checkbox should be in error state
   })
 
   it('Emits the button actions', async () => {

--- a/ppr-ui/tests/unit/ExemptionDetails.spec.ts
+++ b/ppr-ui/tests/unit/ExemptionDetails.spec.ts
@@ -2,15 +2,21 @@ import { ExemptionDetails } from '@/views'
 import { CautionBox, DocumentId, LienAlert, Remarks, SimpleHelpToggle } from '@/components/common'
 import { HomeLocationReview, HomeOwnersReview, YourHomeReview } from '@/components/mhrRegistration/ReviewConfirm'
 
-import { createComponent, setupMockStaffUser } from './utils'
+import { createComponent, getTestId, setupActiveTransportPermit, setupMockStaffUser } from './utils'
 import { nextTick } from 'vue'
 import { axe } from 'vitest-axe'
+import { TransportPermitDetails } from '@/components/mhrTransportPermit'
+import { useStore } from '@/store/store'
+import { mockedAddress } from './test-data'
+import { UnitNoteDocTypes } from '@/enums'
+
+const store = useStore()
 
 describe('ExemptionDetails', () => {
   let wrapper
 
   beforeEach(async () => {
-    wrapper = await createComponent((ExemptionDetails as any), { showErrors: false })
+    wrapper = await createComponent(ExemptionDetails as any, { showErrors: false })
     await nextTick()
   })
 
@@ -45,8 +51,32 @@ describe('ExemptionDetails', () => {
   it('should have no accessibility violations', async () => {
     // Run the axe-core accessibility check on the component's HTML
     const results = await axe(wrapper.html())
-    expect(results).toBeDefined();
-    expect(results.violations).toBeDefined();
-    expect(results.violations).toHaveLength(0);
+    expect(results).toBeDefined()
+    expect(results.violations).toBeDefined()
+    expect(results.violations).toHaveLength(0)
+  })
+
+  it('renders the Exemption Details with active Transport Permit', async () => {
+    setupMockStaffUser()
+
+    // setup active Transport Permit and Non-Res Exemption
+    setupActiveTransportPermit()
+    store.setMhrLocation({ key: 'address', value: mockedAddress })
+    store.setMhrExemptionNote({ key: 'documentType', value: UnitNoteDocTypes.NON_RESIDENTIAL_EXEMPTION })
+    await nextTick()
+
+    expect(wrapper.findComponent(CautionBox).exists()).toBe(true)
+    expect(wrapper.findComponent(SimpleHelpToggle).exists()).toBe(true)
+    expect(wrapper.findComponent(DocumentId).exists()).toBe(true)
+    expect(wrapper.findComponent(YourHomeReview).exists()).toBe(true)
+    expect(wrapper.findComponent(HomeLocationReview).findComponent(HomeLocationReview).exists()).toBe(true)
+
+    const transportPermitDetails = wrapper.findComponent(HomeLocationReview).findComponent(TransportPermitDetails)
+    expect(transportPermitDetails.exists()).toBe(true)
+    expect(transportPermitDetails.find(getTestId('void-transport-permit-badge')).exists()).toBeTruthy()
+    expect(transportPermitDetails.find(getTestId('permit-details-info-text')).exists()).toBeTruthy()
+
+    expect(wrapper.findComponent(HomeOwnersReview).exists()).toBe(true)
+    expect(wrapper.findComponent(Remarks).exists()).toBe(true)
   })
 })

--- a/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
@@ -273,11 +273,7 @@ describe('Mhr Information Transport Permit', async () => {
   beforeEach(async () => {
     defaultFlagSet['mhr-transport-permit-enabled'] = true
 
-    wrapper = await createComponent(
-      MhrInformation,
-      { appReady: true },
-      RouteNames.MHR_INFORMATION
-    )
+    wrapper = await createComponent(MhrInformation, { appReady: true }, RouteNames.MHR_INFORMATION)
     await store.setAuthRoles([AuthRoles.PPR_STAFF])
     wrapper.vm.dataLoaded = true
   })
@@ -781,7 +777,7 @@ describe('Mhr Information Transport Permit', async () => {
     wrapper.vm.dataLoaded = true
 
     // setup current location to be cancelled
-    const location = {...mockTransportPermitNewLocation }
+    const location = { ...mockTransportPermitNewLocation }
     location.otherType = mockTransportPermitNewLocation.locationType
     location.locationType = HomeLocationTypes.HOME_PARK
 
@@ -798,7 +794,7 @@ describe('Mhr Information Transport Permit', async () => {
     await setupActiveTransportPermit()
 
     // setup previous location to restore
-    const previousLocation: MhrRegistrationHomeLocationIF = {...mockTransportPermitPreviousLocation}
+    const previousLocation: MhrRegistrationHomeLocationIF = { ...mockTransportPermitPreviousLocation }
     previousLocation.otherType = mockTransportPermitPreviousLocation.locationType
     previousLocation.locationType = HomeLocationTypes.OTHER_LAND
 
@@ -839,7 +835,7 @@ describe('Mhr Information Transport Permit', async () => {
     wrapper.vm.dataLoaded = true
 
     // setup current location to be cancelled
-    const location = {...mockTransportPermitNewLocation }
+    const location = { ...mockTransportPermitNewLocation }
     location.otherType = mockTransportPermitNewLocation.locationType
     location.locationType = HomeLocationTypes.HOME_PARK
 
@@ -856,7 +852,7 @@ describe('Mhr Information Transport Permit', async () => {
     await setupActiveTransportPermit()
 
     // setup previous location to restore
-    const previousLocation: MhrRegistrationHomeLocationIF = {...mockTransportPermitPreviousLocation}
+    const previousLocation: MhrRegistrationHomeLocationIF = { ...mockTransportPermitPreviousLocation }
     previousLocation.otherType = mockTransportPermitPreviousLocation.locationType
     previousLocation.locationType = HomeLocationTypes.OTHER_LAND
 
@@ -894,7 +890,13 @@ describe('Mhr Information Transport Permit', async () => {
 
     expect(homeLocationReview.findAllComponents(InfoChip).length).toBe(1)
     expect(homeLocationReview.findAllComponents(InfoChip)[0].text()).toContain('CANCELLED')
-    expect(homeLocationReview.findComponent(TransportPermitDetails).classes('cancelled-transport-permit-details')).toBeTruthy()
+
+    const transportPermitDetails = homeLocationReview.findComponent(TransportPermitDetails)
+    expect(transportPermitDetails.classes('cancelled-transport-permit-details')).toBeTruthy()
+    expect(transportPermitDetails.find(getTestId('permit-details-info-text')).exists()).toBeFalsy()
+    // only visible for Exemptions with active Transport Permit
+    expect(transportPermitDetails.find(getTestId('void-transport-permit-badge')).exists()).toBeFalsy()
+
     expect(homeLocationReviewText).toContain(store.getMhrInformation.permitRegistrationNumber) // Transport Permit number should be visible
     expect(homeLocationReviewText).toContain(mockTransportPermitNewLocation.address.street)
     expect(homeLocationReviewText).toContain('Manufactured home park')


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#21507

*Description of changes:*
- Add modal when launching Exemptions flow when there is active Transport Permit
- Update BaseDialog to include confirm checkbox
- Exemptions Details & Review pages updates
- Unit tests

![Screenshot 2024-06-06 at 01 45 51](https://github.com/bcgov/ppr/assets/2333290/07de4d99-c387-4ff0-84eb-c2421f288b89)

![Screenshot 2024-06-06 at 05 23 48](https://github.com/bcgov/ppr/assets/2333290/4f5201f7-9542-49cf-b43f-78645c4f3799)

![Screenshot 2024-06-06 at 06 11 33](https://github.com/bcgov/ppr/assets/2333290/00bef270-29db-44a3-b613-923e7d07a5e4)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
