### PR TITLE
Tax Cert: CheckOptions and Help Content

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.64",
+  "version": "3.2.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.2.64",
+      "version": "3.2.65",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.2.64",
+  "version": "3.2.65",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
@@ -23,7 +23,7 @@
       <v-checkbox
         v-if="isRoleStaffReg || isRoleStaffSbc"
         v-model="state.certificateWaived"
-        class="ml-n3"
+        class="ml-n3 mb-n6"
         label="Certificate requirement waived"
       />
     </template>

--- a/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
@@ -23,7 +23,7 @@
       <v-checkbox
         v-if="isRoleStaffReg || isRoleStaffSbc"
         v-model="state.certificateWaived"
-        class="ml-n3 mb-n6"
+        class="ml-n3 mb-n8"
         label="Certificate requirement waived"
       />
     </template>
@@ -72,10 +72,11 @@ watch(() => props.validate, async () => {
 })
 
 watch(() => state.certificateWaived, async (val: boolean) => {
-  expiryDatePickerRef.value.clearDate()
-  await nextTick()
-
-  expiryDatePickerRef.value?.validate()
+  if (val){
+    expiryDatePickerRef.value.clearDate()
+    await nextTick()
+    expiryDatePickerRef.value?.validate()
+  }
   emit('isValid', val)
   emit('waiveCertificate', val)
 })

--- a/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
+++ b/ppr-ui/src/components/mhrTransfers/TaxCertificate.vue
@@ -61,7 +61,10 @@ const state = reactive({
 })
 
 onMounted(() => {
-  state.certificateWaived = getMhrTransportPermitHomeLocation.value?.waiveCertificate
+  // Set the initial value of the certificate waived checkbox if the user is a staff member
+  if (isRoleStaffReg.value || isRoleStaffSbc.value) {
+    state.certificateWaived = getMhrTransportPermitHomeLocation.value?.waiveCertificate
+  }
 })
 
 watch(() => props.validate, async () => {

--- a/ppr-ui/src/components/mhrTransportPermit/HelpContent/QsTaxCertificateHelp.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/HelpContent/QsTaxCertificateHelp.vue
@@ -1,0 +1,38 @@
+<script  setup lang="ts" />
+<template>
+  <article
+    id="qs-tax-certificate-help"
+    class="px-8 py-2"
+  >
+    <h3 class="text-center">
+      Help with Tax Certificate
+    </h3>
+
+    <p class="pt-3">
+      The tax certificate or an equivalent form of consent must be issued from the tax authority with
+      jurisdiction of the home, and must be valid for the period of the transport permit.
+    </p>
+    <p class="mt-7">
+      If the tax notice for the current year has not yet been mailed to the owner, then the owner must pay a
+      deposit against taxes owing in order to receive a tax certificate. The deposit must be an amount equal
+      to the greater of $75 or the previous year's taxes less any home owner grant
+    </p>
+    <p class="mt-7">
+      The form of tax certificate may vary depending upon the tax authority. However, the tax certificate must
+      state that:
+    </p>
+    <p class="ml-4 mb-0">
+      a. all local taxes have been paid for the current tax year,
+    </p>
+    <p class="ml-4 mb-0">
+      b. a deposit has been paid against the current year's taxes, or
+    </p>
+    <p class="ml-4 mb-0">
+      c. the tax collector has consented to the transport permit.
+    </p>
+    <p class="mt-7">
+      If there is no expiry date in the tax certificate, then enter the last day of the relevant tax year,
+      e.g. 31 Dec 20xx.
+    </p>
+  </article>
+</template>

--- a/ppr-ui/src/components/mhrTransportPermit/HelpContent/StaffTaxCertificateHelp.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/HelpContent/StaffTaxCertificateHelp.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+</script>
+<template>
+  <article
+    id="staff-tax-certificate-help"
+    class="px-8 py-2"
+  >
+    <h3 class="text-center">
+      Help with Tax Certificate
+    </h3>
+
+    <p class="pt-3">
+      The certificate must be issued from the tax authority with jurisdiction of the home, and must be valid for the
+      period of the transport permit. It must state that all local taxes have been paid for the current tax year, or
+      that a deposit has been paid against the current year's taxes, or that the tax collector has consented to the
+      transport permit.
+    </p>
+
+    <p class="mt-7">
+      The form of tax certificate may vary depending upon the tax authority. However, the tax certificate must
+      state that:
+    </p>
+    <p class="ml-4 mb-0">
+      a. all local taxes have been paid for the current tax year,
+    </p>
+    <p class="ml-4 mb-0">
+      b. a deposit has been paid against the current year's taxes, or
+    </p>
+    <p class="ml-4 mb-0">
+      c. the tax collector has consented to the transport permit.
+    </p>
+
+    <p class="mt-7">
+      A valid tax certificate is required in all cases except in the scenarios described below:
+    </p>
+
+    <p class="mt-7 font-weight-bold">
+      Scenario 1
+    </p>
+    <p>
+      No tax certificate is required for moving the manufactured home to a different pad within the same park, or moving
+      the manufactured home from locations on a manufacturer or dealer’s lot. To confirm this exemption applies check
+      the ‘Certificate requirement waved’ below
+    </p>
+
+    <p class="mt-7 font-weight-bold">
+      Scenario 2
+    </p>
+    <p>
+      If the transport permit is requested by a landlord under MHA section 15(2)(b), then you must confirm consent from
+      the taxing authority. To confirm you have received evidence of consent, check the ‘Certificate requirement waved’
+      below
+    </p>
+
+    <p class="mt-7 font-weight-bold">
+      Scenario 3
+    </p>
+    <p>
+      If there are special circumstances for which registry staff deem it appropriate to waive the requirement for a tax
+      certificate, then check the ‘Certificate requirement waved’ below.
+    </p>
+
+    <p class="mt-7">
+      If there is no expiry date in the tax certificate, then enter the last day of the relevant tax year, e.g. 31 Dec
+      20xx.
+    </p>
+
+    <p class="mt-7">
+      If the tax notice for the current year has not yet been mailed to the owner, then the owner must pay a deposit
+      against taxes owing in order to receive a tax certificate. The deposit must be an amount equal to the greater of
+      $75 or the previous year's taxes less any home owner grant.
+    </p>
+  </article>
+</template>

--- a/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
+++ b/ppr-ui/src/components/mhrTransportPermit/LocationChange.vue
@@ -185,11 +185,32 @@
         class="mt-10"
       >
         <h2>4. Confirm Tax Certificate </h2>
-        <p class="mt-2">
+        <p
+          v-if="isRoleStaffSbc || isRoleStaffReg"
+          class="mt-2"
+        >
+          A valid tax certificate is required in all cases. To confirm your tax certificate, enter the expiry date
+          below. If there is no expiry date in the tax certificate, then enter the last day of the relevant tax year
+          , e.g. 31 Dec 20xx. Exceptions are outlined in the tax certificate help section.
+        </p>
+        <p
+          v-else
+          class="mt-2"
+        >
           A valid tax certificate is required; it must be issued from the tax
           authority with jurisdiction of the home, and must show that all local taxes have
           been paid for the current tax year. To confirm your tax certificate, enter the expiry date below.
         </p>
+
+        <SimpleHelpToggle
+          :toggleButtonTitle="'Help with Tax Certificate'"
+          class="my-6"
+        >
+          <template #content>
+            <StaffTaxCertificateHelp v-if="isRoleStaffSbc || isRoleStaffReg" />
+            <QsTaxCertificateHelp v-else />
+          </template>
+        </SimpleHelpToggle>
 
         <TaxCertificate
           ref="taxCertificateRef"
@@ -198,6 +219,7 @@
           :class="{ 'border-error-left': validate && !getInfoValidation('isTaxCertificateValid') }"
           :validate="validate && !getInfoValidation('isTaxCertificateValid')"
           @setStoreProperty="handleTaxCertificateUpdate($event)"
+          @waiveCertificate="setMhrTransportPermitNewLocation({ key: 'waiveCertificate', value: $event })"
           @isValid="setValidation('isTaxCertificateValid', $event)"
         />
       </section>
@@ -211,7 +233,7 @@ import { FormIF } from '@/interfaces'
 import { locationChangeTypes } from '@/resources/mhr-transport-permits/transport-permits'
 import { useStore } from '@/store/store'
 import { reactive, computed, watch, ref, nextTick, onMounted } from 'vue'
-import { FormCard } from '@/components/common'
+import { FormCard, SimpleHelpToggle } from '@/components/common'
 import { HomeCivicAddress, HomeLandOwnership, HomeLocationType } from '@/components/mhrRegistration'
 import { CivicAddressSchema } from '@/schemas/civic-address'
 import { TaxCertificate } from '@/components/mhrTransfers'
@@ -221,6 +243,8 @@ import { storeToRefs } from "pinia"
 import { changeTransportPermitLocationTypeDialog } from '@/resources/dialogOptions'
 import { BaseDialog } from '@/components/dialogs'
 import { cloneDeep } from 'lodash'
+import QsTaxCertificateHelp from '@/components/mhrTransportPermit/HelpContent/QsTaxCertificateHelp.vue'
+import StaffTaxCertificateHelp from '@/components/mhrTransportPermit/HelpContent/StaffTaxCertificateHelp.vue'
 
 const props = defineProps<{
   validate: boolean
@@ -234,6 +258,7 @@ const { setMhrTransportPermit, setMhrTransportPermitNewLocation,
 const {
   hasUnsavedChanges,
   isRoleStaffSbc,
+  isRoleStaffReg,
   isRoleQualifiedSupplier,
   getMhrTransportPermit,
   getMhrTransportPermitHomeLocation,

--- a/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeLocationIF.ts
+++ b/ppr-ui/src/interfaces/mhr-registration-interfaces/MhrRegistrationHomeLocationIF.ts
@@ -38,4 +38,5 @@ export interface MhrRegistrationHomeLocationWithoutAddressIF {
   reserveNumber?: string
   exceptionPlan?: string
   permitWithinSamePark?: boolean // for transport permit amendment
+  waiveCertificate?: boolean // waive transport permit tax certificate
 }

--- a/ppr-ui/src/resources/dialogOptions/cancelDialogs.ts
+++ b/ppr-ui/src/resources/dialogOptions/cancelDialogs.ts
@@ -86,6 +86,6 @@ export const confirmNewTransportPermit: DialogOptionsIF = {
   title: 'Verify Transport Permit Status',
   label: '',
   text: 'By applying for a new transport permit you are confirming that the active Transport permit {number} issued' +
-    ' on {date of issue} has been completed and will render as no longer active.'
+    ' on {date of issue} has been completed and will no longer be active.'
 }
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1506,21 +1506,16 @@ export default defineComponent({
       localState.showTransferType = !localState.showTransferType
     }
 
-    const resetPermitState = () => {
-      resetValidationState()
-      resetMhrInformation()
-      resetTransportPermit(true)
-      localState.validate = false
-    }
-
     const handleCancelTransportPermitChanges = (showConfirmationDialog = true) => {
       if (hasUnsavedChanges.value && showConfirmationDialog) {
         // show dialog
         localState.showCancelTransportPermitDialog = true
       } else {
-        console.log('Cancel Called')
         // reset validation and close dialog
-        resetPermitState()
+        resetValidationState()
+        resetMhrInformation()
+        resetTransportPermit(true)
+        localState.validate = false
       }
     }
 

--- a/ppr-ui/src/views/mhrInformation/MhrInformation.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrInformation.vue
@@ -1506,16 +1506,21 @@ export default defineComponent({
       localState.showTransferType = !localState.showTransferType
     }
 
+    const resetPermitState = () => {
+      resetValidationState()
+      resetMhrInformation()
+      resetTransportPermit(true)
+      localState.validate = false
+    }
+
     const handleCancelTransportPermitChanges = (showConfirmationDialog = true) => {
       if (hasUnsavedChanges.value && showConfirmationDialog) {
         // show dialog
         localState.showCancelTransportPermitDialog = true
       } else {
+        console.log('Cancel Called')
         // reset validation and close dialog
-        resetValidationState()
-        resetMhrInformation()
-        resetTransportPermit(true)
-        localState.validate = false
+        resetPermitState()
       }
     }
 

--- a/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
+++ b/ppr-ui/src/views/mhrInformation/MhrTransportPermit.vue
@@ -579,6 +579,7 @@ const toggleCancelTransportPermit = (val: boolean) => {
 const toggleExtendTransportPermit = (val: boolean) => {
   setExtendLocationChange(val)
   setMhrTransportPermitLocationChangeType(val ? LocationChangeTypes.EXTEND_PERMIT : null)
+  if (!val) emit('cancelTransportPermitChanges', val)
 }
 
 const handleConfirmNewPermit = (val: boolean) => {
@@ -586,6 +587,7 @@ const handleConfirmNewPermit = (val: boolean) => {
   setLocationChange(val)
   setLocationChangeType(val ? LocationChangeTypes.TRANSPORT_PERMIT : null)
   state.showConfirmNewPermitDialog = false
+  if (!val) emit('cancelTransportPermitChanges', val)
 }
 
 </script>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23025

*Description of changes:*
- Adds help content for Tax certificate
- Staff and Qs Help Content
- Staff only: Checkbox to disable the requirement for Tax Certification.

<img width="1287" alt="Screenshot 2024-10-16 at 12 17 25 PM" src="https://github.com/user-attachments/assets/361d409a-cb8a-41b6-b8c8-8b6dc7880e24">

<img width="1209" alt="Screenshot 2024-10-16 at 12 17 34 PM" src="https://github.com/user-attachments/assets/dd9b3221-aff8-4ec7-a7df-1ce7880b3292">

<img width="1224" alt="Screenshot 2024-10-16 at 12 23 34 PM" src="https://github.com/user-attachments/assets/bd49e424-771b-4c66-9434-15970b87f117">

<img width="1195" alt="Screenshot 2024-10-16 at 12 23 43 PM" src="https://github.com/user-attachments/assets/1d6edd41-c226-4402-b2d1-53fbee3463a9">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
