### PR TITLE
Cancel permit legacy registraitons bug fix

### DIFF
--- a/jobs/permanent/ppr-registrations-historical/src/ppr_registrations_historical/job.py
+++ b/jobs/permanent/ppr-registrations-historical/src/ppr_registrations_historical/job.py
@@ -11,7 +11,7 @@ from .services.logging import logging
 EVENT_JOB_ID = 777777001
 UPDATE_ACCOUNT_DISCHARGED = """
 UPDATE registrations
-   SET account_id = account_id || '_HIS'
+   SET account_id = LEFT(account_id, 15) || '_HIS'
  WHERE financing_id IN
  (SELECT DISTINCT fs.id
     FROM registrations r, financing_statements fs
@@ -47,7 +47,7 @@ UPDATE financing_statements
 """
 UPDATE_ACCOUNT_EXPIRED = """
 UPDATE registrations
-   SET account_id = account_id || '_HIS'
+   SET account_id = LEFT(account_id, 15) || '_HIS'
  WHERE financing_id IN
  (SELECT DISTINCT fs.id
     FROM registrations r, financing_statements fs

--- a/mhr_api/src/mhr_api/models/db2/manuhome.py
+++ b/mhr_api/src/mhr_api/models/db2/manuhome.py
@@ -881,7 +881,7 @@ class Db2Manuhome(db.Model):
         manuhome.reg_documents.append(doc)
         if new_doc.document_type in (MhrDocumentTypes.NCAN, MhrDocumentTypes.NRED, MhrDocumentTypes.EXRE):
             manuhome.cancel_note(manuhome, reg_json, new_doc.document_type, doc.id)
-        elif doc_type == MhrDocumentTypes.CANCEL_PERMIT:
+        elif new_doc.document_type == MhrDocumentTypes.CANCEL_PERMIT:
             legacy_reg_utils.cancel_permit_note(manuhome, doc.id)
         elif doc_type in (Db2Document.DocumentTypes.AMENDMENT, Db2Document.DocumentTypes.CORRECTION) and \
                 reg_json.get('status'):

--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -358,8 +358,8 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                         note.status_type = MhrNoteStatusTypes.CANCELLED
                         note.change_registration_id = new_reg_id
         if json_data and json_data.get('documentType') == MhrDocumentTypes.CANCEL_PERMIT:
-            if self.status_type == MhrRegistrationStatusTypes.EXEMPT and \
-                    json_data['location']['address']['region'] == model_utils.PROVINCE_BC:
+            if self.status_type and self.status_type == MhrRegistrationStatusTypes.EXEMPT and \
+                    json_data.get('location') and json_data['location']['address']['region'] == model_utils.PROVINCE_BC:
                 self.status_type = MhrRegistrationStatusTypes.ACTIVE
                 current_app.logger.info('Cancel Transport Permit new location in BC, updating EXEMPT status to ACTIVE.')
         elif json_data and json_data.get('documentType') == MhrDocumentTypes.AMEND_PERMIT and \

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -136,13 +136,14 @@ def get_permit_previous_location_json(registration) -> dict:
     if permit_reg_id:
         if registration.locations and registration.locations[0].registration_id < permit_reg_id and \
                 registration.locations[0].change_registration_id == permit_reg_id:
-            return registration.locations[0].json
-        for reg in registration.change_registrations:
-            if reg.locations and reg.locations[0].registration_id < permit_reg_id and \
-                    reg.locations[0].change_registration_id == permit_reg_id:
-                loc_json = reg.locations[0].json
-                break
-    elif model_utils.is_legacy():
+            loc_json = registration.locations[0].json
+        else:
+            for reg in registration.change_registrations:
+                if reg.locations and reg.locations[0].registration_id < permit_reg_id and \
+                        reg.locations[0].change_registration_id == permit_reg_id:
+                    loc_json = reg.locations[0].json
+                    break
+    if (not loc_json or not loc_json.get('locationType')) and model_utils.is_legacy():
         return legacy_reg_utils.get_permit_previous_location_json(registration)
     return loc_json
 
@@ -334,7 +335,7 @@ def set_group_json(registration, reg_json, current: bool, cleanup: bool = False)
     return reg_json
 
 
-def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
+def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:  # pylint: disable=too-many-branches; +1
     """Build the transfer registration owner groups JSON."""
     if not registration.is_transfer() and registration.registration_type != MhrRegistrationTypes.REG_STAFF_ADMIN:
         return reg_json
@@ -342,24 +343,27 @@ def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
             doc_type not in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
                              MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE):
         return reg_json
-    add_groups = []
-    delete_groups = []
-    if reg_json and registration.owner_groups:
-        for group in registration.owner_groups:
-            if group.registration_id == registration.id:
-                add_groups.append(group.json)
-            elif group.change_registration_id == registration.id:
-                delete_groups.append(group.json)
-    reg_json['addOwnerGroups'] = add_groups
-    if registration.change_registrations:
-        for reg in registration.change_registrations:
-            for existing in reg.owner_groups:
-                if existing.registration_id != registration.id and existing.change_registration_id == registration.id:
-                    delete_groups.append(existing.json)
-    reg_json['deleteOwnerGroups'] = delete_groups
-    if not delete_groups and not add_groups and model_utils.is_legacy():  # Legacy MH home
-        current_app.logger.debug(f'Transfer legacy MHR {registration.mhr_number} using legacy owner groups.')
+
+    if model_utils.is_legacy():  # Use legacy as source, modern could be out of sequence.
+        current_app.logger.debug(f'Transfer MHR {registration.mhr_number} using legacy owner groups.')
         reg_json = legacy_reg_utils.set_transfer_group_json(registration, reg_json)
+    else:
+        add_groups = []
+        delete_groups = []
+        if reg_json and registration.owner_groups:
+            for group in registration.owner_groups:
+                if group.registration_id == registration.id:
+                    add_groups.append(group.json)
+                elif group.change_registration_id == registration.id:
+                    delete_groups.append(group.json)
+        reg_json['addOwnerGroups'] = add_groups
+        if registration.change_registrations:
+            for reg in registration.change_registrations:
+                for existing in reg.owner_groups:
+                    if existing.registration_id != registration.id and \
+                            existing.change_registration_id == registration.id:
+                        delete_groups.append(existing.json)
+        reg_json['deleteOwnerGroups'] = delete_groups
     if reg_json.get('addOwnerGroups'):
         reg_json['addOwnerGroups'] = sort_owner_groups(reg_json.get('addOwnerGroups'), False)
     return reg_json

--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -335,7 +335,7 @@ def set_group_json(registration, reg_json, current: bool, cleanup: bool = False)
     return reg_json
 
 
-def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:  # pylint: disable=too-many-branches; +1
+def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:
     """Build the transfer registration owner groups JSON."""
     if not registration.is_transfer() and registration.registration_type != MhrRegistrationTypes.REG_STAFF_ADMIN:
         return reg_json
@@ -343,27 +343,24 @@ def set_transfer_group_json(registration, reg_json, doc_type: str) -> dict:  # p
             doc_type not in (MhrDocumentTypes.REGC_CLIENT, MhrDocumentTypes.REGC_STAFF,
                              MhrDocumentTypes.PUBA, MhrDocumentTypes.EXRE):
         return reg_json
-
-    if model_utils.is_legacy():  # Use legacy as source, modern could be out of sequence.
-        current_app.logger.debug(f'Transfer MHR {registration.mhr_number} using legacy owner groups.')
+    add_groups = []
+    delete_groups = []
+    if reg_json and registration.owner_groups:
+        for group in registration.owner_groups:
+            if group.registration_id == registration.id:
+                add_groups.append(group.json)
+            elif group.change_registration_id == registration.id:
+                delete_groups.append(group.json)
+    reg_json['addOwnerGroups'] = add_groups
+    if registration.change_registrations:
+        for reg in registration.change_registrations:
+            for existing in reg.owner_groups:
+                if existing.registration_id != registration.id and existing.change_registration_id == registration.id:
+                    delete_groups.append(existing.json)
+    reg_json['deleteOwnerGroups'] = delete_groups
+    if not delete_groups and not add_groups and model_utils.is_legacy():  # Legacy MH home
+        current_app.logger.debug(f'Transfer legacy MHR {registration.mhr_number} using legacy owner groups.')
         reg_json = legacy_reg_utils.set_transfer_group_json(registration, reg_json)
-    else:
-        add_groups = []
-        delete_groups = []
-        if reg_json and registration.owner_groups:
-            for group in registration.owner_groups:
-                if group.registration_id == registration.id:
-                    add_groups.append(group.json)
-                elif group.change_registration_id == registration.id:
-                    delete_groups.append(group.json)
-        reg_json['addOwnerGroups'] = add_groups
-        if registration.change_registrations:
-            for reg in registration.change_registrations:
-                for existing in reg.owner_groups:
-                    if existing.registration_id != registration.id and \
-                            existing.change_registration_id == registration.id:
-                        delete_groups.append(existing.json)
-        reg_json['deleteOwnerGroups'] = delete_groups
     if reg_json.get('addOwnerGroups'):
         reg_json['addOwnerGroups'] = sort_owner_groups(reg_json.get('addOwnerGroups'), False)
     return reg_json

--- a/mhr_api/src/mhr_api/resources/registration_utils.py
+++ b/mhr_api/src/mhr_api/resources/registration_utils.py
@@ -375,8 +375,7 @@ def pay_and_save_admin(req: request,  # pylint: disable=too-many-arguments
                                                   MhrDocumentTypes.STAT,
                                                   MhrDocumentTypes.PUBA):
             save_admin(current_reg, request_json, registration.id)
-        elif request_json.get('documentType') == MhrDocumentTypes.CANCEL_PERMIT and \
-                current_reg.id and current_reg.id > 0:
+        elif request_json.get('documentType') == MhrDocumentTypes.CANCEL_PERMIT and current_reg:
             current_reg.save_permit(request_json, registration.id)
         return registration
     except Exception as db_exception:   # noqa: B902; handle all db related errors.

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.18'  # pylint: disable=invalid-name
+__version__ = '1.8.19'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22642

*Description of changes:*
- Fix cancel permit on a legacy home transport permit not updating the status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
