### PR TITLE
Mhr History Owners

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.32",
+  "version": "3.2.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.32",
+      "version": "3.2.33",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.32",
+  "version": "3.2.33",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -168,6 +168,9 @@ a {
 .error-text {
   color: $error !important;
 }
+.gray7 {
+  color: $gray7;
+}
 
 .disabled-text {
   opacity: 0.4;

--- a/ppr-ui/src/components/common/SimpleTable.vue
+++ b/ppr-ui/src/components/common/SimpleTable.vue
@@ -20,8 +20,13 @@
           <td
             v-for="(header, colIndex) in tableHeaders"
             :key="`cell-${rowIndex}-${colIndex}`"
-            :class="{ 'font-weight-bold' : colIndex === 1, 'expanded-row-cell' : expandRow[rowIndex] }"
+            :class="{
+              'pt-1' : colIndex === 0,
+              'font-weight-bold gray9' : colIndex === 1,
+              'expanded-row-cell' : expandRow[rowIndex]
+            }"
           >
+            <!-- Expand/Collapse Btn -->
             <v-btn
               v-if="colIndex === 0"
               class="toggle-expand-row-btn"
@@ -40,7 +45,15 @@
                 {{ expandRow[rowIndex] ? 'Hide' : 'View' }} {{ rowLabel }}
               </span>
             </v-btn>
-            <span v-else>{{ getItemValue(item, header.value) }}</span>
+            <!-- Cell Content -->
+            <template v-else>
+              <slot
+                :name="`cell-slot-${colIndex}`"
+                :content="item"
+              >
+                {{ getItemValue(item, header.value) }}
+              </slot>
+            </template>
           </td>
         </tr>
         <tr
@@ -136,6 +149,12 @@ const getItemValue = (item: object, valuePaths: Array<string> | string): string 
 </script>
 <style lang="scss" scoped>
 @import '@/assets/styles/theme';
+:deep(td) {
+  align-content: flex-start;
+}
+.gray9 {
+  color: $gray9 !important;
+}
 .expanded-row-cell {
   border-bottom: 0!important;
 }

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryDescription.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryDescription.vue
@@ -127,7 +127,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ shortPacificDate(content?.createDateTime) || '(Not Entered)' }}</p>
+        <p>{{ pacificDate(content?.createDateTime, true) || '(Not Entered)' }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Document Type</h4>
@@ -136,7 +136,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+        <p>{{ multipleWordsToTitleCase(content?.registrationDescription, false) }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Registration Number</h4>
@@ -163,7 +163,7 @@
 <script setup lang="ts">
 import { HomeSectionsTable } from '@/components/tables/mhr'
 import { DescriptionIF } from '@/interfaces'
-import { shortPacificDate } from '@/utils'
+import { multipleWordsToTitleCase, pacificDate, shortPacificDate } from '@/utils'
 
 /** Props **/
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    id="mhr-history-description"
+    id="mhr-history-location"
     class="pr-4"
   >
     <v-row

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
@@ -223,7 +223,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ shortPacificDate(content?.createDateTime) || '(Not Entered)' }}</p>
+        <p>{{ pacificDate(content?.createDateTime, true) }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Document Type</h4>
@@ -232,7 +232,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+        <p>{{ multipleWordsToTitleCase(content?.registrationDescription, false) }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Registration Number</h4>
@@ -264,7 +264,7 @@
           cols="6"
           class="pl-3 mt-4"
         >
-          <p>{{ shortPacificDate(content?.endDateTime) || '(Not Entered)' }}</p>
+          <p>{{ pacificDate(content?.endDateTime, true) }}</p>
         </v-col>
         <v-col cols="3">
           <h4>Document Type</h4>
@@ -273,7 +273,7 @@
           cols="6"
           class="pl-3"
         >
-          <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+          <p>{{ multipleWordsToTitleCase(content?.registrationDescription, false) || '(Not Entered)' }}</p>
         </v-col>
         <v-col cols="3">
           <h4>Registration Number</h4>
@@ -316,7 +316,7 @@ import { ref } from 'vue'
 import { LocationIF, RegistrationIF } from '@/interfaces'
 import { HomeLocationTypes } from '@/enums'
 import { useCountriesProvinces } from '@/composables/address/factories'
-import { shortPacificDate } from '@/utils'
+import { multipleWordsToTitleCase, pacificDate } from '@/utils'
 
 /** Props **/
 const props = withDefaults(defineProps<{

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
@@ -1,0 +1,190 @@
+<template>
+  <section
+    id="mhr-history-owners"
+    class="pr-4"
+  >
+    <v-row
+      noGutters
+      class="condensed-row py-3"
+    >
+      <p>
+        <span class="generic-label-14">Tenancy Type:</span>
+        {{ content.type }} <v-divider vertical />
+      </p>
+      <p>
+        <span class="generic-label-14">Group:</span>
+        {{ content.groupId }} of {{ content.groupCount }} <v-divider vertical />
+      </p>
+      <p>
+        <span class="generic-label-14">Owner:</span>
+        {{ content.ownerId }} of {{ content.groupOwnerCount }} <v-divider vertical />
+      </p>
+      <p>
+        <span class="generic-label-14">Group Tenancy Type:</span>
+        {{ content.groupTenancyType }}
+        <v-divider vertical />
+      </p>
+      <p>
+        <span class="generic-label-14">Interest:</span>
+        {{ content.interest }} {{ content.interestNumerator }}/{{ content.interestDenominator }}
+      </p>
+    </v-row>
+
+    <v-row
+      noGutters
+      class="condensed-row py-3"
+    >
+      <v-col cols="3">
+        <h4>Mailing Address</h4>
+        <BaseAddress :value="content.address" />
+      </v-col>
+      <v-col
+        cols="3"
+        class="pl-3"
+      >
+        <h4>Phone Number</h4>
+        <p>{{ content.phoneNumber }} {{ content.phoneExtension ? `Ext ${content.phoneExtension}` : '' }}</p>
+      </v-col>
+      <v-col cols="3">
+        <h4>Email Address</h4>
+        <p>{{ content.emailAddress || '(Not Entered)' }}</p>
+      </v-col>
+    </v-row>
+
+    <!-- Owner From/Until Details -->
+    <v-row
+      noGutters
+      class="py-6 condensed-row"
+    >
+      <v-col cols="3">
+        <h4>Owned From</h4>
+      </v-col>
+      <v-col
+        cols="6"
+        class="pl-3"
+      >
+        <p>{{ shortPacificDate(content?.createDateTime) || '(Not Entered)' }}</p>
+      </v-col>
+      <v-col cols="3">
+        <h4>Document Type</h4>
+      </v-col>
+      <v-col
+        cols="6"
+        class="pl-3"
+      >
+        <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+      </v-col>
+      <v-col cols="3">
+        <h4>Registration Number</h4>
+      </v-col>
+      <v-col
+        cols="6"
+        class="pl-3"
+      >
+        <p>{{ content?.documentRegistrationNumber || '(Not Entered)' }}</p>
+      </v-col>
+      <v-col cols="3">
+        <h4>Document ID</h4>
+      </v-col>
+      <v-col
+        cols="6"
+        class="pl-3"
+      >
+        <p>{{ content?.documentId || '(Not Entered)' }}</p>
+      </v-col>
+
+      <template v-if="content?.endDateTime">
+        <v-col
+          cols="3"
+          class="mt-4"
+        >
+          <h4>Owned Until</h4>
+        </v-col>
+        <v-col
+          cols="6"
+          class="pl-3 mt-4"
+        >
+          <p>{{ shortPacificDate(content?.endDateTime) || '(Not Entered)' }}</p>
+        </v-col>
+        <v-col cols="3">
+          <h4>Document Type</h4>
+        </v-col>
+        <v-col
+          cols="6"
+          class="pl-3"
+        >
+          <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+        </v-col>
+        <v-col cols="3">
+          <h4>Registration Number</h4>
+        </v-col>
+        <v-col
+          cols="6"
+          class="pl-3"
+        >
+          <p>{{ content?.documentRegistrationNumber || '(Not Entered)' }}</p>
+        </v-col>
+        <v-col cols="3">
+          <h4>Document ID</h4>
+        </v-col>
+        <v-col
+          cols="6"
+          class="pl-3"
+        >
+          <p>{{ content?.documentId || '(Not Entered)' }}</p>
+        </v-col>
+      </template>
+      <template v-else>
+        <v-col
+          cols="3"
+          class="mt-4"
+        >
+          <h4>Owned Until</h4>
+        </v-col>
+        <v-col
+          cols="6"
+          class="pl-3 mt-4"
+        >
+          <p>Current</p>
+        </v-col>
+      </template>
+    </v-row>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { OwnerIF } from '@/interfaces'
+import { BaseAddress } from '@/composables/address'
+import { shortPacificDate } from '@/utils'
+
+/** Props **/
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const props = withDefaults(defineProps<{
+  content: OwnerIF
+}>(), {
+  content: null
+})
+
+</script>
+<style lang="scss" scoped>
+@import '@/assets/styles/theme';
+.v-row {
+  min-height: 65px;
+  border-top: 1px solid $gray3;
+}
+.condensed-row {
+  p, h4 {
+    line-height: 1.5rem;
+  }
+}
+:deep(.v-divider) {
+  height: 14px;
+  color: $gray3;
+  margin: 0 20px;
+  opacity: 1;
+}
+:deep(.v-col-3) {
+  flex: 0 0 26.25%;
+  max-width: 26.25%;
+}
+</style>

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
@@ -5,29 +5,35 @@
   >
     <v-row
       noGutters
-      class="condensed-row py-3"
+      class="condensed-row pt-5"
     >
       <p>
         <span class="generic-label-14">Tenancy Type:</span>
-        {{ content.type }} <v-divider vertical />
+        {{ content.type }}
+        <v-divider
+          v-if="content.type === HomeTenancyTypes.COMMON"
+          vertical
+        />
       </p>
-      <p>
-        <span class="generic-label-14">Group:</span>
-        {{ content.groupId }} of {{ content.groupCount }} <v-divider vertical />
-      </p>
-      <p>
-        <span class="generic-label-14">Owner:</span>
-        {{ content.ownerId }} of {{ content.groupOwnerCount }} <v-divider vertical />
-      </p>
-      <p>
-        <span class="generic-label-14">Group Tenancy Type:</span>
-        {{ content.groupTenancyType }}
-        <v-divider vertical />
-      </p>
-      <p>
-        <span class="generic-label-14">Interest:</span>
-        {{ content.interest }} {{ content.interestNumerator }}/{{ content.interestDenominator }}
-      </p>
+      <template v-if="content.type === HomeTenancyTypes.COMMON">
+        <p>
+          <span class="generic-label-14">Group:</span>
+          {{ content.groupId }} of {{ content.groupCount }} <v-divider vertical />
+        </p>
+        <p>
+          <span class="generic-label-14">Owner:</span>
+          {{ content.ownerId }} of {{ content.groupOwnerCount }} <v-divider vertical />
+        </p>
+        <p>
+          <span class="generic-label-14">Group Tenancy Type:</span>
+          {{ content.groupTenancyType }}
+          <v-divider vertical />
+        </p>
+        <p>
+          <span class="generic-label-14">Interest:</span>
+          {{ content.interest }} {{ content.interestNumerator }}/{{ content.interestDenominator }}
+        </p>
+      </template>
     </v-row>
 
     <v-row
@@ -43,7 +49,10 @@
         class="pl-3"
       >
         <h4>Phone Number</h4>
-        <p>{{ content.phoneNumber }} {{ content.phoneExtension ? `Ext ${content.phoneExtension}` : '' }}</p>
+        <p>
+          {{ content.phoneNumber || '(Not Entered)' }}
+          {{ content.phoneExtension ? `Ext ${content.phoneExtension}` : '' }}
+        </p>
       </v-col>
       <v-col cols="3">
         <h4>Email Address</h4>
@@ -63,7 +72,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ shortPacificDate(content?.createDateTime) || '(Not Entered)' }}</p>
+        <p>{{ pacificDate(content?.createDateTime, true) || '(Not Entered)' }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Document Type</h4>
@@ -72,7 +81,7 @@
         cols="6"
         class="pl-3"
       >
-        <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+        <p>{{ multipleWordsToTitleCase(content?.registrationDescription, false) }}</p>
       </v-col>
       <v-col cols="3">
         <h4>Registration Number</h4>
@@ -104,7 +113,7 @@
           cols="6"
           class="pl-3 mt-4"
         >
-          <p>{{ shortPacificDate(content?.endDateTime) || '(Not Entered)' }}</p>
+          <p>{{ pacificDate(content?.endDateTime, true) || '(Not Entered)' }}</p>
         </v-col>
         <v-col cols="3">
           <h4>Document Type</h4>
@@ -113,7 +122,7 @@
           cols="6"
           class="pl-3"
         >
-          <p>{{ content?.registrationDescription || '(Not Entered)' }}</p>
+          <p>{{ multipleWordsToTitleCase(content?.registrationDescription, false) }}</p>
         </v-col>
         <v-col cols="3">
           <h4>Registration Number</h4>
@@ -155,7 +164,8 @@
 <script setup lang="ts">
 import { OwnerIF } from '@/interfaces'
 import { BaseAddress } from '@/composables/address'
-import { shortPacificDate } from '@/utils'
+import { multipleWordsToTitleCase, pacificDate } from '@/utils'
+import { ApiHomeTenancyTypes, HomeTenancyTypes } from '@/enums'
 
 /** Props **/
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryOwners.vue
@@ -165,7 +165,7 @@
 import { OwnerIF } from '@/interfaces'
 import { BaseAddress } from '@/composables/address'
 import { multipleWordsToTitleCase, pacificDate } from '@/utils'
-import { ApiHomeTenancyTypes, HomeTenancyTypes } from '@/enums'
+import { HomeTenancyTypes } from '@/enums'
 
 /** Props **/
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ppr-ui/src/components/mhrHistory/index.ts
+++ b/ppr-ui/src/components/mhrHistory/index.ts
@@ -1,2 +1,3 @@
 export { default as MhrHistoryDescription } from './MhrHistoryDescription.vue'
 export { default as MhrHistoryLocations } from './MhrHistoryLocations.vue'
+export { default as MhrHistoryOwners } from './MhrHistoryOwners.vue'

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -9,7 +9,7 @@ import {
 import { useStore } from '@/store/store'
 import { ActionTypes, ApiTransferTypes, HomeOwnerPartyTypes, HomeTenancyTypes, MhApiStatusTypes } from '@/enums'
 import { MhrCompVal, MhrSectVal } from '@/composables/mhrRegistration/enums'
-import { useMhrValidations } from '@/composables'
+import { useMhrValidations, useTransferOwners } from '@/composables'
 import { find, findIndex, remove, set, uniq } from 'lodash'
 import { storeToRefs } from 'pinia'
 import { deepChangesComparison } from '@/utils'
@@ -302,7 +302,8 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
     // Try to find a group to add the owner
     // If frozen Sale or Gift Transfer: Add Owner to the last ownership group with recently added Executor
     const groupToUpdate = isFrozenSoGTransfer
-      ? homeOwnerGroups[homeOwnerGroups?.length -1]
+      ? homeOwnerGroups.find(group => group.groupId ===
+        useTransferOwners().getMostRecentExecutorOrAdmin(homeOwnerGroups)?.groupId)
       : homeOwnerGroups.find(
       (group: MhrRegistrationHomeOwnerGroupIF) => group.groupId === (groupId || fallBackId)
     ) || ({} as MhrRegistrationHomeOwnerGroupIF)

--- a/ppr-ui/src/interfaces/mhr-api-interfaces/MhrHistoryIF.ts
+++ b/ppr-ui/src/interfaces/mhr-api-interfaces/MhrHistoryIF.ts
@@ -1,4 +1,5 @@
 import { AddressIF, MhrLocationInfoIF } from '@/interfaces'
+import { HomeOwnerPartyTypes } from '@/enums'
 
 export interface DescriptionIF {
   baseInformation?: {
@@ -62,8 +63,10 @@ export interface IndividualNameIF {
 export interface OwnerIF {
   address?: AddressIF
   createDateTime?: string
+  description?: string
   documentId?: string
   documentRegistrationNumber?: string
+  emailAddress?: string
   endDateTime?: string
   endRegistrationDescription?: string
   groupCount?: number
@@ -75,8 +78,10 @@ export interface OwnerIF {
   interestDenominator?: number
   interestNumerator?: number
   ownerId?: number
-  partyType?: string
+  organizationName?: string
+  partyType?: HomeOwnerPartyTypes
   phoneNumber?: string
+  phoneExtension?: number
   registrationDescription?: string
   status?: string
   type?: string

--- a/ppr-ui/src/resources/mhr-history/mhHistoryTableHeaders.ts
+++ b/ppr-ui/src/resources/mhr-history/mhHistoryTableHeaders.ts
@@ -64,7 +64,7 @@ export const homeOwnerHeaders: Array<BaseHeaderIF> = [
   },
   {
     name: 'Owner Name',
-    value: ['individualName.first', 'individualName.middle', 'individualName.last'],
+    value: ['individualName.first', 'individualName.middle', 'individualName.last', 'organizationName'],
     class: 'col-22-5'
   },
   {

--- a/ppr-ui/src/views/mhrInformation/MhrHistory.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrHistory.vue
@@ -66,8 +66,29 @@
             :tableHeaders="homeOwnerHeaders"
             :tableData="mhrHistory.owners"
           >
+            <template #cell-slot-1="{ content }: { content: OwnerIF }">
+              <div class="icon-text">
+                <v-icon class="mt-n1">
+                  {{ getHomeOwnerIcon(content.partyType, !content?.individualName) }}
+                </v-icon>
+                <span class="align-bottom pl-2">
+                  <template v-if="content?.individualName">
+                    {{ content.individualName.first }}
+                    {{ content.individualName.middle }}
+                    {{ content.individualName.last }}
+                  </template>
+                  <template v-else>
+                    {{ content.organizationName }}
+                  </template>
+                  <template v-if="content.partyType === HomeOwnerPartyTypes.EXECUTOR">
+                    <br>
+                    <span class="fs-14 font-weight-regular gray7">{{ content.description }}</span>
+                  </template>
+                </span>
+              </div>
+            </template>
             <template #content-slot="{ content }">
-              {{ content }}
+              <MhrHistoryOwners :content="content" />
             </template>
           </SimpleTable>
         </template>
@@ -114,7 +135,9 @@ import {
   homeOwnerHeaders,
   mhHistoryTabConfig
 } from '@/resources/mhr-history'
-import { MhrHistoryDescription, MhrHistoryLocations } from '@/components/mhrHistory'
+import { MhrHistoryDescription, MhrHistoryLocations, MhrHistoryOwners } from '@/components/mhrHistory'
+import { HomeOwnerPartyTypes } from '@/enums'
+import { OwnerIF } from '@/interfaces'
 
 /** Composables **/
 const { isAuthenticated } = useAuth()
@@ -148,9 +171,43 @@ onMounted(async (): Promise<void> => {
   loading.value = false
 })
 
+const getHomeOwnerIcon = (partyType: HomeOwnerPartyTypes, isBusiness = false): string => {
+  const uniqueRoleIcon = isBusiness
+    ? 'custom:ExecutorBusinessIcon'
+    : 'custom:ExecutorPersonIcon'
+  const ownerIcon = isBusiness
+    ? 'mdi-domain'
+    : 'mdi-account'
+
+  switch (partyType) {
+    case HomeOwnerPartyTypes.EXECUTOR:
+    case HomeOwnerPartyTypes.ADMINISTRATOR:
+    case HomeOwnerPartyTypes.TRUSTEE:
+      return uniqueRoleIcon
+    case HomeOwnerPartyTypes.OWNER_IND:
+    case HomeOwnerPartyTypes.OWNER_BUS:
+      return ownerIcon
+  }
+}
+
 </script>
 <style lang="scss" scoped>
 @import '@/assets/styles/theme';
+.align-bottom {
+  vertical-align: bottom;
+}
+.person-executor-icon {
+  margin-top: -3px !important;
+  height: 22px !important;
+  width: 22px !important;
+}
+
+.business-executor-icon {
+  margin-top: -8px !important;
+  margin-left: -4px !important;
+  height: 29px !important;
+  width: 28px !important;
+}
 .v-footer {
   position: absolute;
   bottom: 0;

--- a/ppr-ui/src/views/mhrInformation/MhrHistory.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrHistory.vue
@@ -64,7 +64,7 @@
         <template #tab-2>
           <SimpleTable
             :tableHeaders="homeOwnerHeaders"
-            :tableData="mhrHistory.owners"
+            :tableData="mapOwnersApiToUi(mhrHistory.owners)"
           >
             <template #cell-slot-1="{ content }: { content: OwnerIF }">
               <div class="icon-text">
@@ -136,7 +136,7 @@ import {
   mhHistoryTabConfig
 } from '@/resources/mhr-history'
 import { MhrHistoryDescription, MhrHistoryLocations, MhrHistoryOwners } from '@/components/mhrHistory'
-import { HomeOwnerPartyTypes } from '@/enums'
+import { ApiHomeTenancyTypes, HomeOwnerPartyTypes, HomeTenancyTypes } from '@/enums'
 import { OwnerIF } from '@/interfaces'
 
 /** Composables **/
@@ -188,6 +188,59 @@ const getHomeOwnerIcon = (partyType: HomeOwnerPartyTypes, isBusiness = false): s
     case HomeOwnerPartyTypes.OWNER_BUS:
       return ownerIcon
   }
+}
+
+/**
+ * Maps an API home tenancy type to a UI home tenancy type.
+ *
+ * @param {ApiHomeTenancyTypes} apiType - The API home tenancy type to map.
+ * @returns {HomeTenancyTypes} The corresponding UI home tenancy type.
+ */
+function mapApiToUiTenancyType(apiType: ApiHomeTenancyTypes): HomeTenancyTypes {
+  switch (apiType) {
+    case ApiHomeTenancyTypes.JOINT:
+      return HomeTenancyTypes.JOINT
+    case ApiHomeTenancyTypes.SOLE:
+      return HomeTenancyTypes.SOLE
+    case ApiHomeTenancyTypes.COMMON:
+      return HomeTenancyTypes.COMMON
+    case ApiHomeTenancyTypes.NA:
+      return HomeTenancyTypes.NA
+    default:
+      throw new Error(`Unknown API tenancy type: ${apiType}`)
+  }
+}
+
+/**
+ * Maps an API status to a UI status.
+ *
+ * @param {string} status - The API status to map.
+ * @returns {string} The corresponding UI status.
+ */
+function mapApiToUiStatus(status: string): string {
+  switch (status) {
+    case 'ACTIVE':
+      return 'Active'
+    case 'PREVIOUS':
+      return 'Historical'
+    default:
+      return status
+  }
+}
+
+/**
+ * Maps the `type` and `groupTenancyType` properties in each owner object to the UI tenancy types.
+ *
+ * @param {Array<any>} owners - The array of owner objects.
+ * @returns {Array<any>} The new array with updated tenancy types.
+ */
+function mapOwnersApiToUi(owners: Array<any>): Array<any> {
+  return owners.map(owner => ({
+    ...owner,
+    type: mapApiToUiTenancyType(owner.type),
+    groupTenancyType: owner.groupTenancyType ? mapApiToUiTenancyType(owner.groupTenancyType) : undefined,
+    status: mapApiToUiStatus(owner.status)
+  }))
 }
 
 </script>

--- a/ppr-ui/tests/unit/MhrHistoryOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrHistoryOwners.spec.ts
@@ -7,12 +7,12 @@ import BaseAddress from '@/composables/address/BaseAddress.vue'
 
 // Mock content data
 const contentMock: OwnerIF = {
-  type: 'Joint Tenants',
+  type: 'Tenants In Common',
   groupId: 1,
   groupCount: 2,
   ownerId: 1,
   groupOwnerCount: 3,
-  groupTenancyType: 'Joint',
+  groupTenancyType: 'Tenants In Common',
   interest: 'Undivided',
   interestNumerator: 1,
   interestDenominator: 2,

--- a/ppr-ui/tests/unit/MhrHistoryOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrHistoryOwners.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createComponent } from './utils'
+import { MhrHistoryOwners } from '@/components/mhrHistory'
+import { OwnerIF } from '@/interfaces'
+import { nextTick } from 'vue'
+import BaseAddress from '@/composables/address/BaseAddress.vue'
+
+// Mock content data
+const contentMock: OwnerIF = {
+  type: 'Joint Tenants',
+  groupId: 1,
+  groupCount: 2,
+  ownerId: 1,
+  groupOwnerCount: 3,
+  groupTenancyType: 'Joint',
+  interest: 'Undivided',
+  interestNumerator: 1,
+  interestDenominator: 2,
+  address: {
+    street: '123 Main St',
+    city: 'Vancouver',
+    region: 'BC',
+    country: 'CA',
+    postalCode: 'V1A 1A1'
+  },
+  phoneNumber: '123-456-7890',
+  phoneExtension: 123,
+  emailAddress: 'test@example.com',
+  createDateTime: '2022-01-01T14:30:45+00:00',
+  registrationDescription: 'Test Registration',
+  documentRegistrationNumber: '123456',
+  documentId: '7890',
+  endDateTime: '2023-01-01T14:30:45+00:00'
+}
+
+describe('MhrHistoryOwners.vue', () => {
+  let wrapper
+
+  beforeEach(async () => {
+    wrapper = await createComponent(MhrHistoryOwners, {
+      content: contentMock
+    })
+    await nextTick()
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.find('#mhr-history-owners').exists()).toBe(true)
+  })
+
+  it('displays tenancy type, group, owner, group tenancy type, and interest correctly', () => {
+    expect(wrapper.text()).toContain('Tenancy Type:')
+    expect(wrapper.text()).toContain(contentMock.type)
+    expect(wrapper.text()).toContain('Group:')
+    expect(wrapper.text()).toContain(`${contentMock.groupId} of ${contentMock.groupCount}`)
+    expect(wrapper.text()).toContain('Owner:')
+    expect(wrapper.text()).toContain(`${contentMock.ownerId} of ${contentMock.groupOwnerCount}`)
+    expect(wrapper.text()).toContain('Group Tenancy Type:')
+    expect(wrapper.text()).toContain(contentMock.groupTenancyType)
+    expect(wrapper.text()).toContain('Interest:')
+    expect(wrapper.text()).toContain(`${contentMock.interest} ${contentMock.interestNumerator}/${contentMock.interestDenominator}`)
+  })
+
+  it('displays mailing address correctly', () => {
+    expect(wrapper.text()).toContain('Mailing Address')
+    const baseAddress = wrapper.findComponent(BaseAddress)
+    expect(baseAddress.text()).toContain(contentMock.address.street)
+    expect(baseAddress.text()).toContain(contentMock.address.city)
+    expect(baseAddress.text()).toContain(contentMock.address.region)
+    expect(baseAddress.text()).toContain('Canada') // Formatted value
+    expect(baseAddress.text()).toContain(contentMock.address.postalCode)
+  })
+
+  it('displays phone number and email address correctly', () => {
+    expect(wrapper.text()).toContain('Phone Number')
+    expect(wrapper.text()).toContain(contentMock.phoneNumber)
+    expect(wrapper.text()).toContain(`Ext ${contentMock.phoneExtension}`)
+    expect(wrapper.text()).toContain('Email Address')
+    expect(wrapper.text()).toContain(contentMock.emailAddress)
+  })
+
+  it('displays owned from details correctly', () => {
+    expect(wrapper.text()).toContain('Owned From')
+    expect(wrapper.text()).toContain('January 1, 2022') // Adjust the date format to shortPacificDate
+    expect(wrapper.text()).toContain('Document Type')
+    expect(wrapper.text()).toContain(contentMock.registrationDescription)
+    expect(wrapper.text()).toContain('Registration Number')
+    expect(wrapper.text()).toContain(contentMock.documentRegistrationNumber)
+    expect(wrapper.text()).toContain('Document ID')
+    expect(wrapper.text()).toContain(contentMock.documentId)
+  })
+
+  it('displays owned until details correctly if endDateTime is present', () => {
+    expect(wrapper.text()).toContain('Owned Until')
+    expect(wrapper.text()).toContain('January 1, 2023') // Adjust the date format according to shortPacificDate
+    expect(wrapper.text()).toContain('Document Type')
+    expect(wrapper.text()).toContain(contentMock.registrationDescription)
+    expect(wrapper.text()).toContain('Registration Number')
+    expect(wrapper.text()).toContain(contentMock.documentRegistrationNumber)
+    expect(wrapper.text()).toContain('Document ID')
+    expect(wrapper.text()).toContain(contentMock.documentId)
+  })
+
+  it('displays "Current" for owned until if endDateTime is not present', async () => {
+    wrapper = await createComponent(MhrHistoryOwners, {
+      content: { ...contentMock, endDateTime: null }
+    })
+    await nextTick()
+    await nextTick()
+    expect(wrapper.text()).toContain('Owned Until')
+    expect(wrapper.text()).toContain('Current')
+  })
+
+  it('displays email address as "(Not Entered)" if not present', async () => {
+    wrapper = await createComponent(MhrHistoryOwners, {
+      content: { ...contentMock, emailAddress: null }
+    })
+    expect(wrapper.text()).toContain('Email Address')
+    expect(wrapper.text()).toContain('(Not Entered)')
+  })
+})


### PR DESCRIPTION
*Issue #:* 

*Description of changes:*
/bcgov/entity#21927
- Mhr History for Home Owners
- Unit tests
- Added some display value formatting

![Screenshot 2024-07-08 at 10 21 16 AM](https://github.com/bcgov/ppr/assets/53542131/80740bef-a868-4a84-ba32-411c29b212b0)


![Screenshot 2024-07-08 at 10 21 24 AM](https://github.com/bcgov/ppr/assets/53542131/9d2e1bcd-3c2d-4c47-9937-c7387f25cf3b)


/bcgov/entity#22140
- Update to adapt UI to preserved owner group orders following Transfers
- Includes the logic update that auto-adds to the appropriate owner group

![Screenshot 2024-07-08 at 10 19 47 AM](https://github.com/bcgov/ppr/assets/53542131/f2ce6886-5142-443b-a57c-37dcd6708a43)

![Screenshot 2024-07-08 at 10 20 01 AM](https://github.com/bcgov/ppr/assets/53542131/0a1acfbc-4894-402e-bed4-3cbd7de53d02)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
