### PR TITLE
22482 cancel note output error

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.42",
+  "version": "3.2.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.42",
+      "version": "3.2.43",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.42",
+  "version": "3.2.43",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
+++ b/ppr-ui/src/components/unitNotes/UnitNoteReview.vue
@@ -200,7 +200,7 @@ export default defineComponent({
 
     const localState = reactive({
       validateSubmittingParty: false,
-      initialAttention: (isCancelUnitNote.value || isRedemptionUnitNote.value)
+      initialAttention: isRedemptionUnitNote.value
         ? ''
         : getMhrUnitNoteRegistration.value?.attentionReference,
       unitNoteType: UnitNotesInfo[getMhrUnitNote.value.documentType],

--- a/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
@@ -119,7 +119,8 @@ export default defineComponent({
 
     const {
       setRegTableNewItem,
-      setEmptyUnitNoteRegistration
+      setEmptyUnitNoteRegistration,
+      setMhrAttentionReference
     } = useStore()
 
     const {
@@ -185,7 +186,9 @@ export default defineComponent({
         initialUnitNote.note.documentType = getMhrUnitNoteType.value
         await setEmptyUnitNoteRegistration(initialUnitNote)
       }
-
+      if (isCancelUnitNote.value) {
+        setMhrAttentionReference('')
+      }
       // reset validation trigger
       localState.validate = false
     })

--- a/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrUnitNote.vue
@@ -158,6 +158,9 @@ export default defineComponent({
       isUnitNoteAddValid: computed((): boolean => {
         const { documentId, remarks, personGivingNotice } =
           getMhrUnitNoteValidation.value
+        if(isCancelUnitNote.value) {
+          return documentId && remarks
+        }
         return documentId && remarks && personGivingNotice
       }),
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22482
*Description of changes:*
* Cancel Unit Notes - Attention value is displayed in the outputs without user input
* Cancel Unit Notes - Fixed error on validation when there is no person giving notice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
