### PR TITLE
Fix legacy individual owner suffix.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/owner.py
+++ b/mhr_api/src/mhr_api/models/db2/owner.py
@@ -255,7 +255,9 @@ class Db2Owner(db.Model):
         suffix: str = new_info.get('suffix', '')
         if suffix:
             suffix = suffix.strip().upper()
-        if new_info.get('partyType') and new_info.get('description'):
+        # Description is only for TRUSTEE/ADMINISTRATOR/EXECUTOR: ignore for owners.
+        if new_info.get('partyType') and new_info.get('description') and \
+                new_info.get('partyType') not in (MhrPartyTypes.OWNER_BUS, MhrPartyTypes.OWNER_IND):
             suffix = str(new_info.get('description')).strip().upper()
             if new_info.get('partyType') == MhrPartyTypes.TRUSTEE and suffix.find(TRUSTEE_SUFFIX) < 0:
                 suffix = TRUSTEE_SUFFIX + ' ' + suffix

--- a/mhr_api/src/mhr_api/models/db2/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/db2/registration_utils.py
@@ -346,9 +346,7 @@ def cancel_note(manuhome, reg_json, doc_type: str, doc_id: int):
                                            Db2Document.DocumentTypes.EXTEND_CAUTION):
                 note.can_document_id = doc_id
                 note.status = Db2Mhomnote.StatusTypes.CANCELLED
-    elif doc_type == MhrDocumentTypes.EXRE and cancel_doc_type in (MhrDocumentTypes.EXNR,
-                                                                   MhrDocumentTypes.EXRS,
-                                                                   MhrDocumentTypes.EXMN):
+    elif doc_type == MhrDocumentTypes.EXRE:
         for note in manuhome.reg_notes:
             if note.status == Db2Mhomnote.StatusTypes.ACTIVE and \
                     note.document_type in (MhrDocumentTypes.EXNR, MhrDocumentTypes.EXRS, MhrDocumentTypes.EXMN):

--- a/mhr_api/src/mhr_api/models/registration_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_utils.py
@@ -525,6 +525,18 @@ def save_active(registration):
         current_app.logger.info('No modernized registration to set to active status.')
 
 
+def cancel_note_exre(registration, new_reg_id):
+    """EXRE cancel all active exemption notes."""
+    for reg in registration.change_registrations:
+        if reg.notes and reg.notes[0].document_type in (MhrDocumentTypes.EXNR,
+                                                        MhrDocumentTypes.EXRS,
+                                                        MhrDocumentTypes.EXMN):
+            note = reg.notes[0]
+            if note.status_type == MhrNoteStatusTypes.ACTIVE:
+                note.status_type = MhrNoteStatusTypes.CANCELLED
+                note.change_registration_id = new_reg_id
+
+
 def save_admin(registration, json_data: dict, new_reg_id: int):
     """Admin registration updates to existing records."""
     doc_type: str = json_data.get('documentType', '')
@@ -549,6 +561,9 @@ def save_admin(registration, json_data: dict, new_reg_id: int):
     save_admin_status(registration, json_data, new_reg_id, doc_type)
     if json_data.get('addOwnerGroups') and json_data.get('deleteOwnerGroups'):
         registration.remove_groups(json_data, new_reg_id)
+    # EXRE cancel exemption notes as well.
+    if doc_type == MhrDocumentTypes.EXRE:
+        cancel_note_exre(registration, new_reg_id)
     db.session.commit()
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21724

*Description of changes:*
- Fix saving to legacy DB2 when UI submitting description with individual owner suffix.
- 21244 EXRE close out active exemption unit notes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
