### PR TITLE
Legacy config transfer report data always legacy DB.

### DIFF
--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -334,7 +334,7 @@ def set_group_json(registration, reg_json, current: bool, cleanup: bool = False)
     return reg_json
 
 
-def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
+def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:  # pylint: disable=too-many-branches; +1
     """Build the transfer registration owner groups JSON."""
     if not registration.is_transfer() and registration.registration_type != MhrRegistrationTypes.REG_STAFF_ADMIN:
         return reg_json
@@ -342,24 +342,27 @@ def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
             doc_type not in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
                              MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE):
         return reg_json
-    add_groups = []
-    delete_groups = []
-    if reg_json and registration.owner_groups:
-        for group in registration.owner_groups:
-            if group.registration_id == registration.id:
-                add_groups.append(group.json)
-            elif group.change_registration_id == registration.id:
-                delete_groups.append(group.json)
-    reg_json['addOwnerGroups'] = add_groups
-    if registration.change_registrations:
-        for reg in registration.change_registrations:
-            for existing in reg.owner_groups:
-                if existing.registration_id != registration.id and existing.change_registration_id == registration.id:
-                    delete_groups.append(existing.json)
-    reg_json['deleteOwnerGroups'] = delete_groups
-    if not delete_groups and not add_groups and model_utils.is_legacy():  # Legacy MH home
-        current_app.logger.debug(f'Transfer legacy MHR {registration.mhr_number} using legacy owner groups.')
+
+    if model_utils.is_legacy():  # Use legacy as source, modern could be out of sequence.
+        current_app.logger.debug(f'Transfer MHR {registration.mhr_number} using legacy owner groups.')
         reg_json = legacy_reg_utils.set_transfer_group_json(registration, reg_json)
+    else:
+        add_groups = []
+        delete_groups = []
+        if reg_json and registration.owner_groups:
+            for group in registration.owner_groups:
+                if group.registration_id == registration.id:
+                    add_groups.append(group.json)
+                elif group.change_registration_id == registration.id:
+                    delete_groups.append(group.json)
+        reg_json['addOwnerGroups'] = add_groups
+        if registration.change_registrations:
+            for reg in registration.change_registrations:
+                for existing in reg.owner_groups:
+                    if existing.registration_id != registration.id and \
+                            existing.change_registration_id == registration.id:
+                        delete_groups.append(existing.json)
+        reg_json['deleteOwnerGroups'] = delete_groups
     if reg_json.get('addOwnerGroups'):
         reg_json['addOwnerGroups'] = sort_owner_groups(reg_json.get('addOwnerGroups'), False)
     return reg_json

--- a/mhr_api/src/mhr_api/resources/v1/transfers.py
+++ b/mhr_api/src/mhr_api/resources/v1/transfers.py
@@ -124,7 +124,7 @@ def setup_report(registration: MhrRegistration,  # pylint: disable=too-many-loca
     add_groups = response_json.get('addOwnerGroups')
     if model_utils.is_legacy():
         current_app.logger.info('setup_report legacy configuration using response owners.')
-        current_app.logger.debug(response_json.get('addOwnerGroups'))
+        # current_app.logger.debug(response_json.get('addOwnerGroups'))
     else:
         new_groups = []
         if not response_json.get('deleteOwnerGroups'):

--- a/mhr_api/src/mhr_api/resources/v1/transfers.py
+++ b/mhr_api/src/mhr_api/resources/v1/transfers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """API endpoints for requests to maintain MH transfer of sale/ownership requests."""
-
 from http import HTTPStatus
 
 from flask import Blueprint
@@ -119,32 +118,37 @@ def setup_report(registration: MhrRegistration,  # pylint: disable=too-many-loca
                  account_id: str,
                  current_owners):
     """Include all active owners in the transfer report request data and add it to the queue."""
-    add_groups = response_json.get('addOwnerGroups')
     current_reg.current_view = True
     current_json = current_reg.new_registration_json
     current_json['ownerGroups'] = current_owners
-    new_groups = []
-    if not response_json.get('deleteOwnerGroups'):
-        delete_groups = []
-        for group in current_reg.owner_groups:
-            if group.change_registration_id == registration.id and group.status_type == MhrOwnerStatusTypes.PREVIOUS:
-                delete_groups.append(group.json)
-        response_json['deleteOwnerGroups'] = delete_groups
-    for group in current_json.get('ownerGroups'):
-        deleted: bool = False
-        for delete_group in response_json.get('deleteOwnerGroups'):
-            if delete_group.get('groupId') == group.get('groupId'):
-                deleted = True
-        if not deleted:
-            new_groups.append(group)
-    for add_group in add_groups:
-        added: bool = False
-        for new_group in new_groups:
-            if add_group.get('groupId') == new_group.get('groupId'):
-                added = True
-        if not added:
-            new_groups.append(add_group)
-    response_json['addOwnerGroups'] = sort_owner_groups(new_groups)
+    add_groups = response_json.get('addOwnerGroups')
+    if model_utils.is_legacy():
+        current_app.logger.info('setup_report legacy configuration using response owners.')
+        current_app.logger.debug(response_json.get('addOwnerGroups'))
+    else:
+        new_groups = []
+        if not response_json.get('deleteOwnerGroups'):
+            delete_groups = []
+            for group in current_reg.owner_groups:
+                if group.change_registration_id == registration.id and \
+                        group.status_type == MhrOwnerStatusTypes.PREVIOUS:
+                    delete_groups.append(group.json)
+            response_json['deleteOwnerGroups'] = delete_groups
+        for group in current_json.get('ownerGroups'):
+            deleted: bool = False
+            for delete_group in response_json.get('deleteOwnerGroups'):
+                if delete_group.get('groupId') == group.get('groupId'):
+                    deleted = True
+            if not deleted:
+                new_groups.append(group)
+        for add_group in add_groups:
+            added: bool = False
+            for new_group in new_groups:
+                if add_group.get('groupId') == new_group.get('groupId'):
+                    added = True
+            if not added:
+                new_groups.append(add_group)
+        response_json['addOwnerGroups'] = sort_owner_groups(new_groups)
     # Report setup is current view except for FROZEN status: update report data.
     status: str = response_json.get('status')
     if status == model_utils.STATUS_FROZEN:
@@ -163,10 +167,11 @@ def setup_report(registration: MhrRegistration,  # pylint: disable=too-many-loca
                                               response_json,
                                               ReportTypes.MHR_TRANSFER,
                                               current_json)
-    response_add_groups = []
-    for add_group in add_groups:
-        if not add_group.get('existing'):
-            response_add_groups.append(add_group)
-    response_json['addOwnerGroups'] = response_add_groups
+    if not model_utils.is_legacy():
+        response_add_groups = []
+        for add_group in add_groups:
+            if not add_group.get('existing'):
+                response_add_groups.append(add_group)
+        response_json['addOwnerGroups'] = response_add_groups
     response_json['status'] = status
     response_json = cleanup_owner_groups(response_json)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22014

*Description of changes:*
- Pre data migration transfer always use legacy database for report data owner groups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
