### PR TITLE
Transport Permits: Include FolioRef in QS payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "ppr",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ppr",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.60",
+  "version": "3.2.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.60",
+      "version": "3.2.61",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.60",
+  "version": "3.2.61",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
@@ -43,7 +43,8 @@ export const useTransportPermits = () => {
     getMhrAccountSubmittingParty,
     getMhrRegistrationLocation,
     getMhrTransportPermitPreviousLocation,
-    getStaffPayment
+    getStaffPayment,
+    getMhrTransferAttentionReference
   } = storeToRefs(useStore())
 
   const {
@@ -223,6 +224,9 @@ export const useTransportPermits = () => {
       ...getMhrTransportPermit.value,
       ...(isRoleStaffReg.value && !!getStaffPayment.value && {
         clientReferenceId: getStaffPayment.value.folioNumber
+      }),
+      ...(isRoleQualifiedSupplier.value && {
+        clientReferenceId: getMhrTransferAttentionReference.value
       }),
       submittingParty: {
         ...submittingParty,

--- a/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransportPermits.ts
@@ -226,7 +226,7 @@ export const useTransportPermits = () => {
         clientReferenceId: getStaffPayment.value.folioNumber
       }),
       ...(isRoleQualifiedSupplier.value && {
-        clientReferenceId: getMhrTransferAttentionReference.value
+        clientReferenceId: getMhrTransferAttentionReference.value || ''
       }),
       submittingParty: {
         ...submittingParty,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23106

*Description of changes:*
- adds absent clientReferenceId to QS Transport Permits payloads


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
