### PR TITLE
Note report effective time, BCA timestamps no tz.

### DIFF
--- a/mhr_api/report-templates/unitNoteV2.html
+++ b/mhr_api/report-templates/unitNoteV2.html
@@ -31,9 +31,9 @@
       <tr>
         <td>
             {% if note is defined and note.documentType is defined and note.documentType in ('NCAN', 'NRED') %}
-                Cancelled Date:
+                Cancelled Date and Time:
             {% else %}
-               Effective Date:
+               Effective Date and Time:
             {% endif %}
         </td>
         <td>

--- a/mhr_api/src/mhr_api/models/batch_utils.py
+++ b/mhr_api/src/mhr_api/models/batch_utils.py
@@ -430,8 +430,8 @@ def get_batch_registration_data(start_ts: str = None, end_ts: str = None):
     query = text(query_s)
     result = None
     if start_ts and end_ts:
-        start: str = start_ts[:19].replace('T', ' ')
-        end: str = end_ts[:19].replace('T', ' ')
+        start: str = get_query_ts(start_ts)
+        end: str = get_query_ts(end_ts)
         current_app.logger.debug(f'start={start} end={end}')
         result = db.session.execute(query, {'query_val1': start, 'query_val2': end})
     else:
@@ -445,3 +445,10 @@ def get_batch_registration_data(start_ts: str = None, end_ts: str = None):
     else:
         current_app.logger.debug('No batch registrations found within the timestamp range.')
     return results_json
+
+
+def get_query_ts(request_ts: str):
+    """Get a query timestamp as UTC in the DB format."""
+    ts = model_utils.ts_from_iso_format_no_tz(request_ts)
+    query_ts: str = model_utils.format_ts(ts)
+    return query_ts[:19].replace('T', ' ')

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -299,8 +299,9 @@ def ts_from_iso_format_no_tz(timestamp_iso: str):
     if len(timestamp_iso) > 19:
         return ts_from_iso_format(timestamp_iso)
     ts: _datetime = _datetime.fromisoformat(timestamp_iso)
-    ts.replace(tzinfo=LOCAL_TZ)
-    return ts.astimezone(timezone.utc)
+    local_ts = LOCAL_TZ.localize(ts, is_dst=True)
+    # Return as UTC
+    return local_ts.astimezone(timezone.utc)
 
 
 def today_ts_offset(offset_days: int = 1, add: bool = False):

--- a/mhr_api/src/mhr_api/models/utils.py
+++ b/mhr_api/src/mhr_api/models/utils.py
@@ -294,6 +294,15 @@ def now_ts_offset(offset_days: int = 1, add: bool = False):
     return now - timedelta(days=offset_days)
 
 
+def ts_from_iso_format_no_tz(timestamp_iso: str):
+    """Create a datetime object from a timestamp string in the ISO format using the local time zone."""
+    if len(timestamp_iso) > 19:
+        return ts_from_iso_format(timestamp_iso)
+    ts: _datetime = _datetime.fromisoformat(timestamp_iso)
+    ts.replace(tzinfo=LOCAL_TZ)
+    return ts.astimezone(timezone.utc)
+
+
 def today_ts_offset(offset_days: int = 1, add: bool = False):
     """Create a timestamp representing the current date at 00:00:00 adjusted by offset number of days."""
     today = date.today()

--- a/mhr_api/src/mhr_api/reports/v2/report.py
+++ b/mhr_api/src/mhr_api/reports/v2/report.py
@@ -548,7 +548,7 @@ class Report:  # pylint: disable=too-few-public-methods
             elif note.get('expiryDateTime'):
                 note['expiryDateTime'] = Report._to_report_datetime(note.get('expiryDateTime'), False)
             if note.get('effectiveDateTime'):
-                note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'), False)
+                note['effectiveDateTime'] = Report._to_report_datetime(note.get('effectiveDateTime'), True)
             if note.get('cancelledDateTime'):
                 note['cancelledDateTime'] = Report._to_report_datetime(note.get('cancelledDateTime'), True)
             if note.get('givingNoticeParty') and note['givingNoticeParty'].get('phoneNumber'):

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.16'  # pylint: disable=invalid-name
+__version__ = '1.8.17'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/models/test_batch_utils.py
+++ b/mhr_api/tests/unit/models/test_batch_utils.py
@@ -45,6 +45,8 @@ TEST_DATA_NOC_LOCATION_UPDATE = [
 # testdata pattern is ({start_ts}, {end_ts})
 TEST_DATA_BATCH_REGISTRATION = [
     ('2023-12-15T08:01:00+00:00', '2023-12-22T08:01:00+00:00'),
+    ('2023-12-15T00:01:00-08:00', '2023-12-22T00:01:00-00:00'),
+    ('2023-12-15T00:01:00', '2023-12-22T00:01:00'),
     (None, None)
 ]
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18042

*Description of changes:*
- Unit Note registration reports display time for effective date and time

*Issue #:* /bcgov/entity#22194

*Description of changes:*
- BCA endpoint accept a timestamp range without time zones, convert to the local time zone. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
