### PR TITLE
History view always include registration.ownLand.

### DIFF
--- a/mhr_api/src/mhr_api/models/registration_history_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_history_utils.py
@@ -203,7 +203,8 @@ def get_reg_summary_json(registration: MhrRegistration) -> dict:
         'createDateTime': model_utils.format_ts(registration.registration_ts),
         'registrationDescription': get_document_description(doc.document_type),
         'documentId': doc.document_id,
-        'documentRegistrationNumber': doc.document_registration_number
+        'documentRegistrationNumber': doc.document_registration_number,
+        'ownLand': doc.own_land == 'Y'
     }
     if doc.attention_reference:
         reg_json['attentionReference'] = doc.attention_reference
@@ -214,8 +215,6 @@ def get_reg_summary_json(registration: MhrRegistration) -> dict:
             reg_json['declaredValue'] = doc.declared_value
         if doc.consideration_value:
             reg_json['consideration'] = doc.consideration_value
-        if doc.own_land:
-            reg_json['ownLand'] = doc.own_land == 'Y'
         if doc.transfer_date:
             reg_json['transferDate'] = model_utils.format_ts(doc.transfer_date)
     return reg_json

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.15'  # pylint: disable=invalid-name
+__version__ = '1.8.16'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_registration_history_utils.py
+++ b/mhr_api/tests/unit/models/test_registration_history_utils.py
@@ -47,6 +47,12 @@ def test_get_home_history(session, mhr_num, reg_view, reg_status, reg_count, not
     assert history_json.get('registrations')
     assert len(history_json['registrations']) == reg_count
     if not reg_view:
+        for reg in history_json.get('registrations'):
+            assert 'ownLand' in reg
+            assert reg.get('createDateTime')
+            assert reg.get('registrationDescription')
+            assert reg.get('documentId')
+            assert reg.get('documentRegistrationNumber')
         assert history_json.get('descriptions')
         assert history_json.get('locations')
         assert history_json.get('owners')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21864

*Description of changes:*
- MH history JSON registrations array always include registration.ownLand

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
