### PR TITLE
enabled change ownership button when hasLien and isRoleStaffReg are true

### DIFF
--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -892,8 +892,9 @@ export default defineComponent({
         'Ownership Transfer or Change'
       ),
       isChangeOwnershipBtnDisabled: computed((): boolean => {
-        if(isRoleStaffReg.value && hasLien.value)
-          return false  
+        if(isRoleStaffReg.value && hasLien.value && !isFrozenMhrDueToAffidavit.value){
+          return false
+        }  
 
         const isFrozenMhr = isFrozenMhrDueToAffidavit.value || isFrozenMhrDueToUnitNote.value
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -892,6 +892,9 @@ export default defineComponent({
         'Ownership Transfer or Change'
       ),
       isChangeOwnershipBtnDisabled: computed((): boolean => {
+        if(isRoleStaffReg.value && hasLien.value)
+          return false  
+
         const isFrozenMhr = isFrozenMhrDueToAffidavit.value || isFrozenMhrDueToUnitNote.value
 
         const isTransportPermitDisabled = isChangeLocationActive.value ||


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22366

*Description of changes:*
Enabled `Change Ownership` button when there is a lien and logged in as a staff.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
