### PR TITLE
don't scroll to top if it is staff

### DIFF
--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1185,7 +1185,7 @@ export default defineComponent({
           ? await getMHRegistrationSummary(getMhrInformation.value.mhrNumber, false)
           : null
 
-          if (!!regSum && !!regSum.lienRegistrationType && !isRoleStaffReg.value) {
+        if (!!regSum && !!regSum.lienRegistrationType && !isRoleStaffReg.value) {
           await setLienType(regSum.lienRegistrationType)
           await scrollToFirstError(true)
           localState.hasLienInfoDisplayed = true

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1185,7 +1185,7 @@ export default defineComponent({
           ? await getMHRegistrationSummary(getMhrInformation.value.mhrNumber, false)
           : null
 
-        if (!!regSum && !!regSum.lienRegistrationType) {
+          if (!!regSum && !!regSum.lienRegistrationType && !isRoleStaffReg.value) {
           await setLienType(regSum.lienRegistrationType)
           await scrollToFirstError(true)
           localState.hasLienInfoDisplayed = true


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22366

*Description of changes:*
Stop scrolling to top to review if the user is staff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
