### PR TITLE
Update owner name search results sort order.

### DIFF
--- a/mhr_api/src/mhr_api/models/search_utils.py
+++ b/mhr_api/src/mhr_api/models/search_utils.py
@@ -142,12 +142,14 @@ SELECT mhr_number, status_type, registration_ts, city, serial_number, year_made,
        business_name, owner_status_type
   FROM mhr_search_owner_bus_vw
  WHERE compressed_name LIKE mhr_name_compressed_key(:query_value) || '%'
-"""
+ ORDER BY business_name ASC, owner_status_type ASC, status_type ASC, mhr_number DESC
+ """
 SEARCH_OWNER_IND_QUERY = """
 SELECT mhr_number, status_type, registration_ts, city, serial_number, year_made, make, model, id,
        owner_status_type, last_name, first_name, middle_name
   FROM mhr_search_owner_ind_vw
  WHERE compressed_name LIKE mhr_name_compressed_key(:query_value) || '%'
+ ORDER BY last_name ASC, first_name ASC, middle_name ASC, owner_status_type ASC, status_type ASC, mhr_number DESC
 """
 
 

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.22'  # pylint: disable=invalid-name
+__version__ = '1.8.23'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23292

*Description of changes:*
- Update the post data migration query owner name search results sort order to match the pre data migration sort order.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
