### PR TITLE
Check no person giving notice by default for decal replacement

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.41",
+  "version": "3.2.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.41",
+      "version": "3.2.42",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.41",
+  "version": "3.2.42",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteAdd.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, toRefs, watch } from 'vue'
+import { computed, defineComponent, reactive, toRefs, watch, onMounted } from 'vue'
 import { UnitNotesInfo } from '@/resources/unitNotes'
 import { UnitNoteDocTypes } from '@/enums'
 import { useStore } from '@/store/store'
@@ -136,7 +136,7 @@ export default defineComponent({
           : personGivingNoticeContent
       ),
       isNoticeOfTaxSale: computed((): boolean => props.docType === UnitNoteDocTypes.NOTICE_OF_TAX_SALE),
-      hasNoPersonGivingNotice: (getMhrUnitNote.value as UnitNoteIF).hasNoPersonGivingNotice || false,
+      hasNoPersonGivingNotice: props.docType === UnitNoteDocTypes.DECAL_REPLACEMENT || (getMhrUnitNote.value as UnitNoteIF).hasNoPersonGivingNotice || false,
 
       // Remarks
       unitNoteRemarks: (getMhrUnitNote.value as UnitNoteIF).remarks || '',
@@ -172,6 +172,13 @@ export default defineComponent({
 
     watch(() => [localState.isUnitNoteValid, props.validate], () => {
       emit('isValid', localState.isUnitNoteValid)
+    })
+
+    onMounted(() => {
+      if(props.docType === UnitNoteDocTypes.DECAL_REPLACEMENT) {
+        setValidation(MhrSectVal.UNIT_NOTE_VALID, MhrCompVal.PERSON_GIVING_NOTICE_VALID, localState.hasNoPersonGivingNotice)
+        handleStoreUpdate('hasNoPersonGivingNotice', localState.hasNoPersonGivingNotice)
+      }
     })
 
     return {

--- a/ppr-ui/tests/unit/MhrUnitNote.spec.ts
+++ b/ppr-ui/tests/unit/MhrUnitNote.spec.ts
@@ -199,7 +199,7 @@ describe('MHR Unit Note Filing', async () => {
   })
 
   it('should not show field errors when no person giving notice checkbox is checked', async () => {
-    wrapper = await createUnitNoteComponent(UnitNoteDocTypes.DECAL_REPLACEMENT)
+    wrapper = await createUnitNoteComponent(UnitNoteDocTypes.PUBLIC_NOTE)
 
     let UnitNoteAddComponent = wrapper.findComponent(UnitNoteAdd)
     expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(0)
@@ -210,9 +210,9 @@ describe('MHR Unit Note Filing', async () => {
 
     expect(wrapper.findComponent(UnitNoteReview).exists()).toBeFalsy()
 
-    // Asserts error shown before checking the checkbox
-    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(2)
-    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(2)
+    // Asserts error shown before checking the checkbox(document ID, remarks, contactInfo)
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(3)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(3)
 
     const PersonGivingNoticeComponent = UnitNoteAddComponent.findComponent(ContactInformation)
 
@@ -228,9 +228,9 @@ describe('MHR Unit Note Filing', async () => {
     // Assert contact form is disabled
     expect(PersonGivingNoticeComponent.find('#contact-info').exists()).toBeFalsy()
 
-    // Asserts error not shown after checking the checkbox (1 error remains from doucment ID)
-    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(1)
-    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(1)
+    // Asserts error not shown after checking the checkbox (2 error remains from doucment ID and remarks)
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(2)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(2)
     expect(PersonGivingNoticeComponent.findAll('.error-text').length).toBe(0)
 
     // uncheck the checkbox
@@ -239,8 +239,8 @@ describe('MHR Unit Note Filing', async () => {
     expect(store.getMhrUnitNote.hasNoPersonGivingNotice).toBe(false)
 
     // Asserts error shown after the checkbox is unchecked and form is not disabled
-    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(2)
-    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(2)
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(3)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(3)
     expect(PersonGivingNoticeComponent.findAll('.error-text').length).toBeGreaterThan(0)
     expect(PersonGivingNoticeComponent.find('#contact-info').classes('v-card--disabled')).toBe(false)
 
@@ -270,6 +270,34 @@ describe('MHR Unit Note Filing', async () => {
       .checked).toBe(true)
   })
 
+  it('Person Giving Notice should be checked if doctype is decal replacement', async () => {
+    wrapper = await createUnitNoteComponent(UnitNoteDocTypes.DECAL_REPLACEMENT)
+
+    let UnitNoteAddComponent = wrapper.findComponent(UnitNoteAdd)
+    
+    expect((UnitNoteAddComponent.find('#no-person-giving-notice-checkbox').element as HTMLInputElement)
+      .checked).toBe(true)
+    await wrapper.find('#btn-stacked-submit').trigger('click')
+    await nextTick()
+
+    expect(wrapper.findComponent(UnitNoteReview).exists()).toBeFalsy()
+
+    // Asserts error shown before checking the checkbox(document ID)
+    expect(UnitNoteAddComponent.findAll('.border-error-left').length).toBe(1)
+    expect(UnitNoteAddComponent.findAll('.error-text').length).toBe(1)
+
+
+    await wrapper.findComponent(UnitNoteAdd).vm.$emit('isValid', true)
+    await wrapper.find('#btn-stacked-submit').trigger('click')
+    await nextTick()
+
+    // should be on the Review & Confirm screen
+    expect(wrapper.findComponent(UnitNoteReview).exists()).toBeTruthy()
+
+    // 'There no Person Giving Notice...' should be shown next to Person Giving Notice
+    expect(wrapper.find('.no-person-giving-notice').text())
+      .toBe(hasNoPersonGivingNoticeText)
+  })
   // eslint-disable-next-line max-len
   it('should not show EffectiveDate component for Decal Replacement, Public Note, and Confidential Note', async () => {
     wrapper = await createUnitNoteComponent(UnitNoteDocTypes.DECAL_REPLACEMENT)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18101

*Description of changes:*
For Decal Replacement, check `No Person Giving Notice` checkbox by default.
![image](https://github.com/user-attachments/assets/227caaa6-6d53-4fad-9efe-fda7c099627f)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
