### PR TITLE
Preserve Table Filters for both PPR/MHR

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.47",
+  "version": "3.2.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.47",
+      "version": "3.2.48",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.47",
+  "version": "3.2.48",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -866,7 +866,7 @@ export default defineComponent({
     const removeMhrDraft = async (mhrNumber: string): Promise<void> => {
       localState.myRegDataLoading = true
       await deleteMhrDraft(mhrNumber)
-      await fetchMhRegistrations(getRegTableMhSortOptions.value) // Refresh the table with update Registration History
+      await fetchMhRegistrations(getRegTableMhSortOptions.value)
       localState.myRegDataLoading = false
     }
 
@@ -1174,7 +1174,7 @@ export default defineComponent({
             }
           }
         } else {
-          fetchMhRegistrations(getRegTableMhSortOptions.value)
+          await fetchMhRegistrations(getRegTableMhSortOptions.value)
         }
 
         localState.myRegDataAdding = false

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -201,7 +201,7 @@
               :setNewRegItem="getRegTableNewItem"
               :setRegistrationHistory="myRegistrations"
               :setSearch="myRegFilter"
-              :setSort="getRegTableSortOptions"
+              :setSort="isPpr ? getRegTableSortOptions : getRegTableMhSortOptions"
               @action="myRegActionHandler($event)"
               @error="emitError($event)"
               @sort="myRegSort($event)"
@@ -357,7 +357,7 @@ export default defineComponent({
       getRegTableBaseRegs, getRegTableDraftsBaseReg, isMhrRegistration, isMhrManufacturerRegistration,
       getRegTableTotalRowCount, getStateModel, getRegTableDraftsChildReg, hasMorePages, getRegTableNewItem,
       getRegTableSortOptions, getRegTableSortPage, getUserSettings, getMhRegTableBaseRegs, isRoleStaffReg,
-      isRoleQualifiedSupplier
+      isRoleQualifiedSupplier, getRegTableMhSortOptions
     } = storeToRefs(useStore())
 
     const {
@@ -365,11 +365,8 @@ export default defineComponent({
       initNewManufacturerMhr,
       fetchMhRegistrations
     } = useNewMhrRegistration(true)
-
     const { initDraftMhrCorrection } = useMhrCorrections()
-
     const { goToExemptions } = useExemptions()
-
     const { initMhrReRegistration, initDraftMhrReRegistration } = useMhrReRegistration()
 
     const localState = reactive({
@@ -447,8 +444,8 @@ export default defineComponent({
       } else if (props.isPpr) {
         // load in registrations from scratch
         resetRegTableData(null)
-        const myRegDrafts = await draftHistory(cloneDeep(getRegTableSortOptions.value))
-        const myRegHistory = await registrationHistory()
+        const myRegDrafts = await draftHistory(getRegTableSortOptions.value)
+        const myRegHistory = await registrationHistory(getRegTableSortOptions.value)
 
         if (myRegDrafts?.error || myRegHistory?.error) {
           // prioritize reg error
@@ -469,7 +466,7 @@ export default defineComponent({
           setRegTableTotalRowCount(getRegTableTotalRowCount.value + historyDraftsCollapsed.drafts.length)
         }
       } else if (props.isMhr && !props.isTabView) { // If Tab view, Mhr Data will be loaded in dashboardTabs component
-        await fetchMhRegistrations()
+        await fetchMhRegistrations(getRegTableMhSortOptions.value)
       }
 
 
@@ -703,7 +700,7 @@ export default defineComponent({
           prevDraft: ''
         }
         setRegTableNewItem(newRegItem)
-        await fetchMhRegistrations()
+        await fetchMhRegistrations(getRegTableMhSortOptions.value)
       }
       localState.loading = false
     }
@@ -869,7 +866,7 @@ export default defineComponent({
     const removeMhrDraft = async (mhrNumber: string): Promise<void> => {
       localState.myRegDataLoading = true
       await deleteMhrDraft(mhrNumber)
-      await fetchMhRegistrations() // Refresh the table with update Registration History
+      await fetchMhRegistrations(getRegTableMhSortOptions.value) // Refresh the table with update Registration History
       localState.myRegDataLoading = false
     }
 
@@ -916,7 +913,7 @@ export default defineComponent({
       localState.myRegDataLoading = true
       const page = getRegTableSortPage.value + 1
       setRegTableSortPage(page)
-      const nextRegs = await registrationHistory(cloneDeep(getRegTableSortOptions.value), page)
+      const nextRegs = await registrationHistory(getRegTableSortOptions.value, page)
       if (nextRegs.error) {
         emitError(nextRegs.error)
       } else {
@@ -1029,7 +1026,7 @@ export default defineComponent({
 
     const myRegSort = async (args: { sortOptions: RegistrationSortIF, sorting: boolean }): Promise<void> => {
       localState.myRegDataLoading = true
-      setRegTableSortOptions(args.sortOptions)
+      setRegTableSortOptions(args.sortOptions, props.isMhr)
 
       const sorting = args.sorting
       let sortedDrafts = { drafts: [] as DraftResultIF[], error: null }
@@ -1062,7 +1059,7 @@ export default defineComponent({
           setRegTableBaseRegs(updatedRegs.registrations)
         }
       } else if (props.isMhr) {
-        await fetchMhRegistrations(cloneDeep(args.sortOptions))
+        await fetchMhRegistrations(getRegTableMhSortOptions.value)
       }
       localState.myRegDataLoading = false
     }
@@ -1086,7 +1083,7 @@ export default defineComponent({
               val.addedRegSummary = regSummary
             } else {
               // its a draft - get draft summary
-              const drafts = await draftHistory(null)
+              const drafts = await draftHistory(getRegTableSortOptions.value)
               if (drafts.error) {
                 emitError(drafts.error) // dialog and will reload the dash after
                 localState.myRegDataAdding = false
@@ -1177,7 +1174,7 @@ export default defineComponent({
             }
           }
         } else {
-          await fetchMhRegistrations()
+          fetchMhRegistrations(getRegTableMhSortOptions.value)
         }
 
         localState.myRegDataAdding = false
@@ -1282,6 +1279,7 @@ export default defineComponent({
       getRegTableNewItem,
       getRegTableTotalRowCount,
       getRegTableSortOptions,
+      getRegTableMhSortOptions,
       getMhRegTableBaseRegs,
       hasMorePages,
       myRegSort,

--- a/ppr-ui/src/components/dashboard/DashboardTabs.vue
+++ b/ppr-ui/src/components/dashboard/DashboardTabs.vue
@@ -104,6 +104,7 @@ export default defineComponent({
     } = useStore()
     const {
       // Getters
+      getRegTableMhSortOptions,
       getMhRegTableBaseRegs,
       getRegTableBaseRegs,
       getRegTableTotalRowCount,
@@ -133,7 +134,7 @@ export default defineComponent({
     }
 
     onMounted(async () => {
-      await fetchMhRegistrations()
+      await fetchMhRegistrations(getRegTableMhSortOptions.value)
     })
 
     return {

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -369,7 +369,6 @@
 import {
   computed,
   defineComponent,
-  onBeforeMount,
   onUpdated,
   reactive,
   ref,
@@ -811,11 +810,6 @@ export default defineComponent({
       },
       { deep: true }
     )
-
-    // Ensures filtering is cleared when returing to dashboard from registrations
-    onBeforeMount(() => {
-      clearFilters()
-    })
 
     onUpdated(() => {
       // needed to set overrideWidth to true

--- a/ppr-ui/src/interfaces/store-interfaces/state-interfaces/reg-table-data-interface.ts
+++ b/ppr-ui/src/interfaces/store-interfaces/state-interfaces/reg-table-data-interface.ts
@@ -21,6 +21,7 @@ export interface RegTableDataI {
   newItem: RegTableNewItemI
   sortHasMorePages: boolean
   sortOptions: RegistrationSortIF
+  mhSortOptions: RegistrationSortIF
   sortPage: number
   totalRowCount: number
 }

--- a/ppr-ui/src/store/state/state-model.ts
+++ b/ppr-ui/src/store/state/state-model.ts
@@ -116,6 +116,19 @@ export const stateModel: StateModelIF = {
       startDate: null,
       status: ''
     },
+    mhSortOptions: {
+      endDate: null,
+      folNum: '',
+      orderBy: 'createDateTime',
+      orderVal: 'desc',
+      regBy: '',
+      regNum: '',
+      regParty: '',
+      regType: '',
+      secParty: '',
+      startDate: null,
+      status: ''
+    },
     sortPage: 1,
     totalRowCount: 0
   },

--- a/ppr-ui/src/store/store.ts
+++ b/ppr-ui/src/store/store.ts
@@ -582,6 +582,9 @@ export const useStore = defineStore('assetsStore', () => {
   const getRegTableSortOptions = computed<RegistrationSortIF>(() => {
     return state.value.registrationTable.sortOptions
   })
+  const getRegTableMhSortOptions = computed<RegistrationSortIF>(() => {
+    return state.value.registrationTable.mhSortOptions
+  })
   const getRegTableSortPage = computed<number>(() => {
     return state.value.registrationTable.sortPage
   })
@@ -957,19 +960,6 @@ export const useStore = defineStore('assetsStore', () => {
       prevDraft: ''
     }
     state.value.registrationTable.sortHasMorePages = true
-    state.value.registrationTable.sortOptions = {
-      endDate: null,
-      folNum: '',
-      orderBy: 'createDateTime',
-      orderVal: 'desc',
-      regBy: '',
-      regNum: '',
-      regParty: '',
-      regType: '',
-      secParty: '',
-      startDate: null,
-      status: ''
-    }
     state.value.registrationTable.sortPage = 1
     state.value.registrationTable.totalRowCount = 0
   }
@@ -1223,8 +1213,10 @@ export const useStore = defineStore('assetsStore', () => {
     state.value.registrationTable.sortHasMorePages = hasMorePages
   }
 
-  function setRegTableSortOptions (options: RegistrationSortIF) {
-    state.value.registrationTable.sortOptions = options
+  function setRegTableSortOptions (options: RegistrationSortIF, isMhr: boolean = false) {
+    isMhr
+    ? state.value.registrationTable.mhSortOptions = options
+    : state.value.registrationTable.sortOptions = options
   }
 
   function setRegTableSortPage (page: number) {
@@ -1644,6 +1636,7 @@ export const useStore = defineStore('assetsStore', () => {
     getRegTableDraftsChildReg,
     getRegTableNewItem,
     getRegTableSortOptions,
+    getRegTableMhSortOptions,
     getRegTableSortPage,
     getRegTableTotalRowCount,
     hasMorePages,

--- a/ppr-ui/src/utils/mhr-api-helper.ts
+++ b/ppr-ui/src/utils/mhr-api-helper.ts
@@ -325,6 +325,7 @@ export async function submitMhrRegistration (payloadData, staffPayment) {
  * Method to return Mhr registrations.
  *
  * @param withCollapse // Used to indicate whether api should return registrations collapsed
+ * @param sortOptions // Used to sort the registration results
  * @returns MhRegistrationSummaryIF
  */
 export async function mhrRegistrationHistory (withCollapse: boolean = false, sortOptions: RegistrationSortIF = null) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21326

*Description of changes:*
- Refactors to preserve Table Filters for both PPR and MHR Registration Table instances
- Preserves ALL filters throughout filings, route changes, registrations etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
