### PR TITLE
PPR Validation Scrolling / Search Highlight / MF Address Comparison Update

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.34",
+  "version": "3.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.34",
+      "version": "3.2.35",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.34",
+  "version": "3.2.35",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/App.vue
+++ b/ppr-ui/src/App.vue
@@ -25,12 +25,14 @@
 
     <div class="app-body">
       <main>
-        <sbc-system-banner
+        <SbcSystemBanner
           v-if="bannerText != null"
+          class="mt-n1"
           :show="bannerText != null"
-          :type="null"
+          type="warning"
+          icon="''"
           :message="bannerText"
-          icon=" "
+          :dismissible="false"
         />
         <Breadcrumb v-if="haveData" />
         <Tombstone

--- a/ppr-ui/src/assets/styles/base.scss
+++ b/ppr-ui/src/assets/styles/base.scss
@@ -365,7 +365,8 @@ a {
 
 // borders
 .border-error-left {
-  border-left: 3px solid $error !important;
+  scroll-margin-top: 200px; // Provides space between top of viewport and scrolled-to element
+  border-left: 3px solid $error!important;
 }
 
 .rounded-all {

--- a/ppr-ui/src/components/parties/summaries/BasePartySummary.vue
+++ b/ppr-ui/src/components/parties/summaries/BasePartySummary.vue
@@ -108,7 +108,7 @@
               <tr>
                 <td
                   :colspan="headers.length"
-                  class="error-text text-left"
+                  class="error-text text-left border-error-left"
                 >
                   <v-icon color="error ml-2">
                     mdi-information-outline

--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -33,8 +33,9 @@
 
             <tbody v-if="searchHistory.length > 0">
               <tr
-                v-for="item in searchHistory"
+                v-for="(item, index) in searchHistory"
                 :key="item.searchId"
+                :class="{ 'added-search-effect': searchAdded && index === 0 }"
               >
                 <td>
                   <v-row noGutters>
@@ -215,9 +216,9 @@
 <script lang="ts">
 import {
   computed,
-  defineComponent,
+  defineComponent, nextTick,
   reactive,
-  toRefs
+  toRefs, watch
 } from 'vue'
 import { useStore } from '@/store/store'
 import { SearchCriteriaIF, SearchResponseIF } from '@/interfaces'
@@ -236,6 +237,9 @@ export default defineComponent({
   components: {
     SortingIcon,
     ErrorContact
+  },
+  props: {
+    searchAdded: { type: Boolean, default: false },
   },
   emits: ['error', 'retry'],
   setup (props, { emit }) {
@@ -457,6 +461,23 @@ export default defineComponent({
       sortDates(searchHistory, dateType, reverse)
     }
 
+    /** Scroll to Search Table **/
+    async function scrollToAddedSearch(defaultIndex: number = 0): Promise<void> {
+      setTimeout(() => {
+        document?.getElementsByClassName('main-results-div').length > 0 &&
+        document?.getElementsByClassName('main-results-div')[defaultIndex]
+          .scrollIntoView({ behavior: 'smooth' })
+      }, 300)
+    }
+
+    /** Scroll to event on added search **/
+    watch(() => props.searchAdded, async () => {
+      if (props.searchAdded) {
+        await nextTick()
+        await scrollToAddedSearch()
+      }
+    }, { immediate: true })
+
     return {
       ...toRefs(localState),
       displayDate,
@@ -479,6 +500,17 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
+.added-search-effect {
+  background-color: $greenSelected;
+  font-weight: bold;
+}
+.main-results-div {
+  width: 100%;
+}
+.search-contact-container {
+  width: 350px;
+  font-size: 0.875rem;
+}
 :deep(#search-history-table) {
   td {
     text-overflow: initial;
@@ -489,12 +521,4 @@ export default defineComponent({
     word-wrap: break-word;
   }
 }
-.main-results-div {
-  width: 100%;
-}
-.search-contact-container {
-  width: 350px;
-  font-size: 0.875rem;
-}
-
 </style>

--- a/ppr-ui/src/composables/userAccess/useUserAccess.ts
+++ b/ppr-ui/src/composables/userAccess/useUserAccess.ts
@@ -39,6 +39,7 @@ import {
   UserAccessMessageIF,
   UserProductSubscriptionIF
 } from '@/interfaces'
+import { omit } from 'lodash'
 
 export const useUserAccess = () => {
   const { initializeUserProducts } = useAuth()
@@ -359,7 +360,10 @@ export const useUserAccess = () => {
       dealerManufacturerAddress = manufacturerData?.location?.address
     }
 
-    return !isObjectEqual(getMhrRegistrationLocation.value?.address, dealerManufacturerAddress)
+    return !isObjectEqual(
+      omit(getMhrRegistrationLocation.value?.address, 'postalCode'),
+      omit(dealerManufacturerAddress, 'postalCode')
+    )
   }
 
   /**

--- a/ppr-ui/src/utils/form-helper.ts
+++ b/ppr-ui/src/utils/form-helper.ts
@@ -17,7 +17,7 @@ export async function scrollToFirstErrorComponent(defaultIndex: number = 0): Pro
     document?.getElementsByClassName('border-error-left').length > 0 &&
     document?.getElementsByClassName('border-error-left')[defaultIndex]
       .scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
-  }, 500)
+  }, 300)
 }
 
 /**

--- a/ppr-ui/src/views/Dashboard.vue
+++ b/ppr-ui/src/views/Dashboard.vue
@@ -109,6 +109,7 @@
       </header>
       <SearchHistory
         v-if="!loading"
+        :searchAdded="toggleSearchAdded"
         @retry="retrieveSearchHistory"
         @error="emitError"
       />
@@ -233,6 +234,7 @@ export default defineComponent({
       isMHRSearchType: useSearch().isMHRSearchType,
       snackbarMsg: '',
       toggleSnackbar: false,
+      toggleSearchAdded: false,
       searchHistoryLength: computed((): number => {
         return (getSearchHistory.value as SearchResponseIF[])?.length || 0
       }),
@@ -344,10 +346,14 @@ export default defineComponent({
     })
 
     watch(() => getSearchHistoryLength.value, (newVal: number, oldVal: number): void => {
-      // show snackbar if oldVal was not null
+      // show snackbar if oldVal was not null and highlight new search
       if (oldVal !== null) {
         localState.snackbarMsg = 'Your search was successfully added to your table.'
         localState.toggleSnackbar = !localState.toggleSnackbar
+        localState.toggleSearchAdded = !localState.toggleSearchAdded
+
+        // Remove search added styling after timeout
+        setTimeout(() => { localState.toggleSearchAdded = !localState.toggleSearchAdded }, 5000)
       }
     })
 

--- a/ppr-ui/src/views/discharge/ConfirmDischarge.vue
+++ b/ppr-ui/src/views/discharge/ConfirmDischarge.vue
@@ -123,7 +123,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
+import { computed, defineComponent, nextTick, reactive, toRefs, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from '@/store/store'
 import { storeToRefs } from 'pinia'
@@ -137,7 +137,7 @@ import {
 import { RegisteringPartyChange } from '@/components/parties/party'
 import { BaseDialog } from '@/components/dialogs'
 import { notCompleteDialog } from '@/resources/dialogOptions'
-import { getFeatureFlag, saveDischarge } from '@/utils'
+import { getFeatureFlag, saveDischarge, scrollToFirstVisibleErrorComponent } from '@/utils'
 import { ActionTypes, APIRegistrationTypes, RouteNames, UIRegistrationTypes } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import {
@@ -262,6 +262,8 @@ export default defineComponent({
     const submitDischarge = async (): Promise<void> => {
       if ((!localState.validConfirm) || (!localState.validFolio) || (!localState.validCertify)) {
         localState.showErrors = true
+        await nextTick()
+        await scrollToFirstVisibleErrorComponent()
         return
       }
 

--- a/ppr-ui/src/views/newRegistration/ReviewConfirm.vue
+++ b/ppr-ui/src/views/newRegistration/ReviewConfirm.vue
@@ -232,7 +232,7 @@ import { RegistrationLengthTrustSummary } from '@/components/registration'
 import { Collateral } from '@/components/collateral'
 import { Parties } from '@/components/parties'
 import FolioNumberSummary from '@/components/common/FolioNumberSummary.vue'
-import { getFeatureFlag } from '@/utils'
+import { getFeatureFlag, scrollToFirstVisibleErrorComponent } from '@/utils'
 import { ErrorIF } from '@/interfaces'
 import { RegistrationLengthI } from '@/composables/fees/interfaces'
 import { storeToRefs } from 'pinia'
@@ -356,9 +356,10 @@ export default defineComponent({
       localState.dataLoaded = true
     }
 
-    const registrationIncomplete = (): void => {
+    const registrationIncomplete = async (): Promise<void> => {
       localState.showStepErrors = true
       setShowStepErrors(true)
+      await scrollToFirstVisibleErrorComponent()
     }
 
     /** Emits error to app.vue for handling */


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19803

*Description of changes:*
- Updated border-error-left styling to give some margin above scrolled to element on validation scrolls
- Includes scroll-to in PPR registrations/discharges at submission (was already in Amendments/Renews)
- Adds error borders to incomplete parties

 /bcgov/entity#22240
- Omit Postal code from MF Address Comparison to support legacy data where it could be absent

 /bcgov/entity#19087
- Search Highlight and scroll to
![Screenshot 2024-07-10 at 10 29 22 AM](https://github.com/bcgov/ppr/assets/53542131/48cebc9c-37a3-40d8-b737-0e28eb4cef80)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
