### PR TITLE
fixed error on transfer pop up modal

### DIFF
--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -942,9 +942,11 @@ export default defineComponent({
       hasActiveExemption: computed((): boolean => !!getActiveExemption() ||
         getMhrInformation.value.statusType === MhApiStatusTypes.EXEMPT),
       transferRequiredDialogOptions: computed((): DialogOptionsIF => {
-        transferRequiredDialog.text =
-          transferRequiredDialog.text.replace('mhr_number', getMhrInformation.value.mhrNumber)
-        return transferRequiredDialog
+        const textArray = transferRequiredDialog.text.split(' mhr_number')
+        return {
+          ...transferRequiredDialog,
+          text: `${textArray[0]} ${getMhrInformation.value.mhrNumber} ${textArray[1]}`
+        }
       }),
       hasTransferChanges: computed((): boolean => {
         return (


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16198

*Description of changes:*
I changed the method for generating `transferRequiredDialogOptions`. Initially, it works correctly with `text.replace()`, but subsequent changes to the value aren't reflected, even though the `computed` function is called.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
