### PR TITLE
align dropdown items left

### DIFF
--- a/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
+++ b/ppr-ui/src/components/registration/RegistrationBarTypeAheadList.vue
@@ -204,5 +204,7 @@ export default defineComponent({
 }
 .registration-list-item {
   width: 730px!important;
+  text-align: left;
+  text-align-last: left;
 }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23867

*Description of changes:*
* Applied `align-left` and `align-left-last` css to registration dropdown element. 

<img width="1816" alt="image" src="https://github.com/user-attachments/assets/d2f5d07f-b397-43b8-afe6-c34669a2f546">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
