### PR TITLE
Preserve Default Group: SO/JT Scenarios

### DIFF
--- a/ppr-ui/package-lock.json
+++ b/ppr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppr-ui",
-      "version": "3.3.10",
+      "version": "3.3.11",
       "dependencies": {
         "@bcrs-shared-components/input-field-date-picker": "^1.0.0",
         "@lemoncode/fonk": "^1.5.1",

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
+++ b/ppr-ui/src/composables/mhrRegistration/useHomeOwners.ts
@@ -260,7 +260,7 @@ export function useHomeOwners (isMhrTransfer: boolean = false, isMhrCorrection: 
     }
 
     // Remove first group option when there is existing SO/JT
-    if (!showGroups.value && homeOwnerGroups.length && isMhrTransfer) dropDownItems.shift()
+    if (!showGroups.value && homeOwnerGroups.length) dropDownItems.shift()
 
     // Handle Edit Defaults
     if (!dropDownItems.length) return [{ title: 'Group 1 (New Group)', value: DEFAULT_GROUP_ID }]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25643

*Description of changes:*
- After removing a SO or JTs - preserve a default group for creating new ownership groups. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
