### PR TITLE
Registration Table: Preserve filters for staff only

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.48",
+  "version": "3.2.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.48",
+      "version": "3.2.49",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.48",
+  "version": "3.2.49",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -368,7 +368,7 @@
 <script lang="ts">
 import {
   computed,
-  defineComponent,
+  defineComponent, onMounted,
   onUpdated,
   reactive,
   ref,
@@ -501,7 +501,7 @@ export default defineComponent({
       clientReferenceId: 7
     }
     // getters
-    const { getAccountProductSubscriptions } = storeToRefs(useStore())
+    const { isRoleStaffReg, getAccountProductSubscriptions } = storeToRefs(useStore())
     // helpers
     const {
       // filters
@@ -818,6 +818,10 @@ export default defineComponent({
           localState.overrideWidth = true
         }
       }
+    })
+
+    onMounted(() => {
+      if (!isRoleStaffReg.value) clearFilters()
     })
 
     return {

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -440,7 +440,7 @@ import {
 } from '@/composables'
 
 import { MhrRegistrationHomeOwnerGroupIF } from '@/interfaces'
-import { ActionTypes, RouteNames, UITransferTypes } from '@/enums'
+import { ActionTypes, RouteNames } from '@/enums'
 
 import { transfersErrors } from '@/resources'
 import { formatCurrency } from '@/utils'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21326

*Description of changes:*
- Clear Registration Table Filters when User is not PPR Staff 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
