### PR TITLE
Fix validation in Home Owner Transfers

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.30",
+  "version": "3.2.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.30",
+      "version": "3.2.31",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.30",
+  "version": "3.2.31",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -869,6 +869,7 @@ export default defineComponent({
 
         return ((props.validateTransfer || (!props.isMhrTransfer && localState.reviewedOwners)) &&
           (
+            localState.homeOwners.length === 0 ||
             !hasMinimumGroups() ||
             (props.isMhrTransfer && !hasUnsavedChanges.value) ||
             !localState.isValidAllocation ||

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -200,7 +200,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
     const hasNoGroups = [HomeTenancyTypes.SOLE, HomeTenancyTypes.JOINT].includes(getHomeTenancyType()) ||
       groups.length === 0
 
-    return !hasNoGroups || !groups || groups.length >= 2 ||
+    return hasNoGroups || !groups || groups.length >= 2 ||
       (!showGroups.value && groups.length === 1)
   }
 

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -45,9 +45,53 @@ import {
 } from '@/enums'
 import { DeathCertificate, SupportingDocuments } from '@/components/mhrTransfers'
 import { transferSupportingDocuments, transfersErrors, MixedRolesErrors } from '@/resources'
-import { useNewMhrRegistration } from '@/composables'
+import { useHomeOwners, useNewMhrRegistration } from '@/composables'
 
 const store = useStore()
+
+describe('useHomeOwners composable', () => {
+  it('test hasMinimumGroups', async () => {
+
+    // setup owners structure where 3 groups of sole owners were removed
+    // and one owner was added
+    const homeOwnerGroups: MhrRegistrationHomeOwnerGroupIF[] = [
+      {
+        groupId: 1,
+        interest: 'Undivided',
+        interestDenominator: 2,
+        interestNumerator: 1,
+        owners: [mockedRemovedPerson],
+        type: HomeTenancyTypes.SOLE,
+        action: ActionTypes.REMOVED
+      },
+      {
+        groupId: 2,
+        interest: 'Undivided',
+        interestDenominator: 2,
+        interestNumerator: 1,
+        owners: [mockedRemovedPerson],
+        type: HomeTenancyTypes.SOLE,
+        action: ActionTypes.REMOVED
+      },
+      {
+        groupId: 3,
+        owners: [mockedAddedPerson],
+        type: HomeTenancyTypes.SOLE,
+        action: ActionTypes.ADDED
+      }
+    ]
+
+    await store.setMhrTransferHomeOwnerGroups(homeOwnerGroups)
+    await store.setMhrTransferType({ transferType: ApiTransferTypes.SALE_OR_GIFT } as TransferTypeSelectIF)
+
+    const useHomeOwnersComposable = useHomeOwners(true)
+    useHomeOwnersComposable.setShowGroups(true)
+
+    const { hasMinimumGroups } = useHomeOwnersComposable
+
+    expect(hasMinimumGroups()).toBe(true)
+  })
+})
 
 describe('Home Owners', () => {
   let wrapper


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#18364

*Description of changes:*
- Fixed bug was introduced in #1947 that was breaking validation for Tenants in Common structure
- Applied a different fix for Home Owners page border error that same PR was trying to fix
- Now both bugs should be fixed
- Unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
