### PR TITLE
Re-Registration Updates

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.24",
+  "version": "3.2.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.24",
+      "version": "3.2.25",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.24",
+  "version": "3.2.25",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -77,7 +77,7 @@
                   color="primary"
                   label="Middle Name (Optional)"
                   data-test-id="middle-name"
-                  :rules="maxLength(15)"
+                  :rules="maxLength(50)"
                   :disabled="disableNameFields"
                   :readonly="disableNameFields"
                 />

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -68,7 +68,7 @@
             </div>
 
             <div
-              v-if="(forceShowGroups || showGroups) &&
+              v-if="(forceShowGroups === undefined ? showGroups : forceShowGroups) &&
                 !(disableGroupHeader(group.groupId) && (hideRemovedOwners || isReadonlyTable))"
               :colspan="4"
               class="py-3 group-header-slot"

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -199,7 +199,8 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
     const groups = getTransferOrRegistrationHomeOwnerGroups().filter(group => group.action !== ActionTypes.REMOVED)
     const hasNoGroups = [HomeTenancyTypes.SOLE, HomeTenancyTypes.JOINT].includes(getHomeTenancyType()) ||
       groups.length === 0
-    return hasNoGroups || !groups || groups.length >= 2 ||
+
+    return !hasNoGroups || !groups || groups.length >= 2 ||
       (!showGroups.value && groups.length === 1)
   }
 

--- a/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
@@ -39,6 +39,7 @@ export const useMhrCorrections = () => {
     getMhrBaseline,
     getMhrHomeSections,
     isRoleStaffReg,
+    isMhrReRegistration,
     getMhrTransportPermit,
     getMhrAccountSubmittingParty,
     getMhrTransportPermitPreviousLocation,
@@ -213,8 +214,12 @@ export const useMhrCorrections = () => {
     // HomeSection: Leveraging section applied actions for correction identification
     homeSections: computed ((): boolean => getMhrHomeSections.value?.some(section => !!section.action)),
     // HomeOwners: Leveraging group and owner applied actions for correction identification
-    ownerGroups: computed ((): boolean => getMhrRegistrationHomeOwnerGroups.value?.some(group =>
-      !!group.action || group.owners.some(owner => !!owner.action))
+    ownerGroups: computed ((): boolean => isMhrReRegistration.value ||
+      getMhrRegistrationHomeOwnerGroups.value?.some(group =>
+        !!group.action || group.owners.some(owner =>
+          !!owner.action
+        )
+      )
     )
   })
 

--- a/ppr-ui/src/composables/mhrRegistration/useMhrReRegistration.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrReRegistration.ts
@@ -60,9 +60,9 @@ export const useMhrReRegistration = () => {
 
       // remove props that should not be pre-populated into Re-Registration
       data.documentId = ''
-      data.ownerGroups = []
       data.attentionReference = ''
       data.submittingParty = {}
+
       // parse Transport Permit data to correctly show Location of Home step
       parseMhrPermitData(data)
     } else {
@@ -85,6 +85,8 @@ export const useMhrReRegistration = () => {
     )
 
     if (!isDraft) {
+      // Remove owners after setting Mhr Baseline
+      data.ownerGroups = []
       await useNewMhrRegistration().initDraftOrCurrentMhr(data)
     }
   }

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -55,6 +55,7 @@ import {
 import { TransferDetails, TransferDetailsReview, TransferType } from '@/components/mhrTransfers'
 
 import { defaultFlagSet, toDisplayPhone } from '@/utils'
+import { setupCurrentHomeOwners, setupCurrentMultipleHomeOwnersGroups, triggerUnsavedChange } from './utils'
 import { QualifiedSupplierTransferTypes, StaffTransferTypes, StaffTransferTypesOrg, UnitNotesInfo } from '@/resources'
 import { useTransportPermits } from '@/composables'
 
@@ -63,47 +64,6 @@ const store = useStore()
 const TRANSFER_DECLARED_VALUE = '123'
 const TRANSFER_CONSIDERATION = `$${TRANSFER_DECLARED_VALUE}.00`
 const TRANSFER_DATE = '2020-10-10'
-
-// TODO: Remove after API updates to include the ID for Owners
-function addIDsForOwners (ownersGroups): Array<any> {
-  // Create an ID to each individual owner for UI Tracking
-  ownersGroups.forEach(ownerGroup => {
-    for (const [index, owner] of ownerGroup.owners.entries()) {
-      owner.ownerId = ownerGroup.groupId + (index + 1)
-    }
-  })
-
-  return ownersGroups
-}
-
-async function setupCurrentHomeOwners (): Promise<void> {
-  await store.setMhrTransferCurrentHomeOwnerGroups([mockMhrTransferCurrentHomeOwner])
-  // TODO: Remove after API updates to include the ID for Owners
-  const homeOwnerWithIdsArray = addIDsForOwners([mockMhrTransferCurrentHomeOwner])
-  await store.setMhrTransferHomeOwnerGroups(homeOwnerWithIdsArray)
-}
-
-async function setupCurrentMultipleHomeOwnersGroups (): Promise<void> {
-  // setup two groups so they can be shown in the table
-  const currentHomeOwnersGroups = [
-    mockMhrTransferCurrentHomeOwner,
-    {
-      ...mockMhrTransferCurrentHomeOwner,
-      groupId: 2
-    }
-  ]
-
-  await store.setMhrTransferCurrentHomeOwnerGroups(currentHomeOwnersGroups)
-  // TODO: Remove after API updates to include the ID for Owners
-  const homeOwnerWithIdsArray = addIDsForOwners(currentHomeOwnersGroups)
-  await store.setMhrTransferHomeOwnerGroups(homeOwnerWithIdsArray)
-}
-
-async function triggerUnsavedChange (): Promise<void> {
-  // set unsaved changes to make Transfer Details visible
-  await store.setUnsavedChanges(true)
-  await nextTick()
-}
 
 // For future use when Transfer Details will be required to go to Review
 async function enterTransferDetailsFields (transferDetailsWrapper): Promise<void> {

--- a/ppr-ui/tests/unit/MhrInformationQsTransfers.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformationQsTransfers.spec.ts
@@ -1,0 +1,78 @@
+import { defaultFlagSet } from '@/utils'
+import { mockMhrTransferCurrentHomeOwner } from './test-data'
+import { createComponent, mapMhrTypeToProductCode, setupCurrentHomeOwners, setupMockUser } from './utils'
+import { HomeOwners, MhrInformation } from '@/views'
+import { MhrSubTypes, ProductCode, RouteNames } from '@/enums'
+import { nextTick } from 'vue'
+import { LienAlert } from '@/components/common'
+import { TransferType } from '@/components/mhrTransfers'
+import { HomeOwnersTable } from '@/components/mhrRegistration'
+import { useStore } from '@/store/store'
+import { beforeAll } from 'vitest'
+import { useUserAccess } from '@/composables'
+import flushPromises from 'flush-promises'
+
+
+const store = useStore()
+
+//TODO:  Work in progress to test the variations between QS Type in Transfers
+const subProducts: MhrSubTypes[] = [MhrSubTypes.DEALERS, MhrSubTypes.LAWYERS_NOTARIES, MhrSubTypes.MANUFACTURER]
+for (const subProduct of subProducts) {
+  describe(`MhrInformation: ${subProduct}`, () => {
+    let wrapper
+    const { setQsInformationModel } = useUserAccess()
+
+    beforeAll(async () => {
+      // Setup User
+      await setupMockUser()
+
+      // Setup QS
+      await store.setMhrSubProduct(subProduct)
+      await setQsInformationModel(subProduct)
+      await store.setUserProductSubscriptionsCodes([ProductCode.MHR, mapMhrTypeToProductCode(subProduct)])
+
+      await flushPromises()
+      await nextTick()
+    })
+
+    beforeEach(async () => {
+      defaultFlagSet['mhr-transfer-enabled'] = true
+      wrapper = await createComponent(
+        MhrInformation,
+        { appReady: true, isMhrTransfer: true },
+        RouteNames.MHR_INFORMATION
+      )
+
+      await setupCurrentHomeOwners()
+      wrapper.vm.dataLoaded = true
+      await nextTick()
+    })
+
+    it('renders and displays the Mhr Information View for this QS type', async () => {
+      // Verify Base Wrapper
+      expect(wrapper.findComponent(MhrInformation).exists()).toBe(true)
+      expect(wrapper.find('#mhr-information-header').text()).toContain('Manufactured Home Information')
+
+      // Verify Lien Messaging
+      expect(wrapper.findComponent(LienAlert).exists()).toBe(false)
+
+      // Verify Transfer Type Selector
+      expect(wrapper.findComponent(TransferType).exists()).toBe(false)
+
+      // Verify Home Owners
+      const homeOwnersTable = await wrapper.findComponent(HomeOwnersTable)
+      expect(wrapper.findComponent(HomeOwners).exists()).toBeTruthy()
+      expect(wrapper.vm.getMhrTransferCurrentHomeOwnerGroups.length).toBe(1)
+      expect(wrapper.vm.getMhrTransferHomeOwners.length).toBe(1)
+
+      expect(homeOwnersTable.exists()).toBeTruthy()
+      expect(homeOwnersTable.text()).toContain(mockMhrTransferCurrentHomeOwner.owners[0].organizationName)
+      expect(homeOwnersTable.text()).toContain(mockMhrTransferCurrentHomeOwner.owners[0].address.city)
+    })
+
+    it('renders change owners button conditionally', async () => {
+      expect(wrapper.find('#home-owners-header').exists()).toBe(true)
+      expect(wrapper.vm.enableHomeOwnerChanges).toBe(true)
+    })
+  })
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21870 /bcgov/entity#21247 /bcgov/entity#21923

*Description of changes:*
- Updated ReRegistration Submissions to store baseline owners to trigger inclusion in payload
- Increase owner middle name to 50 chars
- Prevent previous owners groups display changing when changing re-reg owners groups
- Fix owner groups validation that was causing error border to not display when no groups.
- Refactored unit testing helpers and ONGOING DEAT/QS Transfer tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
