### PR TITLE
TRANS_ADMIN update rules for removal of trustees/executors.

### DIFF
--- a/mhr_api/src/mhr_api/utils/registration_validator.py
+++ b/mhr_api/src/mhr_api/utils/registration_validator.py
@@ -492,9 +492,15 @@ def validate_transfer_cert_corp(reg_type: str, owner_json: dict) -> str:
 
 def is_delete_exec_admin(reg_type: str, owner_json: dict) -> bool:
     """Evaluate if a deleted owner is an executor or an administrator for one of the death transfers types."""
-    if reg_type == MhrRegistrationTypes.TRANS_WILL and owner_json.get('partyType', '') == MhrPartyTypes.EXECUTOR:
+    if reg_type == MhrRegistrationTypes.TRANS_WILL and owner_json.get('partyType', '') in (MhrPartyTypes.EXECUTOR,
+                                                                                           MhrPartyTypes.ADMINISTRATOR,
+                                                                                           MhrPartyTypes.TRUST,
+                                                                                           MhrPartyTypes.TRUSTEE):
         return True
-    if reg_type == MhrRegistrationTypes.TRANS_ADMIN and owner_json.get('partyType', '') == MhrPartyTypes.ADMINISTRATOR:
+    if reg_type == MhrRegistrationTypes.TRANS_ADMIN and owner_json.get('partyType', '') in (MhrPartyTypes.EXECUTOR,
+                                                                                            MhrPartyTypes.ADMINISTRATOR,
+                                                                                            MhrPartyTypes.TRUST,
+                                                                                            MhrPartyTypes.TRUSTEE):
         return True
     return False
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.21'  # pylint: disable=invalid-name
+__version__ = '1.8.22'  # pylint: disable=invalid-name

--- a/mhr_api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr_api/tests/unit/utils/test_transfer_validator.py
@@ -98,6 +98,7 @@ TEST_TRANSFER_DATA_EXTRA = [
     ('Valid staff missing', True, True, False, False, False, None),
     ('Valid non-staff exists', True, False, True, True, True, None),
     ('Invalid non-staff missing transfer date', False, False, False, True, True, validator.TRANSFER_DATE_REQUIRED),
+    ('Invalid non-staff future transfer date', False, False, True, True, True, validator.TRANSFER_DATE_FUTURE),
     ('Invalid non-staff missing declared value', False, False, True, False, True, validator.DECLARED_VALUE_REQUIRED),
     ('Invalid non-staff missing consideration', False, False, True, True, False, validator.CONSIDERATION_REQUIRED)
 ]
@@ -364,6 +365,10 @@ def test_validate_transfer_details(session, desc, valid, staff, trans_dt, dec_va
         del json_data['documentId']
     if not trans_dt:
         del json_data['transferDate']
+    elif desc == 'Valid non-staff exists':
+        json_data['transferDate'] = model_utils.format_ts(model_utils.now_ts())
+    elif desc == 'Invalid non-staff future transfer date':
+        json_data['transferDate'] = model_utils.format_ts(model_utils.now_ts_offset(1, True))
     if not dec_value:
         del json_data['declaredValue']
     if not consideration:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22264

*Description of changes:*
- TRANS_ADMIN allow removal of joint tenancy trustees/executors with no death certificate.


*Issue #:* /bcgov/entity#23056

*Description of changes:*
- Add QS transfers data validation rule: transfer date of execution cannot be in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
