### PR TITLE
Reset PPR reg number generator from 999***Q to 100000R

### DIFF
--- a/ppr-api/migrations/versions/0001_rebase_2024-10.py
+++ b/ppr-api/migrations/versions/0001_rebase_2024-10.py
@@ -30,7 +30,7 @@ def upgrade():
     # ### Manually create sequences and add them to pk columns. ###
     # PPR sequences
     op.execute(CreateSequence(Sequence('document_number_seq', start=100000, increment=1)))
-    op.execute(CreateSequence(Sequence('registration_num_q_seq', start=100000, increment=1)))
+    op.execute(CreateSequence(Sequence('registration_num_r_seq', start=100000, increment=1)))
     op.execute(CreateSequence(Sequence('account_bcol_id_seq', start=1, increment=1)))
     op.execute(CreateSequence(Sequence('address_id_seq', start=1, increment=1)))
     op.execute(CreateSequence(Sequence('code_branch_id_seq', start=7162, increment=1, minvalue=7162, maxvalue=8999)))
@@ -3589,7 +3589,7 @@ def downgrade():
 
     # Manually added drop sequence commands ###
     op.execute(DropSequence(Sequence('document_number_seq')))
-    op.execute(DropSequence(Sequence('registration_num_q_seq')))
+    op.execute(DropSequence(Sequence('registration_num_r_seq')))
     op.execute(DropSequence(Sequence('account_bcol_id_seq')))
     op.execute(DropSequence(Sequence('address_id_seq')))
     op.execute(DropSequence(Sequence('code_branch_id_seq')))

--- a/ppr-api/migrations/versions/0001_rebase_2024-10.py
+++ b/ppr-api/migrations/versions/0001_rebase_2024-10.py
@@ -1032,7 +1032,7 @@ def upgrade():
     public_get_registration_num = PGFunction(
         schema="public",
         signature="get_registration_num()",
-        definition="RETURNS VARCHAR\n    LANGUAGE plpgsql\n    AS\n    $$\n    BEGIN\n        RETURN trim(to_char(nextval('registration_num_q_seq'), '000000')) || 'Q';\n    END\n    ; \n    $$"
+        definition="RETURNS VARCHAR\n    LANGUAGE plpgsql\n    AS\n    $$\n    BEGIN\n        RETURN trim(to_char(nextval('registration_num_r_seq'), '000000')) || 'R';\n    END\n    ; \n    $$"
     )
     op.create_entity(public_get_registration_num)
 
@@ -3414,7 +3414,7 @@ def downgrade():
     public_get_registration_num = PGFunction(
         schema="public",
         signature="get_registration_num()",
-        definition="RETURNS VARCHAR\n    LANGUAGE plpgsql\n    AS\n    $$\n    BEGIN\n        RETURN trim(to_char(nextval('registration_num_q_seq'), '000000')) || 'Q';\n    END\n    ; \n    $$"
+        definition="RETURNS VARCHAR\n    LANGUAGE plpgsql\n    AS\n    $$\n    BEGIN\n        RETURN trim(to_char(nextval('registration_num_r_seq'), '000000')) || 'R';\n    END\n    ; \n    $$"
     )
     op.drop_entity(public_get_registration_num)
 

--- a/ppr-api/src/database/postgres_functions/get_registration_num.py
+++ b/ppr-api/src/database/postgres_functions/get_registration_num.py
@@ -2,8 +2,8 @@
 from alembic_utils.pg_function import PGFunction
 
 # Assets 19027
-# Update database function to generate registration numbers: roll over 99****P to 100000Q
-# CREATE SEQUENCE registration_num_q_seq INCREMENT 1 START 100000;
+# Update database function to generate registration numbers: roll over 99****Q to 100000R
+# CREATE SEQUENCE registration_num_r_seq INCREMENT 1 START 100000;
 get_registration_num = PGFunction(
     schema="public",
     signature="get_registration_num()",
@@ -13,7 +13,7 @@ get_registration_num = PGFunction(
     AS
     $$
     BEGIN
-        RETURN trim(to_char(nextval('registration_num_q_seq'), '000000')) || 'Q';
+        RETURN trim(to_char(nextval('registration_num_r_seq'), '000000')) || 'R';
     END
     ; 
     $$;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26255

*Description of changes:*
- Rollover the PPR registration number generator to 100000R before it reaches 1000000Q

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
