### PR TITLE
Fix SE reg type amendment set up.

### DIFF
--- a/ppr-api/src/ppr_api/models/financing_statement.py
+++ b/ppr-api/src/ppr_api/models/financing_statement.py
@@ -380,6 +380,14 @@ class FinancingStatement(db.Model):  # pylint: disable=too-many-instance-attribu
                             notice_json['added'] = True
                     if notice_json:
                         notices_list.append(notice.json)
+        if notices_list and self.current_view_json:  # Current view remove existing amendment notice/order links.
+            for notice in notices_list:
+                if 'amendNoticeId' in notice:
+                    del notice['amendNoticeId']
+                if notice.get('securitiesActOrders'):
+                    for order in notice.get('securitiesActOrders'):
+                        if 'amendOrderId' in order:
+                            del order['amendOrderId']
         return notices_list
 
     def validate_debtor_name(self, debtor_name_json, staff: bool = False):

--- a/ppr-api/src/ppr_api/reports/v2/report_utils.py
+++ b/ppr-api/src/ppr_api/reports/v2/report_utils.py
@@ -752,3 +752,10 @@ def set_modified_notice(statement):
             # Amend order check
             if del_notice and del_notice.get('securitiesActOrders') and add_notice.get('securitiesActOrders'):
                 set_modified_order(add_notice, del_notice)
+            elif del_notice and del_notice.get('securitiesActOrders'):  # Notice amended, all orders removed.
+                del_orders = []
+                for del_order in del_notice.get('securitiesActOrders'):
+                    order = copy.deepcopy(del_order)
+                    order['amendDeleted'] = True
+                    del_orders.append(order)
+                add_notice['securitiesActOrders'] = del_orders

--- a/ppr-api/tests/unit/models/test_financing_statement.py
+++ b/ppr-api/tests/unit/models/test_financing_statement.py
@@ -261,6 +261,12 @@ def test_find_by_registration_number(session, desc, reg_number, reg_type, accoun
             assert result['generalCollateral'][0]
             assert result.get('securitiesActNotices')
             assert result['securitiesActNotices'][0].get('securitiesActOrders')
+            if statement.current_view_json:
+                for notice in result.get('securitiesActNotices'):
+                    assert 'amendNoticeId' not in notice
+                    if notice.get('securitiesActOrders'):
+                        for order in notice.get('securitiesActOrders'):
+                            assert 'amendOrderId' not in order
     else:
         with pytest.raises(BusinessException) as request_err:
             FinancingStatement.find_by_registration_number(reg_number, account_id, staff, create)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22195

*Description of changes:*
- SE current view of base registration remove amendNoticeId from notices, amendOrderId from orders.
- Verification report set up handle case where all orders are deleted from an amended notice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
