### PR TITLE
replaced condition to validate on click review button

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.49",
+  "version": "3.2.50",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.49",
+      "version": "3.2.50",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.49",
+  "version": "3.2.50",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
+++ b/ppr-ui/src/views/newMhrRegistration/HomeOwners.vue
@@ -440,7 +440,7 @@ import {
 } from '@/composables'
 
 import { MhrRegistrationHomeOwnerGroupIF } from '@/interfaces'
-import { ActionTypes, RouteNames } from '@/enums'
+import { ActionTypes, RouteNames, UITransferTypes } from '@/enums'
 
 import { transfersErrors } from '@/resources'
 import { formatCurrency } from '@/utils'
@@ -497,13 +497,11 @@ export default defineComponent({
       enableHomeOwnerChanges,
       enableAddHomeOwners,
       enableDeleteAllGroupsActions,
-      isTransferToSurvivingJointTenant,
       isTransferDueToDeath,
       isTransferToExecutorProbateWill,
       isTransferToExecutorUnder25Will,
       isTransferToAdminNoWill,
       TransToExec,
-      TransJointTenants
     } = useTransferOwners(!props.isMhrTransfer)
 
     const {
@@ -599,8 +597,8 @@ export default defineComponent({
       }),
       changesRequired: computed((): boolean => {
         // If the transfer type is "Transfer to Surviving Joint Tenant(s)", at least one owners needs to be removed
-        if(isTransferToSurvivingJointTenant.value){
-          return !TransJointTenants.isValidTransfer.value
+        if(getUiTransferType() === UITransferTypes.SURVIVING_JOINT_TENANT){
+          return props.validateTransfer && !localState.hasRemovedOwners
         }
         return props.validateTransfer && !hasUnsavedChanges.value
       }),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15773

*Description of changes:*
Replaced the conditional statement on `changesRequired` to run validation when the `Review` button is clicked. Previously, the error message was displayed as soon as `Transfer to Surviving Joint Tenants` was selected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
