### PR TITLE
Fix Void Transport Permit Text and Badge

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.28",
+  "version": "3.2.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.28",
+      "version": "3.2.29",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.28",
+  "version": "3.2.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/exemption/useExemptions.ts
+++ b/ppr-ui/src/composables/exemption/useExemptions.ts
@@ -20,8 +20,10 @@ import {
   UnitNoteDocTypes,
   UnitNoteStatusTypes
 } from '@/enums'
+import { useRouter } from 'vue-router'
 
 export const useExemptions = () => {
+  const router = useRouter()
   const { goToRoute } = useNavigation()
   const { setMhrExemption, setMhrExemptionNote, setMhrExemptionValidation, setMhrExemptionValue } = useStore()
   const {
@@ -60,7 +62,8 @@ export const useExemptions = () => {
   const isExemptionWithActiveTransportPermit: ComputedRef<boolean> = computed((): boolean => {
     return (
       getMhrInformation.value.permitStatus === MhApiStatusTypes.ACTIVE &&
-      (isResExemption.value || isNonResExemption.value)
+      (isResExemption.value || isNonResExemption.value) &&
+      [RouteNames.EXEMPTION_DETAILS, RouteNames.EXEMPTION_REVIEW].includes(router.currentRoute.value.name as RouteNames)
     )
   })
 

--- a/ppr-ui/tests/unit/ExemptionDetails.spec.ts
+++ b/ppr-ui/tests/unit/ExemptionDetails.spec.ts
@@ -8,7 +8,7 @@ import { axe } from 'vitest-axe'
 import { TransportPermitDetails } from '@/components/mhrTransportPermit'
 import { useStore } from '@/store/store'
 import { mockedAddress } from './test-data'
-import { UnitNoteDocTypes } from '@/enums'
+import { RouteNames, UnitNoteDocTypes } from '@/enums'
 
 const store = useStore()
 
@@ -16,7 +16,7 @@ describe('ExemptionDetails', () => {
   let wrapper
 
   beforeEach(async () => {
-    wrapper = await createComponent(ExemptionDetails as any, { showErrors: false })
+    wrapper = await createComponent(ExemptionDetails as any, { showErrors: false }, RouteNames.EXEMPTION_DETAILS)
     await nextTick()
   })
 

--- a/ppr-ui/tests/unit/ExemptionReview.spec.ts
+++ b/ppr-ui/tests/unit/ExemptionReview.spec.ts
@@ -22,7 +22,7 @@ import { ConfirmCompletion } from '@/components/mhrTransfers'
 import { StaffPayment } from '@/components/common'
 import { axe } from 'vitest-axe'
 import { useStore } from '@/store/store'
-import { UnitNoteDocTypes } from '@/enums'
+import { RouteNames, UnitNoteDocTypes } from '@/enums'
 import { mockedAddress } from './test-data'
 import { TransportPermitDetails } from '@/components/mhrTransportPermit'
 
@@ -32,7 +32,7 @@ describe('ExemptionReview', () => {
   let wrapper
 
   beforeEach(async () => {
-    wrapper = await createComponent(ExemptionReview, { showErrors: false }, null)
+    wrapper = await createComponent(ExemptionReview, { showErrors: false }, RouteNames.EXEMPTION_REVIEW)
     setupMockStaffUser()
     await nextTick()
   })


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#21507

*Description of changes:*
- Fix Void Transport Permit text in Location of Home (with active Transport Permit) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
