### PR TITLE
MHR API fix reg summary frozen status fix.

### DIFF
--- a/mhr-api/src/database/postgres_views/mhr_account_reg_vw.py
+++ b/mhr-api/src/database/postgres_views/mhr_account_reg_vw.py
@@ -38,10 +38,12 @@ mhr_account_reg_vw = PGView(
         d.document_registration_number,
         (SELECT d2.document_type
             FROM mhr_documents d2
-          WHERE d2.id = (SELECT MAX(d3.id)
-                            FROM mhr_documents d3, mhr_registrations r2
+          WHERE d2.id = (SELECT d3.id
+                           FROM mhr_documents d3, mhr_registrations r2
                           WHERE r2.id = d3.registration_id
-                            AND r2.mhr_number = r.mhr_number)) AS last_doc_type,
+                            AND r2.mhr_number = r.mhr_number
+                          ORDER BY r2.registration_ts DESC
+                        FETCH FIRST 1 ROWS ONLY)) AS last_doc_type,
         (SELECT n.status_type
             FROM mhr_notes n
           WHERE n.registration_id = r.id) AS note_status,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23931

*Description of changes:*
- Legacy data migration document records do not always match the registration sequence. Use the registration timestamp, not the document record ID, to determine the last registration document type for setting the locked/frozen status. Fix for summary incorrectly setting the status as FROZEN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
