### PR TITLE
Enable Home Dealer Transfers

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.41",
+  "version": "3.2.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.41",
+      "version": "3.2.42",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.41",
+  "version": "3.2.42",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
@@ -200,7 +200,9 @@ export default defineComponent({
 
     const localState = reactive({
       validateSubmittingParty: false,
-      initialAttention: (isCancelUnitNote.value || isRedemptionUnitNote.value) ? '' : getMhrUnitNoteRegistration.value?.attentionReference,
+      initialAttention: (isCancelUnitNote.value || isRedemptionUnitNote.value)
+        ? ''
+        : getMhrUnitNoteRegistration.value?.attentionReference,
       unitNoteType: UnitNotesInfo[getMhrUnitNote.value.documentType],
       givingNoticeParty: computed((): PartyIF => getMhrUnitNote.value.givingNoticeParty),
       unitNoteSubmittingParty: computed(() => getMhrUnitNoteRegistration.value.submittingParty || {}),

--- a/ppr-ui/src/composables/userAccess/useUserAccess.ts
+++ b/ppr-ui/src/composables/userAccess/useUserAccess.ts
@@ -325,7 +325,7 @@ export const useUserAccess = () => {
    * Disable manufacturer transfer based on name match conditions and restricted to Sole Owners
    * @returns {Promise<boolean>} Promise that returns true when Manufacturer matches name records and is a sole owner
    */
-  const disableManufacturerTransfer = async (): Promise<boolean> => {
+  const disableDealerManufacturerTransfer = async (isDealer: boolean = false): Promise<boolean> => {
     let isSoleOwner: boolean, isNameMatch: boolean, currentOwnerName: string
 
     // First verify a single owner group & SOLE ownership
@@ -334,12 +334,19 @@ export const useUserAccess = () => {
       currentOwnerName = getMhrTransferCurrentHomeOwnerGroups.value[0]?.owners[0]?.organizationName
     } else return true
 
-    // If a Sole Owner: Fetch and verify the sole owner name matches the manufacturers records org or dba name
+    // If a Sole Owner: Fetch and verify the sole owner name matches the dealers/manufacturers records org or dba name
     if (isSoleOwner) {
-      const manufacturerData: MhrManufacturerInfoIF = await getMhrManufacturerInfo()
-      const manufacturerOrgName = manufacturerData?.ownerGroups[0]?.owners[0]?.organizationName
-      const manufacturerDbaName = manufacturerData?.dbaName
-      isNameMatch = (currentOwnerName === manufacturerOrgName || currentOwnerName === manufacturerDbaName)
+      let orgName, dbaName
+      if (isDealer) {
+        const dealerData: MhrQsPayloadIF = await getQualifiedSupplier()
+        orgName = dealerData?.businessName
+        dbaName = dealerData?.dbaName
+      } else {
+        const manufacturerData: MhrManufacturerInfoIF = await getMhrManufacturerInfo()
+        orgName = manufacturerData?.ownerGroups[0]?.owners[0]?.organizationName
+        dbaName = manufacturerData?.dbaName
+      }
+      isNameMatch = (currentOwnerName === orgName || currentOwnerName === dbaName)
     } else return true
 
     return !isNameMatch
@@ -504,7 +511,7 @@ export const useUserAccess = () => {
     isUserAccessRoute,
     isAuthorizationValid,
     downloadServiceAgreement,
-    disableManufacturerTransfer,
+    disableDealerManufacturerTransfer,
     disableDealerManufacturerLocationChange,
     submitQsApplication
   }

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -521,11 +521,11 @@
                 </v-expand-transition>
                 <p
                   v-if="disableRoleBaseTransfer"
-                  class="manufacturer-mismatch-text mt-9"
+                  class="dealer-manufacturer-mismatch-text mt-9"
                 >
                   <span class="font-weight-bold">Note:</span> You cannot register an ownership transfer or change
-                  because the home does not have a sole owner whose name matches your manufacturer’s name. Transfers can
-                  be registered by BC Registries staff or by a qualified lawyer or notary.
+                  because the home does not have a sole owner whose name matches your dealer's or manufacturer’s name.
+                  Transfers can be registered by BC Registries staff or by a qualified lawyer or notary.
                 </p>
                 <HomeOwners
                   ref="homeOwnersComponentRef"
@@ -834,7 +834,7 @@ export default defineComponent({
 
     const { getActiveExemption } = useExemptions()
     const { buildLocationChange } = useMhrCorrections()
-    const { disableManufacturerTransfer, disableDealerManufacturerLocationChange } = useUserAccess()
+    const { disableDealerManufacturerTransfer, disableDealerManufacturerLocationChange } = useUserAccess()
     const {
       isChangeLocationActive,
       isChangeLocationEnabled,
@@ -881,7 +881,6 @@ export default defineComponent({
       showStartTransferRequiredDialog: false,
       showOutOfDateTransferDialog: false,
       hasLienInfoDisplayed: false, // flag to track if lien info has been displayed after API check
-      enableRoleBasedTransfer: true, // rendering of the transfer/change btn
       disableRoleBaseTransfer: false, // disabled state of transfer/change btn
       disableRoleBaseLocationChange: false, // disabled state of location change/transport permit btn
       submitBtnLoading: false,
@@ -991,8 +990,7 @@ export default defineComponent({
         return localState.isReviewMode ? 'Register Changes and Pay' : 'Review and Confirm'
       }),
       enableHomeOwnerChanges: computed((): boolean => {
-        return !isRoleStaffSbc.value && getFeatureFlag('mhr-transfer-enabled') &&
-          localState.enableRoleBasedTransfer
+        return !isRoleStaffSbc.value && getFeatureFlag('mhr-transfer-enabled')
       }),
       isDraft: computed((): boolean => {
         return getMhrInformation.value.draftNumber
@@ -1072,11 +1070,11 @@ export default defineComponent({
       // Check for product based Transfer access
       switch(true) {
         case isRoleManufacturer.value:
-          localState.disableRoleBaseTransfer = await disableManufacturerTransfer()
+          localState.disableRoleBaseTransfer = await disableDealerManufacturerTransfer()
           localState.disableRoleBaseLocationChange = await disableDealerManufacturerLocationChange()
           break;
         case isRoleQualifiedSupplierHomeDealer.value:
-          localState.enableRoleBasedTransfer = false
+          localState.disableRoleBaseTransfer = await disableDealerManufacturerTransfer(true)
           localState.disableRoleBaseLocationChange = await disableDealerManufacturerLocationChange(true)
           break;
       }

--- a/ppr-ui/tests/unit/MhrInformationQsTransfers.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformationQsTransfers.spec.ts
@@ -76,14 +76,10 @@ for (const subProduct of subProducts) {
     })
 
     it('renders change owners button conditionally', async () => {
-      // enable transfers based on role
-      const isNotDealer = subProduct !== MhrSubTypes.DEALERS
-      wrapper.vm.enableRoleBasedTransfer = isNotDealer
-      await nextTick()
 
       expect(wrapper.find('#home-owners-header').exists()).toBe(true)
-      expect(wrapper.vm.enableHomeOwnerChanges).toBe(isNotDealer)
-      expect(wrapper.find('#home-owners-change-btn').exists()).toBe(isNotDealer)
+      expect(wrapper.vm.enableHomeOwnerChanges).toBe(true)
+      expect(wrapper.find('#home-owners-change-btn').exists()).toBe(true)
     })
 
     it('renders Lien Alert', async () => {
@@ -113,28 +109,30 @@ for (const subProduct of subProducts) {
 
     it('verify role based transfer messaging and button states', async () => {
       const isManufacturer = subProduct === MhrSubTypes.MANUFACTURER
+      const isDealer = subProduct === MhrSubTypes.DEALERS
       // enable transfers based on role
-      wrapper.vm.enableRoleBasedTransfer = subProduct !== MhrSubTypes.DEALERS
-      wrapper.vm.disableRoleBaseTransfer = isManufacturer
+      wrapper.vm.disableRoleBaseTransfer = isManufacturer || isDealer
       await nextTick()
 
       // Verify showTransfer type
       expect(wrapper.vm.showTransferType).toBe(false)
 
       // Verify Mismatch text
-      expect(wrapper.find('.manufacturer-mismatch-text').exists()).toBe(isManufacturer)
+      expect(wrapper.find('.dealer-manufacturer-mismatch-text').exists()).toBe(isManufacturer || isDealer)
 
       // Role based tests
       switch (subProduct) {
         case MhrSubTypes.DEALERS:
-          expect(wrapper.find('#home-owners-change-btn').exists()).toBe(false)
+          expect(wrapper.find('#home-owners-change-btn').attributes().disabled).toBeDefined()
+          // Verify Mismatch text content
+          expect(wrapper.find('.dealer-manufacturer-mismatch-text').text()).toContain('You cannot register an ownership ' +
+            'transfer or change because the home does not have a sole owner whose name matches')
           break;
         case MhrSubTypes.MANUFACTURER:
           expect(wrapper.find('#home-owners-change-btn').attributes().disabled).toBeDefined()
           // Verify Mismatch text content
-          expect(wrapper.find('.manufacturer-mismatch-text').text()).toContain('You cannot register an ownership ' +
-            'transfer or change because the home does not have a sole owner whose name matches your manufacturer’s' +
-            ' name')
+          expect(wrapper.find('.dealer-manufacturer-mismatch-text').text()).toContain('You cannot register an ownership ' +
+            'transfer or change because the home does not have a sole owner whose name matches')
           break;
         case MhrSubTypes.LAWYERS_NOTARIES:
           expect(wrapper.find('#home-owners-change-btn').attributes().disabled).toBeUndefined()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22150

*Description of changes:*
- Removes restrictions for Home Dealers launching transfers
- Refactors to sole owner and name matching to include home dealer records
- Unit test refactors
- removed some obsolete properties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
