### PR TITLE
MHR API TRANS data validation no mixed party types.

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.0.6"
+version = "2.0.7"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/utils/validator_owner_utils.py
+++ b/mhr-api/src/mhr_api/utils/validator_owner_utils.py
@@ -46,7 +46,7 @@ OWNER_DESCRIPTION_REQUIRED = "Owner description is required for the owner party 
 TRANSFER_PARTY_TYPE_INVALID = "Owner party type of administrator, executor, trustee not allowed for this registration. "
 TENANCY_PARTY_TYPE_INVALID = "Owner group tenancy type must be NA for executors, trustees, or administrators. "
 GROUP_PARTY_TYPE_INVALID = (
-    "For TRUSTEE, ADMINISTRATOR, or EXECUTOR, all owner party types within the group " + "must be identical. "
+    "For TRUSTEE, ADMINISTRATOR, or EXECUTOR, all owner party types within the group must be identical. "
 )
 TRAN_DEATH_GROUP_COUNT = "Only one owner group can be modified in a transfer due to death registration. "
 TRAN_DEATH_DELETE_MISSING = "Death transfer excluding owner edits no request deleteOwnerGroups group found. "
@@ -523,7 +523,7 @@ def validate_owner_party_type(  # pylint: disable=too-many-branches
             and group.get("type", "") != MhrTenancyTypes.NA
         ):
             error_msg += TENANCY_PARTY_TYPE_INVALID  # JOINT scenario
-        if new and group_parties_invalid:
+        if group_parties_invalid or (not new and not owner_death and party_count > 0 and party_count != owner_count):
             error_msg += GROUP_PARTY_TYPE_INVALID
     return error_msg
 

--- a/mhr-api/tests/unit/utils/test_transfer_validator.py
+++ b/mhr-api/tests/unit/utils/test_transfer_validator.py
@@ -104,6 +104,8 @@ TEST_TRANSFER_DATA_EXTRA = [
 # testdata pattern is ({description}, {valid}, {numerator}, {denominator}, {add_group}, {message content})
 TEST_TRANSFER_DATA_GROUP = [
     ('Valid', True, 1, 2, None, None),
+    ('Invalid party type OWNER', False, 1, 2, EXEC_ADD_GROUPS_INVALID, val_owner_utils.GROUP_PARTY_TYPE_INVALID),
+    ('Invalid party type ADMIN', False, 1, 2, EXEC_ADD_GROUPS_INVALID, val_owner_utils.GROUP_PARTY_TYPE_INVALID),
     ('Invalid no delete group', False, 1, 2, None, val_owner_utils.DELETE_GROUPS_MISSING),
     ('Invalid no delete groupId', False, 1, 2, None, val_owner_utils.DELETE_GROUP_ID_MISSING),
     ('Invalid add TC no owner', False, None, None, TC_GROUP_TRANSFER_ADD2, val_owner_utils.OWNERS_COMMON_INVALID),
@@ -412,6 +414,8 @@ def test_validate_transfer_group(session, desc, valid, numerator, denominator, a
             json_data['addOwnerGroups'][1]['owners'] = []
         elif desc == 'Invalid add TC > 1 owner':
             json_data['addOwnerGroups'][0]['type'] = 'COMMON'
+        elif desc == 'Invalid party type ADMIN':
+            json_data['addOwnerGroups'][0]['owners'][0]['partyType'] = 'ADMINISTRATOR'
         else:
             for group in json_data.get('addOwnerGroups'):
                 if not numerator:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24761

*Description of changes:*
- Update transfer data validation to not allow groups with mixed owner party types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
