### PR TITLE
Due to Death Transfers: Group Tenancy Typing

### DIFF
--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -481,8 +481,8 @@ export const useMhrInformation = () => {
           // Determine group tenancy type
           type: (ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1 ||
                 getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT)
-                ? getMhrTransferType.value?.transferType === ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL
-                  ? ApiHomeTenancyTypes.NA 
+                ? isTransferDueToDeath.value
+                  ? ApiHomeTenancyTypes.NA
                   : ApiHomeTenancyTypes.JOINT
                 : getMhrTransferHomeOwnerGroups.value.length > 1
                   ? ApiHomeTenancyTypes.NA

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -87,6 +87,7 @@ export const useMhrInformation = () => {
     setShowGroups
   } = useHomeOwners(true)
   const {
+    isTransferToExecOrAdmin,
     isTransferDueToDeath,
     getCurrentOwnerGroupIdByOwnerId,
     isTransferNonGiftBillOfSale,
@@ -481,7 +482,7 @@ export const useMhrInformation = () => {
           // Determine group tenancy type
           type: (ownerGroup.owners.filter(owner => owner.action === ActionTypes.REMOVED).length > 1 ||
                 getMhrTransferType.value?.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT)
-                ? isTransferDueToDeath.value
+                ? isTransferToExecOrAdmin.value
                   ? ApiHomeTenancyTypes.NA
                   : ApiHomeTenancyTypes.JOINT
                 : getMhrTransferHomeOwnerGroups.value.length > 1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2264

*Description of changes:*
- Refactored latest fix to apply to all Transfer due to Death Scenarios except surviving joint tenancy
- @flutistar This was your fix, just applied to the other 2 Due to Death Transfers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
