### PR TITLE
Amend permit ignore postal code in non-staff address validation.

### DIFF
--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -358,8 +358,7 @@ def validate_amend_location_address(json_data: dict, current_location: dict) -> 
             addr_1.get('region', '') != addr_2.get('region', '') or \
             addr_1.get('country', '') != addr_2.get('country', ''):
         error_msg = AMEND_PERMIT_QS_ADDRESS_INVALID
-    if addr_2.get('postalCode', '') != addr_1.get('postalCode', ''):
-        error_msg = AMEND_PERMIT_QS_ADDRESS_INVALID
+    # Skip location address postal code comparison.
     return error_msg
 
 

--- a/mhr_api/tests/unit/utils/test_permit_validator.py
+++ b/mhr_api/tests/unit/utils/test_permit_validator.py
@@ -416,8 +416,7 @@ TEST_AMEND_LOCATION_DATA = [
      validator.AMEND_PERMIT_QS_ADDRESS_INVALID),
     ('Invalid non-staff change region', False, False, '000931', False, False, True, False,
      validator.AMEND_PERMIT_QS_ADDRESS_INVALID),
-    ('Invalid non-staff change pcode', False, False, '000931', False, False, False, True,
-     validator.AMEND_PERMIT_QS_ADDRESS_INVALID)
+    ('Valid non-staff change pcode', True, False, '000931', False, False, False, True, None)
 ]
 # test data pattern is ({description}, {valid}, {staff}, {add_days}, {message_content}, {mhr_num}, {account}, {group})
 TEST_EXPIRY_DATE_DATA = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22313

*Description of changes:*
- Amend transport permit non-staff data validation ignore postal code in location civic address validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
