### PR TITLE
Prevent Res-Exemption on Exempt Homes

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.26",
+      "version": "3.2.27",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -507,6 +507,7 @@
               </v-list-item>
               <v-list-item
                 v-if="isExemptionEnabled && !hasChildResExemption(item) &&
+                  item.statusType !== MhApiStatusTypes.EXEMPT &&
                   ![HomeLocationTypes.HOME_PARK, HomeLocationTypes.LOT].includes(item.locationType)"
                 data-test-id="res-exemption-btn"
                 :disabled="item.frozenDocumentType === MhApiFrozenDocumentTypes.TRANS_AFFIDAVIT"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21171

*Description of changes:*
- Implemented the last requirement in this ticket to prevent Residential Exemption option on Exempt Homes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
