### PR TITLE
Affe Restrictions and A11Y adjustment

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.57",
+  "version": "3.2.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.57",
+      "version": "3.2.58",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.57",
+  "version": "3.2.58",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/SearchHistory.vue
+++ b/ppr-ui/src/components/tables/SearchHistory.vue
@@ -150,7 +150,7 @@
                     variant="plain"
                     :ripple="false"
                     :loading="item.loadingPDF"
-                    aria-label="Download report, Download PDF"
+                    aria-label="Download PDF"
                     @click="downloadPDF(item)"
                   >
                     <img src="@/assets/svgs/pdf-icon-blue.svg">

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -330,8 +330,11 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     if (enableAllActions) return true
 
     switch (getMhrTransferType.value?.transferType) {
-      case ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL:
       case ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL:
+        // Disable Owner actions for Executors and Admins in Trans Affi - Staff Only Transfer
+        return ![HomeOwnerPartyTypes.EXECUTOR, HomeOwnerPartyTypes.ADMINISTRATOR].includes(owner.partyType) &&
+          !groupHasAllBusinesses(getCurrentGroupById(owner.groupId))
+      case ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL:
       case ApiTransferTypes.TO_ADMIN_NO_WILL:
         return !groupHasAllBusinesses(getCurrentGroupById(owner.groupId))
       case ApiTransferTypes.SALE_OR_GIFT:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23294

*Description of changes:*
- Restriction Owner Removal for Executors and Admins in Trans Affi.
- Minor A11Y Screen Reader adjustment for Search History table pdf button.

<img width="999" alt="Screenshot 2024-09-20 at 5 01 10 AM" src="https://github.com/user-attachments/assets/536325e5-fe86-4b36-bf7c-ca0f9d43c897">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
