### PR TITLE
Fix Home Owners Error Message

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.28",
+  "version": "3.2.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.28",
+      "version": "3.2.29",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.28",
+  "version": "3.2.29",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -970,6 +970,14 @@ export default defineComponent({
         item.groupId
       )
 
+      const group: MhrRegistrationHomeOwnerGroupIF = getGroupById(item.groupId)
+      const isEmptyGroup = group.owners.every(owner => owner.action === ActionTypes.REMOVED)
+
+      // mark empty groups as removed to show the 'No owners added yet' error
+      if (isEmptyGroup) {
+        group.action = ActionTypes.REMOVED
+      }
+
       // When base ownership is SO/JT and all current owners have been removed: Move them to a previous owners group.
       if (groupHasRemovedAllCurrentOwners(getGroupById(item.groupId)) && showGroups.value) {
         moveCurrentOwnersToPreviousOwners(getGroupById(item.groupId))

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -418,7 +418,7 @@ describe('Home Owners', () => {
     expect(allDeletedBadges.length).toBe(1)
 
     expect(homeOwners.find(getTestId('invalid-group-msg')).exists()).toBeFalsy()
-    expect(homeOwners.find(getTestId('no-data-msg')).exists()).toBeFalsy()
+    expect(homeOwners.find(getTestId('no-data-msg')).exists()).toBeTruthy()
 
     const deletedOwner: MhrRegistrationHomeOwnerIF =
       homeOwners.vm.getMhrTransferHomeOwnerGroups[0].owners[0]


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#18364

*Description of changes:*
- Show 'No owners added yet' error message when all owners are removed from the table (in Transfers)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
