### PR TITLE
changed owner group type as NA

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.48",
+  "version": "3.2.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.48",
+      "version": "3.2.49",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.48",
+  "version": "3.2.49",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -479,11 +479,14 @@ export const useMhrInformation = () => {
             return owner.individualName ? { ...owner, individualName: normalizeObject(owner.individualName) } : owner
           }),
           // Determine group tenancy type
-          type: getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT
-            ? ApiHomeTenancyTypes.JOINT
-            : getMhrTransferHomeOwnerGroups.value.length > 1
-              ? ApiHomeTenancyTypes.NA
-              : ApiHomeTenancyTypes.SOLE
+          type: (ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1 ||
+                getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT)
+                ? getMhrTransferType.value?.transferType === ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL
+                  ? ApiHomeTenancyTypes.NA 
+                  : ApiHomeTenancyTypes.JOINT
+                : getMhrTransferHomeOwnerGroups.value.length > 1
+                  ? ApiHomeTenancyTypes.NA
+                  : ApiHomeTenancyTypes.SOLE
         })
       }
     })

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -479,8 +479,7 @@ export const useMhrInformation = () => {
             return owner.individualName ? { ...owner, individualName: normalizeObject(owner.individualName) } : owner
           }),
           // Determine group tenancy type
-          type: (ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1 ||
-            getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT)
+          type: getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT
             ? ApiHomeTenancyTypes.JOINT
             : getMhrTransferHomeOwnerGroups.value.length > 1
               ? ApiHomeTenancyTypes.NA

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -440,7 +440,7 @@ import {
 } from '@/composables'
 
 import { MhrRegistrationHomeOwnerGroupIF } from '@/interfaces'
-import { ActionTypes, RouteNames, UITransferTypes } from '@/enums'
+import { ActionTypes, RouteNames } from '@/enums'
 
 import { transfersErrors } from '@/resources'
 import { formatCurrency } from '@/utils'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22264

*Description of changes:*
Since we push deleted owner under `if (ownerGroup.owners.some(owner => owner.action === ActionTypes.REMOVED))` condition, we don't need `ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1` and the `type` is always `JOINT`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
