### PR TITLE
MHR permit active exists, legacy owner names.

### DIFF
--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -221,6 +221,7 @@ class Db2Manuhome(db.Model):
                 index: int = len(self.reg_documents) - 1
                 doc: Db2Document = self.reg_documents[index]
                 doc.save()
+                today = model_utils.today_local()
                 if self.reg_notes:
                     index: int = len(self.reg_notes) - 1
                     note: Db2Mhomnote = self.reg_notes[index]
@@ -229,8 +230,9 @@ class Db2Manuhome(db.Model):
                     for note in self.reg_notes:
                         if note.reg_document_id != doc.id and \
                                 note.document_type in (Db2Document.DocumentTypes.PERMIT,
-                                                       Db2Document.DocumentTypes.PERMIT_TRIM) and \
-                                note.status == Db2Mhomnote.StatusTypes.ACTIVE:
+                                                       Db2Document.DocumentTypes.PERMIT_TRIM,
+                                                       Db2Document.DocumentTypes.PERMIT_EXTENSION) and \
+                                note.status == Db2Mhomnote.StatusTypes.ACTIVE and note.expiry_date >= today.date():
                             note.status = Db2Mhomnote.StatusTypes.CANCELLED
                             note.can_document_id = doc.id
                             note.save()

--- a/mhr_api/src/mhr_api/models/type_tables.py
+++ b/mhr_api/src/mhr_api/models/type_tables.py
@@ -240,6 +240,7 @@ class MhrNoteStatusTypes(BaseEnum):
     CANCELLED = 'CANCELLED'
     EXPIRED = 'EXPIRED'
     CORRECTED = 'CORRECTED'
+    COMPLETED = 'COMPLETED'
 
 
 class MhrOwnerStatusTypes(BaseEnum):

--- a/mhr_api/src/mhr_api/resources/utils.py
+++ b/mhr_api/src/mhr_api/resources/utils.py
@@ -273,9 +273,9 @@ def validate_exemption(registration, json_data, is_staff: bool = False):
     return registration_validator.validate_exemption(registration, json_data, is_staff)
 
 
-def validate_permit(registration, json_data, is_staff: bool = False, group_name: str = None):
+def validate_permit(registration, json_data, account_id: str, is_staff: bool = False, group_name: str = None):
     """Perform non-schema extra validation on a transport permit registration."""
-    return registration_validator.validate_permit(registration, json_data, is_staff, group_name)
+    return registration_validator.validate_permit(registration, json_data, account_id, is_staff, group_name)
 
 
 def validate_note(registration, json_data, is_staff: bool, group: str):

--- a/mhr_api/src/mhr_api/resources/v1/permits.py
+++ b/mhr_api/src/mhr_api/resources/v1/permits.py
@@ -77,7 +77,11 @@ def post_permits(mhr_number: str):  # pylint: disable=too-many-return-statements
         # Additional validation not covered by the schema.
         group: str = get_group(jwt)
         request_json = get_qs_location(request_json, group, account_id)
-        extra_validation_msg = resource_utils.validate_permit(current_reg, request_json, is_all_staff, group)
+        extra_validation_msg = resource_utils.validate_permit(current_reg,
+                                                              request_json,
+                                                              account_id,
+                                                              is_all_staff,
+                                                              group)
         if not valid_format or extra_validation_msg != '':
             return resource_utils.validation_error_response(errors, reg_utils.VAL_ERROR, extra_validation_msg)
         # Set up the registration, pay, and save the data.

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.13'  # pylint: disable=invalid-name
+__version__ = '1.8.14'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_types.py
+++ b/mhr_api/tests/unit/models/test_types.py
@@ -25,7 +25,7 @@ import pytest
 
 # testdata pattern is ({result_count}, {model_class}, {enum_class})
 TEST_TYPE_TABLES = [
-    (4, type_tables.MhrNoteStatusType, type_tables.MhrNoteStatusTypes),
+    (5, type_tables.MhrNoteStatusType, type_tables.MhrNoteStatusTypes),
     (3, type_tables.MhrOwnerStatusType, type_tables.MhrOwnerStatusTypes),
     (5, type_tables.MhrRegistrationStatusType, type_tables.MhrRegistrationStatusTypes),
     (3, type_tables.MhrStatusType, type_tables.MhrStatusTypes)


### PR DESCRIPTION
*Issue #:* 
- /bcgov/entity#21715
- /bcgov/entity#21765

*Description of changes:*
- 21715 Conditionally allow a transport permit registration when an active permit exists.
- 21765 Individual owner names legacy save update when there are multiple middle names: conditionally save to the DB2 owner suffix. Handle Administrator/Executor/Trustee with multiple middle names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
