### PR TITLE
Include REG_103 when setting current reg changePermit

### DIFF
--- a/mhr_api/src/mhr_api/models/registration_json_utils.py
+++ b/mhr_api/src/mhr_api/models/registration_json_utils.py
@@ -87,6 +87,7 @@ def set_permit_json(registration, reg_json: dict) -> dict:  # pylint: disable=to
     expiry_ts = None
     permit_status = None
     permit_reg_id: int = 0
+    permit_doc_type: str = None
     for reg in registration.change_registrations:
         if reg.documents[0].document_type == MhrDocumentTypes.REG_103:
             permit_number = reg.documents[0].document_registration_number
@@ -98,6 +99,7 @@ def set_permit_json(registration, reg_json: dict) -> dict:  # pylint: disable=to
             if reg.notes:
                 permit_status = reg.notes[0].status_type
                 expiry_ts = reg.notes[0].expiry_date
+                permit_doc_type = reg.documents[0].document_type
                 # current_app.logger.debug(f'set permit reg id {reg.id} set_permit status {permit_status}')
             permit_reg_id = reg.id
     if permit_number:
@@ -118,6 +120,7 @@ def set_permit_json(registration, reg_json: dict) -> dict:  # pylint: disable=to
                     reg_json['permitLandStatusConfirmation'] = reg.draft.draft.get('landStatusConfirmation', False)
         if 'permitLandStatusConfirmation' not in reg_json:
             reg_json['permitLandStatusConfirmation'] = False
+        reg_json['permitExtended'] = permit_doc_type and permit_doc_type == MhrDocumentTypes.REG_103E
         if permit_status and permit_status == MhrNoteStatusTypes.ACTIVE:
             reg_json['previousLocation'] = get_permit_previous_location_json(registration)
     return reg_json

--- a/mhr_api/src/mhr_api/resources/v1/registrations.py
+++ b/mhr_api/src/mhr_api/resources/v1/registrations.py
@@ -556,7 +556,9 @@ def get_change_permit(registration: MhrRegistration, account_id: str) -> bool:
     can_edit: bool = False
     if registration.change_registrations:
         for reg in registration.change_registrations:
-            if reg.registration_type in (MhrRegistrationTypes.PERMIT, MhrRegistrationTypes.AMENDMENT):
+            if reg.registration_type in (MhrRegistrationTypes.PERMIT,
+                                         MhrRegistrationTypes.PERMIT_EXTENSION,
+                                         MhrRegistrationTypes.AMENDMENT):
                 if reg.notes and reg.notes[0].status_type == MhrNoteStatusTypes.ACTIVE and \
                         account_id == reg.account_id:
                     can_edit = True


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23541

*Description of changes:*
- Include REG_103E doc type when setting current registration changePermit property.
- Add new property permitExtended and set to true when a permit is extended with a REG_103E doc type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
