### PR TITLE
Residential Exempt Conditions Refactor

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.59",
+  "version": "3.2.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.59",
+      "version": "3.2.60",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.59",
+  "version": "3.2.60",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -522,8 +522,7 @@
                 </v-list-item-subtitle>
               </v-list-item>
               <v-list-item
-                v-if="isExemptionEnabled && !hasChildResExemption(item) &&
-                  item.statusType !== MhApiStatusTypes.EXEMPT &&
+                v-if="isExemptionEnabled && item.statusType === MhApiStatusTypes.ACTIVE &&
                   ![HomeLocationTypes.HOME_PARK, HomeLocationTypes.LOT].includes(item.locationType)"
                 data-test-id="res-exemption-btn"
                 :disabled="item.frozenDocumentType === MhApiFrozenDocumentTypes.TRANS_AFFIDAVIT"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23470

*Description of changes:*
- Refactored conditions for Res Exemption to allow when the Base Mhr is ACTIVE (no longer looking at history for residential exemptions)


<img width="1340" alt="Screenshot 2024-09-23 at 10 12 35 AM" src="https://github.com/user-attachments/assets/572aeae7-dd68-48ac-8778-72c767297658">


<img width="1347" alt="Screenshot 2024-09-23 at 10 14 26 AM" src="https://github.com/user-attachments/assets/16e712b4-bd79-4681-9fd8-1deff178e848">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
