### PR TITLE
PPR API transition from RL to CL changes

### DIFF
--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -30,7 +30,7 @@ import requests
 def get_mock_auth() -> str:
     """For CI unit tests get mock auth value."""
     try:
-        url: str = "https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/testing/mock-sa-ppr"
+        url: str = "https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/testing/mock-sa-ppr"
         headers = {"Content-Type": "application/json"}
         response = requests.get(url, headers=headers, timeout=10.0)
         if response and response.text:

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -954,3 +954,11 @@ def is_cl_enabled() -> bool:
     if reg_type and reg_type.act_ts:
         return now_ts().timestamp() > reg_type.act_ts.timestamp()
     return True
+
+
+def is_rl_transition() -> bool:
+    """Check if an RL amendment/renewal is transitioning to a CL: commercial lien act timestamp must exist."""
+    reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
+    if reg_type and reg_type.act_ts:
+        return now_ts().timestamp() > reg_type.act_ts.timestamp()
+    return False

--- a/ppr-api/tests/unit/api/test_amendment.py
+++ b/ppr-api/tests/unit/api/test_amendment.py
@@ -24,12 +24,13 @@ from flask import current_app
 from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT, FINANCING_STATEMENT
 
 from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE, BCOL_HELP, GOV_ACCOUNT_ROLE
-from ppr_api.models import utils as model_utils, Registration
+from ppr_api.models import FinancingStatement, utils as model_utils, Registration
+from ppr_api.models.type_tables import RegistrationType, RegistrationTypes
 from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 # prep sample post amendment statement data
 SAMPLE_JSON = copy.deepcopy(AMENDMENT_STATEMENT)
 STATEMENT_VALID = {
@@ -424,6 +425,46 @@ TEST_AMENDMENT_EDIT_DATA = [
 TEST_CREATE_SE_DATA = [
     ('Valid change notice', AMENDMENT_SE, 'TEST0022', 'PS00002', HTTPStatus.CREATED),
 ]
+# testdata pattern is ({desc}, {test data}, {roles}, {status}, {after_cla}, {reg_num})
+TEST_CREATE_RL_DATA = [
+    ('Valid before CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, False, 'TEST0017'),
+    ('Valid after CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, True, 'TEST0017'),
+]
+
+
+@pytest.mark.parametrize('desc,json_data,roles,status,after_cla,reg_num', TEST_CREATE_RL_DATA)
+def test_create_amendment_rl(session, client, jwt, desc, json_data, roles, status, after_cla, reg_num):
+    """Assert that a post amendment registration on an RL type works as expected before and after the CLA transition."""
+    headers = None
+    # setup
+    current_app.config.update(PAYMENT_SVC_URL=MOCK_PAY_URL)
+    current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
+    headers = create_header_account(jwt, roles, 'test-user', STAFF_ROLE)
+    act_offset: int = -1 if after_cla else 1
+    now_offset = model_utils.now_ts_offset(act_offset, True)
+    reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
+    reg_type.act_ts = now_offset
+    session.add(reg_type)
+    session.commit()
+    payload = copy.deepcopy(json_data)
+    payload['baseRegistrationNumber'] = reg_num
+    payload['debtorName']['businessName'] = 'TEST 17 DEBTOR INC.'
+
+    # test
+    response = client.post('/api/v1/financing-statements/' + reg_num + '/amendments',
+                           json=payload,
+                           headers=headers,
+                           content_type='application/json')
+
+    # check
+    assert response.status_code == status
+    if status == HTTPStatus.CREATED:
+        statement: FinancingStatement = FinancingStatement.find_by_registration_number(reg_num, 'PS12345', True)
+        reg_type: str = statement.registration[0].registration_type
+        if after_cla:
+            assert reg_type == RegistrationTypes.CL.value
+        else:
+            assert reg_type == RegistrationTypes.RL.value
 
 
 @pytest.mark.parametrize('desc,json_data,reg_num,account_id,status', TEST_CREATE_SE_DATA)

--- a/ppr-api/tests/unit/api/test_callback.py
+++ b/ppr-api/tests/unit/api/test_callback.py
@@ -30,8 +30,8 @@ from ppr_api.services.payment import TransactionTypes
 from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 # testdata pattern is ({desc}, {status}, {registration_id}, {party_id})
 TEST_MAIL_CALLBACK_DATA = [
     ('Missing reg id', HTTPStatus.BAD_REQUEST, None, 9999999),

--- a/ppr-api/tests/unit/api/test_financing.py
+++ b/ppr-api/tests/unit/api/test_financing.py
@@ -31,8 +31,8 @@ from ppr_api.services.payment import TransactionTypes
 from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 # prep sample post financing statement data
 FINANCING_VALID = {
     'type': 'SA',

--- a/ppr-api/tests/unit/api/test_historical_searches.py
+++ b/ppr-api/tests/unit/api/test_historical_searches.py
@@ -27,8 +27,8 @@ from ppr_api.services.authz import BCOL_HELP, PPR_ROLE, STAFF_ROLE
 from tests.unit.services.utils import create_header, create_header_account
 
 
-MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_AUTH_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 
 # Valid test search criteria
 AIRCRAFT_DOT_JSON = {

--- a/ppr-api/tests/unit/api/test_renewal.py
+++ b/ppr-api/tests/unit/api/test_renewal.py
@@ -24,13 +24,14 @@ from flask import current_app
 from registry_schemas.example_data.ppr import FINANCING_STATEMENT
 
 from ppr_api.models import FinancingStatement, Registration, utils as model_utils
+from ppr_api.models.type_tables import RegistrationType, RegistrationTypes
 from ppr_api.resources.utils import get_payment_details
 from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE, BCOL_HELP, GOV_ACCOUNT_ROLE
 from tests.unit.services.utils import create_header, create_header_account, create_header_account_report
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 # prep sample post renewal statement data
 STATEMENT_VALID = {
     'baseRegistrationNumber': 'TEST0001',
@@ -280,6 +281,49 @@ TEST_GET_STATEMENT = [
     ('Mismatch registrations staff', [PPR_ROLE, STAFF_ROLE], HTTPStatus.OK, True, 'TEST00R5', 'TEST0001'),
     ('Missing account staff', [PPR_ROLE, STAFF_ROLE], HTTPStatus.BAD_REQUEST, False, 'TEST00R5', 'TEST0005')
 ]
+# testdata pattern is ({desc}, {test data}, {roles}, {status}, {after_cla}, {reg_num})
+TEST_CREATE_RL_DATA = [
+    ('Valid before CLA', STATEMENT_RL_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, False, 'TEST0017'),
+    ('Valid after CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, True, 'TEST0017'),
+]
+
+
+@pytest.mark.parametrize('desc,json_data,roles,status,after_cla,reg_num', TEST_CREATE_RL_DATA)
+def test_create_renewal_rl(session, client, jwt, desc, json_data, roles, status, after_cla, reg_num):
+    """Assert that a post renewal registration on an RL type works as expected before and after the CLA transition."""
+    headers = None
+    # setup
+    current_app.config.update(PAYMENT_SVC_URL=MOCK_PAY_URL)
+    current_app.config.update(AUTH_SVC_URL=MOCK_URL_NO_KEY)
+    headers = create_header_account(jwt, roles, 'test-user', STAFF_ROLE)
+    act_offset: int = -1 if after_cla else 1
+    now_offset = model_utils.now_ts_offset(act_offset, True)
+    reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
+    reg_type.act_ts = now_offset
+    session.add(reg_type)
+    session.commit()
+    payload = copy.deepcopy(json_data)
+    payload['baseRegistrationNumber'] = reg_num
+    payload['debtorName']['businessName'] = 'TEST 17 DEBTOR INC.'
+    if not after_cla and 'courtOrderInformation' in payload:
+        payload['courtOrderInformation']['orderDate'] = model_utils.format_ts(model_utils.now_ts())
+
+    # test
+    response = client.post('/api/v1/financing-statements/' + reg_num + '/renewals',
+                           json=payload,
+                           headers=headers,
+                           content_type='application/json')
+
+    # check
+    # print(response.json)
+    assert response.status_code == status
+    if status == HTTPStatus.CREATED:
+        statement: FinancingStatement = FinancingStatement.find_by_registration_number(reg_num, 'PS12345', True)
+        reg_type: str = statement.registration[0].registration_type
+        if after_cla:
+            assert reg_type == RegistrationTypes.CL.value
+        else:
+            assert reg_type == RegistrationTypes.RL.value
 
 
 @pytest.mark.parametrize('desc,json_data,roles,status,has_account,reg_num', TEST_CREATE_DATA)

--- a/ppr-api/tests/unit/api/test_search_results.py
+++ b/ppr-api/tests/unit/api/test_search_results.py
@@ -31,8 +31,8 @@ from tests.unit.services.utils import create_header, create_header_account, crea
 
 
 SAMPLE_JSON_SUMMARY = copy.deepcopy(SEARCH_SUMMARY)
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 TEST_SEARCH_REPORT_FILE = 'tests/unit/api/test-get-search-report.pdf'
 # testdata pattern is ({desc}, {roles}, {status}, {has_account}, {search_id}, {is_report})
 TEST_GET_DATA = [

--- a/ppr-api/tests/unit/api/test_searches.py
+++ b/ppr-api/tests/unit/api/test_searches.py
@@ -31,8 +31,8 @@ from ppr_api.resources.v1.searches import get_payment_details
 from ppr_api.services.authz import BCOL_HELP, COLIN_ROLE, PPR_ROLE, GOV_ACCOUNT_ROLE, STAFF_ROLE
 from tests.unit.services.utils import create_header, create_header_account
 
-MOCK_AUTH_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_PAY_URL = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
+MOCK_AUTH_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
 
 SAMPLE_JSON_DATA = copy.deepcopy(SEARCH_QUERY)
 # Valid test search criteria

--- a/ppr-api/tests/unit/api/test_utils.py
+++ b/ppr-api/tests/unit/api/test_utils.py
@@ -35,7 +35,7 @@ from tests.unit.utils.test_financing_validator import FINANCING
 from tests.unit.utils.test_registration_validator import AMENDMENT_VALID
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
 # testdata pattern is ({description}, {account id}, {has name})
 TEST_USER_ORGS_DATA_JSON = [
     ('Valid no account', None, True),

--- a/ppr-api/tests/unit/models/test_utils.py
+++ b/ppr-api/tests/unit/models/test_utils.py
@@ -207,6 +207,12 @@ TEST_DATA_VALID_CL = [
     (1, False),
     (-1, True),
 ]
+# testdata pattern is (today_offset, valid)
+TEST_DATA_TRANSITION_RL = [
+    (None, False),
+    (1, False),
+    (-1, True),
+]
 
 
 @pytest.mark.parametrize('registration_ts,offset,expiry_ts', TEST_DATA_EXPIRY)
@@ -583,6 +589,19 @@ def test_cl_enabled(session, today_offset, valid):
         session.add(reg_type)
         session.commit()
     test_valid = model_utils.is_cl_enabled()
+    assert test_valid == valid
+
+
+@pytest.mark.parametrize('today_offset,valid', TEST_DATA_TRANSITION_RL)
+def test_rl_transition(session, today_offset, valid):
+    """Assert that checking a CL act timestamp for an RL amendment/renewal tranistion works as expected."""
+    if today_offset:
+        now_offset = model_utils.now_ts_offset(today_offset, True)
+        reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
+        reg_type.act_ts = now_offset
+        session.add(reg_type)
+        session.commit()
+    test_valid = model_utils.is_rl_transition()
     assert test_valid == valid
 
 

--- a/ppr-api/tests/unit/services/test_authorization.py
+++ b/ppr-api/tests/unit/services/test_authorization.py
@@ -23,8 +23,8 @@ from ppr_api.services import authz
 from tests.unit.services.utils import helper_create_jwt
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/auth/api/v1/'
-MOCK_URL = 'https://bcregistry-bcregistry-mock.apigee.net/auth/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
+MOCK_URL = 'https://test.api.connect.gov.bc.ca/auth/api/v1/'
 
 # testdata pattern is ({description}, {account id}, {valid})
 TEST_SBC_DATA = [

--- a/ppr-api/tests/unit/services/test_payment.py
+++ b/ppr-api/tests/unit/services/test_payment.py
@@ -31,8 +31,8 @@ from ppr_api.services.authz import PPR_ROLE
 from tests.unit.services.utils import helper_create_jwt
 
 
-MOCK_URL_NO_KEY = 'https://bcregistry-bcregistry-mock.apigee.net/mockTarget/pay/api/v1/'
-MOCK_URL = 'https://bcregistry-bcregistry-mock.apigee.net/pay/api/v1/'
+MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
+MOCK_URL = 'https://test.api.connect.gov.bc.ca/pay/api/v1/'
 PAY_DETAILS_SEARCH = {
     'label': 'Search by SERIAL_NUMBER',
     'value': '123456789'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25900

*Description of changes:*
- Add logic to conditionally transition RL registrations to CL on the completion of renewal and amendment registrations.
- Update RL renewal and amendment data validation. 
- Update unit tests.
- Update unit test gateway URL references to use the new GCP gateway.
- Example reports attached to the ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
