### PR TITLE
Owners Group Selection Fix

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.35",
+  "version": "3.2.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.35",
+      "version": "3.2.36",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.35",
+  "version": "3.2.36",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
+++ b/ppr-ui/src/components/mhrHistory/MhrHistoryLocations.vue
@@ -97,74 +97,76 @@
             </v-col>
           </template>
 
-          <v-col
-            v-else
-            cols="3"
-            class="pb-2"
-          >
-            <h4>Legal Land Description</h4>
-          </v-col>
+          <template v-else>
+            <v-col
+              cols="3"
+              class="pb-2"
+            >
+              <h4>Legal Land Description</h4>
+            </v-col>
 
-          <v-col
-            cols="7"
-            class="pl-3"
-          >
-            <p v-if="content.bandName">
-              Band Name: {{ content.bandName || '(Not Entered)' }}
-            </p>
-            <p v-if="content.reserveNumber">
-              Reserve Number: {{ content.reserveNumber || '(Not Entered)' }}
-            </p>
-            <p v-if="content.lot">
-              Lot: {{ content.lot }}
-            </p>
-            <p v-if="content.parcel">
-              Parcel: {{ content.parcel }}
-            </p>
-            <p v-if="content.block">
-              Block: {{ content.block }}
-            </p>
-            <p v-if="content.districtLot">
-              District Lot: {{ content.districtLot }}
-            </p>
-            <p v-if="content.partOf">
-              Part of: {{ content.partOf }}
-            </p>
-            <p v-if="content.section">
-              Section: {{ content.section }}
-            </p>
-            <p v-if="content.township">
-              Township: {{ content.township }}
-            </p>
-            <p v-if="content.range">
-              Range: {{ content.range }}
-            </p>
-            <p v-if="content.meridian">
-              Meridian: {{ content.meridian }}
-            </p>
-            <p v-if="content.landDistrict">
-              Land District: {{ content.landDistrict }}
-            </p>
-            <p v-if="content.plan">
-              Plan: {{ content.plan }}
-            </p>
-            <p v-if="content.exceptionPlan">
-              Exception Plan: {{ content.exceptionPlan }}
-            </p>
-          </v-col>
+            <v-col
+              cols="7"
+              class="pl-3"
+            >
+              <p v-if="content.bandName">
+                Band Name: {{ content.bandName || '(Not Entered)' }}
+              </p>
+              <p v-if="content.reserveNumber">
+                Reserve Number: {{ content.reserveNumber || '(Not Entered)' }}
+              </p>
+              <p v-if="content.lot">
+                Lot: {{ content.lot }}
+              </p>
+              <p v-if="content.parcel">
+                Parcel: {{ content.parcel }}
+              </p>
+              <p v-if="content.block">
+                Block: {{ content.block }}
+              </p>
+              <p v-if="content.districtLot">
+                District Lot: {{ content.districtLot }}
+              </p>
+              <p v-if="content.partOf">
+                Part of: {{ content.partOf }}
+              </p>
+              <p v-if="content.section">
+                Section: {{ content.section }}
+              </p>
+              <p v-if="content.township">
+                Township: {{ content.township }}
+              </p>
+              <p v-if="content.range">
+                Range: {{ content.range }}
+              </p>
+              <p v-if="content.meridian">
+                Meridian: {{ content.meridian }}
+              </p>
+              <p v-if="content.landDistrict">
+                Land District: {{ content.landDistrict }}
+              </p>
+              <p v-if="content.plan">
+                Plan: {{ content.plan }}
+              </p>
+              <p v-if="content.exceptionPlan">
+                Exception Plan: {{ content.exceptionPlan }}
+              </p>
+            </v-col>
+          </template>
 
-          <v-col
-            v-if="content.additionalDescription"
-            cols="3"
-          >
-            <h4>Additional Description</h4>
-          </v-col>
-          <v-col
-            cols="7"
-            class="pl-3"
-          >
-            <p>{{ content.additionalDescription }}</p>
-          </v-col>
+          <template v-if="content.additionalDescription">
+            <v-col
+              cols="3"
+            >
+              <h4>Additional Description</h4>
+            </v-col>
+            <v-col
+              cols="7"
+              class="pl-3"
+            >
+              <p>{{ content.additionalDescription }}</p>
+            </v-col>
+          </template>
         </v-row>
       </template>
     </v-row>

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -358,7 +358,7 @@
           />
 
           <!-- Group Add / Edit -->
-          <template v-if="!isTransferDueToDeath && !isFrozenMhr && !(isMhrCorrection && editHomeOwner)">
+          <template v-if="!isTransferDueToDeath && !isFrozenMhrDueToAffidavit && !(isMhrCorrection && editHomeOwner)">
             <hr class="mt-3 mb-10">
             <HomeOwnerGroups
               :groupId="isDefinedGroup ? ownersGroupId : null"
@@ -852,6 +852,7 @@ export default defineComponent({
       setShowGroups,
       AdditionalNameConfig,
       isRoleQualifiedSupplier,
+      isFrozenMhrDueToAffidavit,
       ...toRefs(localState)
     }
   }

--- a/ppr-ui/src/components/mhrRegistration/MhrStatusCorrection.vue
+++ b/ppr-ui/src/components/mhrRegistration/MhrStatusCorrection.vue
@@ -109,7 +109,10 @@ const { setMhrCorrectStatusType } = useStore()
 const { getMhrInformation } = storeToRefs(useStore())
 const { correctionState } = useMhrCorrections()
 
-const mhrStatus = ref(getMhrInformation.value?.statusType)
+const mhrStatusDefault = getMhrInformation.value?.statusType === MhApiStatusTypes.FROZEN
+  ? MhApiStatusTypes.ACTIVE
+  : getMhrInformation.value?.statusType
+const mhrStatus = ref(mhrStatusDefault)
 const displayStatusOptions = computed((): boolean => {
   return !containsCurrentRoute([RouteNames.MHR_REVIEW_CONFIRM])
 })

--- a/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useMhrCorrections.ts
@@ -9,7 +9,7 @@ import {
   getFeatureFlag,
   getMhrDraft
 } from '@/utils'
-import { ActionTypes, APIRegistrationTypes, HomeCertificationOptions, RouteNames } from '@/enums'
+import { ActionTypes, APIRegistrationTypes, HomeCertificationOptions, MhApiStatusTypes, RouteNames } from '@/enums'
 import { useNavigation, useNewMhrRegistration, useTransportPermits } from '@/composables'
 import {
   AdminRegistrationIF,
@@ -261,7 +261,9 @@ export const useMhrCorrections = () => {
         certificationOption: certificationOption,
         hasNoCertification: certificationOption === null,
       },
-      statusType: getMhrInformation.value?.statusType
+      statusType: getMhrInformation.value?.statusType === MhApiStatusTypes.FROZEN
+        ? MhApiStatusTypes.ACTIVE
+        : getMhrInformation.value?.statusType
     }))
 
     // Set Current Registration to filing state


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22184

*Description of changes:*
- Only restrict owner group selection in specific transfer type
- Map Frozen to Active for puba/corr 
- minor template fix for location additional info

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
