### PR TITLE
Search History Table AA - Screen Reading/Testing

### DIFF
--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-container class="main-results-div pa-0 bg-white">
+  <v-container
+    class="main-results-div pa-0 bg-white"
+    role="region"
+  >
     <v-row
       noGutters
       class="pt-4"
@@ -41,18 +44,13 @@
                   <v-row noGutters>
                     <v-col cols="2">
                       <v-icon
-                        v-if="isPprSearch(item)"
                         class="pr-2 mt-n1"
                         color="#212529"
+                        aria-hidden="false"
+                        :aria-label="isPprSearch(item) ? 'PPR Search' : 'MHR Search'"
+                        role="img"
                       >
-                        mdi-account-details
-                      </v-icon>
-                      <v-icon
-                        v-else
-                        class="pr-2 mt-n1"
-                        color="#212529"
-                      >
-                        mdi-home
+                        {{ isPprSearch(item) ? 'mdi-account-details' : 'mdi-home' }}
                       </v-icon>
                     </v-col>
                     <v-col>
@@ -86,19 +84,31 @@
                   <span v-if="!item.inProgress || isSearchOwner(item)">
                     {{ item.totalResultsSize }}
                   </span>
-                  <span v-else>-</span>
+                  <span
+                    v-else
+                    role="img"
+                    aria-label="None"
+                  >-</span>
                 </td>
                 <td>
                   <span v-if="(!item.inProgress || isSearchOwner(item)) && item.exactResultsSize >= 0">
                     {{ item.exactResultsSize }}
                   </span>
-                  <span v-else>-</span>
+                  <span
+                    v-else
+                    role="img"
+                    aria-label="None"
+                  >-</span>
                 </td>
                 <td>
                   <span v-if="!item.inProgress || isSearchOwner(item)">
                     {{ item.selectedResultsSize }}
                   </span>
-                  <span v-else>-</span>
+                  <span
+                    v-else
+                    role="img"
+                    aria-label="None"
+                  >-</span>
                 </td>
                 <td>
                   <v-btn
@@ -109,6 +119,7 @@
                     variant="plain"
                     :ripple="false"
                     :loading="item.loadingPDF"
+                    aria-label="Download PDF"
                     @click="downloadPDF(item)"
                   >
                     <img src="@/assets/svgs/pdf-icon-blue.svg">
@@ -128,6 +139,7 @@
                         color="primary"
                         :ripple="false"
                         :loading="item.loadingPDF"
+                        aria-label="Refresh Download Button"
                         @click="refreshRow(item)"
                       >
                         <v-icon
@@ -144,6 +156,7 @@
                         variant="plain"
                         :ripple="false"
                         :loading="item.loadingPDF"
+                        aria-label="Generate Report Button"
                         @click="generateReport(item)"
                       >
                         <v-icon
@@ -161,6 +174,9 @@
                         class="ml-5"
                         v-bind="props"
                         tabindex="0"
+                        role="img"
+                        aria-hidden="false"
+                        :aria-label="getTooltipTxtPdf(item)"
                       >
                         mdi-information-outline
                       </v-icon>
@@ -191,6 +207,7 @@
                       variant="plain"
                       color="primary"
                       :ripple="false"
+                      aria-label="Retry Button"
                       @click="retrySearch()"
                     >
                       Retry <v-icon>mdi-refresh</v-icon>
@@ -520,5 +537,8 @@ export default defineComponent({
     padding-bottom: 20px !important;
     word-wrap: break-word;
   }
+}
+.dontRead {
+  speak: none!important;
 }
 </style>

--- a/ppr-ui/src/components/tables/common/SortingIcon.vue
+++ b/ppr-ui/src/components/tables/common/SortingIcon.vue
@@ -5,6 +5,7 @@
       size="small"
       color="black"
       data-test-id="down-arrow-icon"
+      aria-label="Sort Ascending Button"
       @click="emitSort(true)"
     >
       mdi-arrow-down
@@ -14,6 +15,7 @@
       size="small"
       color="black"
       data-test-id="up-arrow-icon"
+      aria-label="Sort Descending Button"
       @click="emitSort(false)"
     >
       mdi-arrow-up

--- a/ppr-ui/tests/unit/SearchHistory.spec.ts
+++ b/ppr-ui/tests/unit/SearchHistory.spec.ts
@@ -4,6 +4,7 @@ import { createComponent } from './utils'
 import { useStore } from '@/store/store'
 import flushPromises from 'flush-promises'
 import { mockedMHRSearchHistory, mockedSearchHistory } from './test-data'
+import { axe } from 'vitest-axe'
 
 const store = useStore()
 
@@ -17,6 +18,15 @@ describe('Test result table with no results', () => {
     await store.setSearchHistory([])
     wrapper = await createComponent(SearchHistory)
     await flushPromises()
+  })
+
+  it('should have no accessibility violations', async () => {
+    // Run the axe-core accessibility check on the component's HTML
+    const results = await axe(wrapper.html())
+    
+    expect(results).toBeDefined()
+    expect(results.violations).toBeDefined()
+    expect(results.violations).toHaveLength(0)
   })
 
   it('renders and displays correct elements for no results', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22054

*Description of changes:*
- Minor A11Y definitions to support preferred Screen Reading approach
- Includes AXE testing on Search History Table
- Added Screen reading support for ToolTip - if this is preferred by UXA/QA we can move forward with this approach


**Notes** 
- Lots of good findings from this ticket have been documented in the ticket itself - please read!
- Also we need to align on what screen reading tools we use for which browsers. They are not all equal and do not all work the same. I've documented findings in the ticket but the jist is: 

VoiceOver (macOs): Recommended for Safari
NCDA/ChromeVox: Recommended for Chrome/Firefox

Each of these tools yields different results, so in order for accurate development and testing we need to be aware of this and standardize what we tool we use for the respective browsers. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
