### PR TITLE
MHR API bug fixes remove registration, permit move back to BC.

### DIFF
--- a/mhr_api/src/mhr_api/models/mhr_registration.py
+++ b/mhr_api/src/mhr_api/models/mhr_registration.py
@@ -362,7 +362,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
                     json_data.get('location') and json_data['location']['address']['region'] == model_utils.PROVINCE_BC:
                 self.status_type = MhrRegistrationStatusTypes.ACTIVE
                 current_app.logger.info('Cancel Transport Permit new location in BC, updating EXEMPT status to ACTIVE.')
-        elif json_data and json_data.get('documentType') == MhrDocumentTypes.AMEND_PERMIT and \
+        elif json_data and json_data.get('amendment') and \
                 self.status_type == MhrRegistrationStatusTypes.EXEMPT and \
                 json_data['newLocation']['address']['region'] == model_utils.PROVINCE_BC:
             self.status_type = MhrRegistrationStatusTypes.ACTIVE

--- a/mhr_api/src/mhr_api/models/queries.py
+++ b/mhr_api/src/mhr_api/models/queries.py
@@ -136,9 +136,13 @@ QUERY_ACCOUNT_DEFAULT = QUERY_ACCOUNT_REG_BASE + """
                          SELECT DISTINCT mr.mhr_number
                            FROM mhr_registrations mr
                           WHERE account_id = :query_value1
-                            AND mr.registration_type IN ('MHREG', 'MHREG_CONVERSION')))
+                            AND mr.registration_type IN ('MHREG', 'MHREG_CONVERSION')
+                            AND NOT EXISTS (SELECT mer.id
+                                              FROM mhr_extra_registrations mer
+                                             WHERE mer.account_id = mr.account_id
+                                               AND mer.mhr_number = mr.mhr_number
+                                               AND mer.removed_ind = 'Y')))
 """
-
 REG_ORDER_BY_DATE = ' ORDER BY registration_ts DESC'
 REG_ORDER_BY_MHR_NUMBER = ' ORDER BY mhr_number'
 REG_ORDER_BY_REG_TYPE = ' ORDER BY document_type'

--- a/mhr_api/src/mhr_api/version.py
+++ b/mhr_api/src/mhr_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.23'  # pylint: disable=invalid-name
+__version__ = '1.8.24'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23496

*Description of changes:*
- Amend permit location returns to BC from out of province: transition home status to ACTIVE from EXEMPT.

*Issue #:* /bcgov/entity#23567

*Description of changes:*
- Update account registrations query to exclude MHR numbers created by the account and marked for removal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
