### PR TITLE
PPR API omit debtor email addresses.

### DIFF
--- a/ppr-api/src/ppr_api/models/party.py
+++ b/ppr-api/src/ppr_api/models/party.py
@@ -151,7 +151,10 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
                 cp_address = self.address.json
                 party["address"] = cp_address
 
-            if self.email_id:
+            if self.email_id and self.party_type not in (
+                Party.PartyTypes.DEBTOR_COMPANY.value,
+                Party.PartyTypes.DEBTOR_INDIVIDUAL.value,
+            ):
                 party["emailAddress"] = self.email_id
 
             if self.birth_date:
@@ -242,7 +245,10 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
                 if json_data["personName"].get("middle"):
                     party.middle_initial = json_data["personName"]["middle"].strip().upper()
 
-            if json_data.get("emailAddress"):
+            if json_data.get("emailAddress") and party_type not in (
+                Party.PartyTypes.DEBTOR_COMPANY.value,
+                Party.PartyTypes.DEBTOR_INDIVIDUAL.value,
+            ):
                 party.email_id = json_data["emailAddress"]
 
             party.address = Address.create_from_json(json_data["address"])


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26960

*Description of changes:*
- Do not save debtor email with new registrations.
- Do not return existing debtor email addresses in API registration and search responses.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
