### PR TITLE
Update Fee for Amend & Cancel Transport Permit

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.16",
+      "version": "3.2.17",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
+++ b/ppr-ui/src/composables/fees/factories/useFeeSummary.ts
@@ -130,10 +130,10 @@ export function getFeeSummary (
     return { ...defaultFeeSummaries.transportPermit25 }
   }
   if (feeType === FeeSummaryTypes.MHR_AMEND_TRANSPORT_PERMIT) {
-    return { ...defaultFeeSummaries.feeDefaultNoFee }
+    return { ...defaultFeeSummaries.feeDefault15 }
   }
   if (feeType === FeeSummaryTypes.MHR_TRANSPORT_PERMIT_CANCEL) {
-    return { ...defaultFeeSummaries.feeDefaultNoFee }
+    return { ...defaultFeeSummaries.feeDefault15 }
   }
   if(feeType === FeeSummaryTypes.MHR_STAFF_CORRECTION) {
     return { ...defaultFeeSummaries[FeeSummaryDefaults.NO_FEE] }

--- a/ppr-ui/src/composables/mhrInformation/useMhrInfoValidation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInfoValidation.ts
@@ -123,15 +123,6 @@ export const useMhrInfoValidation = (validationState: mhrInfoValidationStateIF) 
 
   const isValidTransportPermitReview = computed((): boolean => {
 
-    if (isCancelChangeLocationActive.value) {
-      return (
-        (isRoleStaffReg.value ? validationState.isSubmittingPartyValid : true) &&
-        validationState.isRefNumValid &&
-        validationState.isCompletionConfirmed &&
-        validationState.isAuthorizationValid
-      )
-    }
-
     return (
       ((isRoleStaffReg.value || isRoleStaffSbc.value) ? validationState.isSubmittingPartyValid : true) &&
       validationState.isRefNumValid &&

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -350,7 +350,7 @@
                 </section>
 
                 <section
-                  v-if="isRoleStaffReg && !isCancelChangeLocationActive"
+                  v-if="isRoleStaffReg"
                   id="staff-transfer-payment-section"
                   class="mt-10 pt-4 pb-4"
                 >

--- a/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
@@ -908,9 +908,7 @@ describe('Mhr Information Transport Permit', async () => {
     const feeSummaryContainerText = wrapper.find(getTestId('fee-summary')).text()
     expect(feeSummaryContainerText).toContain('Cancel Transport Permit')
     expect(feeSummaryContainerText).toContain('$15.00')
-
-    // Staff Payment component should not exist for Cancelled Transport Permits
-    expect(wrapper.findComponent(StaffPayment).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffPayment).exists()).toBeTruthy()
 
     useTransportPermits().setLocationChange(false)
   })

--- a/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransportPermit.spec.ts
@@ -714,6 +714,10 @@ describe('Mhr Information Transport Permit', async () => {
     expect(locationChange.findAll('#updated-badge-component').length).toBe(1)
     expect(locationChange.findByTestId('amend-permit-changes-required-msg').exists()).toBeFalsy()
 
+    const feeSummaryContainerText = wrapper.find(getTestId('fee-summary')).text()
+    expect(feeSummaryContainerText).toContain('Amend Transport Permit')
+    expect(feeSummaryContainerText).toContain('$15.00')
+
     // reset feature flags
     defaultFlagSet['mhr-amend-transport-permit-enabled'] = false
     useTransportPermits().setLocationChange(false)
@@ -903,8 +907,7 @@ describe('Mhr Information Transport Permit', async () => {
 
     const feeSummaryContainerText = wrapper.find(getTestId('fee-summary')).text()
     expect(feeSummaryContainerText).toContain('Cancel Transport Permit')
-    expect(feeSummaryContainerText).toContain('No Fee')
-    expect(feeSummaryContainerText).toContain('$0.00')
+    expect(feeSummaryContainerText).toContain('$15.00')
 
     // Staff Payment component should not exist for Cancelled Transport Permits
     expect(wrapper.findComponent(StaffPayment).exists()).toBe(false)


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#21478

*Description of changes:*
- Add $15 fee for Ament and Cancel TP
- Re-implement StaffPayment component
- Unit test update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
