### PR TITLE
Remove Court Order Fee Override

### DIFF
--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -149,8 +149,7 @@ export default defineComponent({
       getIsStaffClientPayment,
       isRoleStaffReg,
       isRoleStaffSbc,
-      getStaffPayment,
-      getMhrTransferType
+      getStaffPayment
     } = storeToRefs(useStore())
 
     const localState = reactive({
@@ -166,14 +165,6 @@ export default defineComponent({
       disableSubmitBtn: props.setDisableSubmitBtn,
       feeOverride: computed(() => {
         if (isNonBillable.value || localState.isNoFeePayment) {
-          return {
-            feeAmount: 0,
-            processingFee: null, // not used in override
-            quantity: null, // not used in override
-            serviceFee: getUserServiceFee.value as number
-          } as FeeSummaryI
-        }
-        if (getMhrTransferType.value?.transferType === ApiTransferTypes.COU) {
           return {
             feeAmount: 0,
             processingFee: null, // not used in override

--- a/ppr-ui/src/components/common/StickyContainer.vue
+++ b/ppr-ui/src/components/common/StickyContainer.vue
@@ -49,7 +49,7 @@ import {
 import { useStore } from '@/store/store'
 import { ButtonsStacked } from '@/components/common'
 import { FeeSummary } from '@/composables/fees'
-import { ApiTransferTypes, UIRegistrationTypes, UITransferTypes } from '@/enums'
+import { UIRegistrationTypes, UITransferTypes } from '@/enums'
 import { FeeSummaryTypes } from '@/composables/fees/enums'
 import {
   AdditionalSearchFeeIF,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21318

*Description of changes:*
- Removes Court Order override logic and fall back to default MHR Transfer Fee for UI Display

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
