### PR TITLE
Transfers: Owner Contact Info Editing

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.3.4",
+      "version": "3.3.5",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
     flat
-    class="py-6 px-8 mb-5 rounded"
+    class="py-6 pl-6 pr-8 mb-5 rounded"
     :class="{ 'border-error-left': showTableError || showReviewedError}"
   >
     <v-row id="mhr-home-add-person">
@@ -38,7 +38,7 @@
               Person's Name
             </label>
             <v-tooltip
-              v-if="disableNameFields"
+              v-if="disableNameFields && isCurrentOwner(owner)"
               location="top"
               contentClass="top-tooltip pa-5"
               transition="fade-transition"
@@ -55,7 +55,7 @@
               </template>
               {{ disabledNameEditTooltip }}
             </v-tooltip>
-            <v-row>
+            <v-row class="mt-2">
               <v-col cols="4">
                 <v-text-field
                   id="first-name"
@@ -65,8 +65,8 @@
                   label="First Name"
                   data-test-id="first-name"
                   :rules="firsNameRules"
-                  :disabled="disableNameFields"
-                  :readonly="disableNameFields"
+                  :disabled="disableNameFields && isCurrentOwner(owner)"
+                  :readonly="disableNameFields && isCurrentOwner(owner)"
                 />
               </v-col>
               <v-col cols="4">
@@ -78,8 +78,8 @@
                   label="Middle Name (Optional)"
                   data-test-id="middle-name"
                   :rules="maxLength(50)"
-                  :disabled="disableNameFields"
-                  :readonly="disableNameFields"
+                  :disabled="disableNameFields && isCurrentOwner(owner)"
+                  :readonly="disableNameFields && isCurrentOwner(owner)"
                 />
               </v-col>
               <v-col cols="4">
@@ -91,8 +91,8 @@
                   label="Last Name"
                   data-test-id="last-name"
                   :rules="lastNameRules"
-                  :disabled="disableNameFields"
-                  :readonly="disableNameFields"
+                  :disabled="disableNameFields && isCurrentOwner(owner)"
+                  :readonly="disableNameFields && isCurrentOwner(owner)"
                 />
               </v-col>
             </v-row>
@@ -105,7 +105,7 @@
               Business or Organization Name
             </label>
             <v-tooltip
-              v-if="disableNameFields"
+              v-if="disableNameFields && isCurrentOwner(owner)"
               location="top"
               content-class="top-tooltip pa-5"
               transition="fade-transition"
@@ -121,7 +121,10 @@
               </template>
               {{ disabledNameEditTooltip }}
             </v-tooltip>
-            <v-row v-if="!isCurrentOwner(owner)">
+            <v-row
+              v-if="!isCurrentOwner(owner)"
+              class="mt-2"
+            >
               <v-col>
                 <p>
                   You can find the full legal name of an active B.C. business by entering the name
@@ -218,7 +221,7 @@
                 </SimpleHelpToggle>
               </v-col>
             </v-row>
-            <v-row>
+            <v-row class="my-2">
               <v-col>
                 <v-text-field
                   id="org-name"
@@ -234,8 +237,8 @@
                   :rules="orgNameRules"
                   :clearable="showClear"
                   :clearIcon="'mdi-close'"
-                  :disabled="disableNameFields"
-                  :readonly="disableNameFields"
+                  :disabled="disableNameFields && isCurrentOwner(owner)"
+                  :readonly="disableNameFields && isCurrentOwner(owner)"
                   @click:clear="showClear = false"
                 >
                   <template #append-inner>
@@ -266,7 +269,7 @@
             Additional Name Information
           </label>
           <v-tooltip
-            v-if="disableNameFields"
+            v-if="disableNameFields && isCurrentOwner(owner)"
             location="top"
             contentClass="top-tooltip pa-5"
             transition="fade-transition"
@@ -283,7 +286,7 @@
             </template>
             {{ disabledNameEditTooltip }}
           </v-tooltip>
-          <v-row class="py-2">
+          <v-row class="my-2">
             <v-col class="col">
               <v-tooltip
                 location="right"
@@ -299,11 +302,11 @@
                     color="primary"
                     :label="nameConfig.label"
                     data-test-id="suffix"
-                    :hint="nameConfig.hint"
+                    :hint="(disableNameFields && isCurrentOwner(owner)) ? '' : nameConfig.hint"
                     persistentHint
                     :rules="additionalNameRules"
-                    :disabled="disableNameFields"
-                    :readonly="disableNameFields"
+                    :disabled="disableNameFields && isCurrentOwner(owner)"
+                    :readonly="disableNameFields && isCurrentOwner(owner)"
                     v-bind="props"
                   />
                 </template>
@@ -315,7 +318,7 @@
           <label class="generic-label">
             Phone Number
           </label>
-          <v-row class="py-2">
+          <v-row class="my-2">
             <v-col cols="6">
               <v-text-field
                 id="phone-number"
@@ -351,14 +354,17 @@
             :editing="true"
             :schema="{ ...addressSchema }"
             :triggerErrors="triggerAddressErrors"
-            class="mt-2"
+            class="mt-6"
             hideAddressHint
             @valid="isAddressFormValid = $event"
             @update-address="owner.address = $event"
           />
 
           <!-- Group Add / Edit -->
-          <template v-if="!isTransferDueToDeath && !isFrozenMhrDueToAffidavit && !(isMhrCorrection && editHomeOwner)">
+          <template
+            v-if="!isTransferDueToDeath && !isFrozenMhrDueToAffidavit &&
+              !(isMhrCorrection && editHomeOwner) && !(disableNameFields && isCurrentOwner(owner))"
+          >
             <hr class="mt-3 mb-10">
             <HomeOwnerGroups
               :groupId="isDefinedGroup ? ownersGroupId : null"
@@ -678,9 +684,9 @@ export default defineComponent({
 
         return localState.nameConfig?.tooltipContent[getMhrTransferType.value?.transferType]
       }),
-      disabledNameEditTooltip: `Owner name’s cannot be changed here. Name change requests should be
-        submitted separately to BC Registries staff prior to completing this transfer.
-        Contact BC Registries for more information.`
+      disabledNameEditTooltip: `Owner name’s cannot be changed here. Name change requests should be submitted
+        separately, with the appropriate supporting documents, prior to completing this transfer. See Help with
+        Ownership Transfer or Change for more information.`
     })
 
     const done = async (): Promise<void> => {

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/HomeOwnersTable.vue
@@ -143,6 +143,7 @@
                 v-else-if="item.ownerId"
                 :key="`owner-row-key-${homeOwners.indexOf(item)}`"
                 class="owner-info"
+                :class="{ 'border-error-left': isInvalidOwnerGroup(item.groupId) }"
                 :data-test-id="`owner-info-${item.ownerId}`"
               >
                 <!-- Start of Name -->
@@ -151,7 +152,6 @@
                   :class="[
                     {
                       'no-bottom-border': hideRowBottomBorder(item),
-                      'border-error-left': isInvalidOwnerGroup(item.groupId)
                     },
                     homeOwnersTableHeaders[0].class
                   ]"

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -179,9 +179,7 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
 
   /** Returns true when Add/Edit Owner name fields should be disabled **/
   const disableNameFields = computed((): boolean => {
-    return [
-      ApiTransferTypes.SURVIVING_JOINT_TENANT
-    ].includes(getMhrTransferType.value?.transferType)
+    return isTransferDueToDeath.value || isTransferBillOfSale.value || isTransferNonGiftBillOfSale.value
   })
 
   /** Returns true when ownership structure is joint tenancy /w min 2  owners but not executors, trustees or admins. **/
@@ -375,33 +373,13 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     if (enableAllActions) return true
 
     switch (getMhrTransferType.value?.transferType) {
-      case ApiTransferTypes.SALE_OR_GIFT:
-      case ApiTransferTypes.TRANS_FAMILY_ACT:
-      case ApiTransferTypes.TRANS_INFORMAL_SALE:
-      case ApiTransferTypes.TRANS_QUIT_CLAIM:
-      case ApiTransferTypes.TRANS_RECEIVERSHIP:
-      case ApiTransferTypes.TRANS_SEVER_GRANT:
-      case ApiTransferTypes.TRANS_WRIT_SEIZURE:
-      case ApiTransferTypes.ABAN:
-      case ApiTransferTypes.BANK:
-      case ApiTransferTypes.COU:
-      case ApiTransferTypes.FORE:
-      case ApiTransferTypes.GENT:
-      case ApiTransferTypes.TRANS_LAND_TITLE:
-      case ApiTransferTypes.REIV:
-      case ApiTransferTypes.REPV:
-      case ApiTransferTypes.SZL:
-      case ApiTransferTypes.TAXS:
-      case ApiTransferTypes.VEST:
-        return false // Disable for Sale or Gift
-      case ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL:
       case ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL:
         return owner.action === ActionTypes.ADDED
       case ApiTransferTypes.SURVIVING_JOINT_TENANT:
         // Check for joint tenancy (at least two owners who are not executors, trustees or admins)
         return owner.type === ApiHomeTenancyTypes.JOINT
       default:
-        return false
+        return true
     }
   }
 

--- a/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
+++ b/ppr-ui/src/composables/mhrInformation/useTransferOwners.ts
@@ -373,8 +373,6 @@ export const useTransferOwners = (enableAllActions: boolean = false) => {
     if (enableAllActions) return true
 
     switch (getMhrTransferType.value?.transferType) {
-      case ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL:
-        return owner.action === ActionTypes.ADDED
       case ApiTransferTypes.SURVIVING_JOINT_TENANT:
         // Check for joint tenancy (at least two owners who are not executors, trustees or admins)
         return owner.type === ApiHomeTenancyTypes.JOINT

--- a/ppr-ui/src/views/userAccess/QsInformation.vue
+++ b/ppr-ui/src/views/userAccess/QsInformation.vue
@@ -79,11 +79,20 @@
         v-if="[MhrSubTypes.MANUFACTURER, MhrSubTypes.DEALERS].includes(getMhrSubProduct)"
         class="manufacturer-home-location-form mt-8"
       >
-        <h2>Location of Manufactured Home(s)</h2>
-        <p class="mt-1">
-          Enter the civic address of the manufacturer’s lot/premises where the homes are located. This address will
-          display as the registered location for homes owned by the manufacturer.
-        </p>
+        <template v-if="getMhrSubProduct === MhrSubTypes.MANUFACTURER">
+          <h2>Location of Manufactured Home(s)</h2>
+          <p class="mt-1">
+            Enter the civic address of the manufacturer’s lot/premises where the homes are located. This address will
+            display as the registered location for homes owned by the manufacturer.
+          </p>
+        </template>
+        <template v-else>
+          <h2>Location of Dealer Home(s)</h2>
+          <p class="mt-1">
+            Enter the civic address of the dealer’s lot/premises where the homes are located. This address will display
+            as the registered location for homes owned by the dealer.
+          </p>
+        </template>
 
         <HomeCivicAddress
           :value="getMhrQsHomeLocation"

--- a/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
+++ b/ppr-ui/tests/unit/MhrTransferHomeOwners.spec.ts
@@ -744,8 +744,8 @@ describe('Home Owners', () => {
     // has border errors for the group (rows: header, error, owner one, owner two)
     expect(homeOwners.find('.group-header-slot.border-error-left').exists()).toBeTruthy()
     expect(homeOwners.find(getTestId('invalid-group-msg')).classes('border-error-left')).toBeTruthy()
-    expect(homeOwners.find(getTestId('owner-info-10')).find('.owner-name').classes('border-error-left')).toBeTruthy()
-    expect(homeOwners.find(getTestId('owner-info-20')).find('.owner-name').classes('border-error-left')).toBeTruthy()
+    expect(homeOwners.find(getTestId('owner-info-10')).classes('border-error-left')).toBeTruthy()
+    expect(homeOwners.find(getTestId('owner-info-20')).classes('border-error-left')).toBeTruthy()
   })
 
   it('TRANS SALE GIFT: should not show group error for Added and Deleted groups', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24304

*Description of changes:*
- Enables the Contact Information Editing for Owners in ALL Transfer Types
- Minor Payload refactoring to include previousOwnerId
- Refactoring on Add Edit Owner to disable name field editing.
- Minor copy and unit test updates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
