### PR TITLE
Business Party Types: Admin, Exec, Trustee Edit Role Fix

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.3.9",
+      "version": "3.3.10",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -585,7 +585,8 @@ export default defineComponent({
         middle: props.editHomeOwner?.individualName.middle || '',
         last: props.editHomeOwner?.individualName.last || ''
       }
-    } else {
+    } else if (![HomeOwnerPartyTypes.EXECUTOR, HomeOwnerPartyTypes.ADMINISTRATOR, HomeOwnerPartyTypes.TRUSTEE]
+      .includes(props.editHomeOwner?.partyType)) {
       defaultHomeOwner.organizationName = props.editHomeOwner?.organizationName || ''
       defaultHomeOwner.partyType = HomeOwnerPartyTypes.OWNER_BUS
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24304

*Description of changes:*
- Prevents Business Executor, trustees and Admins being default to basic owner when editing contact info during transfers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
