### PR TITLE
Staff PPR and MHR reg table add account ID

### DIFF
--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -80,6 +80,7 @@ from mhr_api.services.authz import (
     MANUFACTURER_GROUP,
     QUALIFIED_USER_GROUP,
     STAFF_ROLE,
+    is_staff_account,
 )
 from mhr_api.utils.logging import logger
 
@@ -904,10 +905,15 @@ def __build_summary(row, account_id: str, staff: bool, add_in_user_list: bool = 
 
 def __get_report_path(account_id: str, staff: bool, summary: dict, row, timestamp) -> dict:
     """Derive the report download path if applicable."""
-    reg_account_id: str = str(row[15])
+    reg_account_id: str = str(row[15]) if row[15] else ""
     doc_storage_url: str = str(row[19]) if row[19] else ""
     rep_count: int = int(row[24])
     summary["legacy"] = rep_count <= 0
+    if is_staff_account(account_id):
+        if reg_account_id != "0":
+            summary["accountId"] = reg_account_id
+        else:
+            summary["accountId"] = "N/A"
     # To be consistent with PPR, allow registries staff to generate reports for legacy registrations
     # if rep_count > 0 and (staff or account_id == reg_account_id) and \
     if (staff or (rep_count > 0 and account_id == reg_account_id)) and (

--- a/mhr-api/tests/unit/models/test_registration_utils.py
+++ b/mhr-api/tests/unit/models/test_registration_utils.py
@@ -449,7 +449,8 @@ def test_account_reg_filter_multiple(session, account_id, collapse, start_value,
                          TEST_QUERY_FILTER_DATA)
 def test_find_account_filter(session, account_id, collapse, filter_name, filter_value, mhr_numbers, expected_clause):
     """Assert that account registration query with an order by clause is as expected."""
-    params: AccountRegistrationParams = AccountRegistrationParams(account_id=account_id,
+    test_account = "ppr_staff" if filter_value == "'000903'" else account_id
+    params: AccountRegistrationParams = AccountRegistrationParams(account_id=test_account,
                                                                   collapse=collapse,
                                                                   sbc_staff=False)
     if filter_name == reg_utils.REG_TS_PARAM:
@@ -484,3 +485,7 @@ def test_find_account_filter(session, account_id, collapse, filter_name, filter_
         assert registration['path'] is not None
         assert registration['documentId'] is not None
         assert not registration.get('inUserList')
+        if test_account == "ppr_staff":
+            assert registration.get("accountId")
+        else:
+            assert not registration.get("accountId")

--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -18,7 +18,7 @@
 from sqlalchemy.sql import text
 
 from ppr_api.models import utils as model_utils
-from ppr_api.services.authz import is_all_staff_account
+from ppr_api.services.authz import is_all_staff_account, is_staff_account
 from ppr_api.utils.logging import logger
 
 from .db import db
@@ -463,7 +463,11 @@ def __build_account_reg_result(
         else:
             result["transitioned"] = False
     if "accountId" in result:
-        del result["accountId"]  # Only use this for report access checking.
+        if is_staff_account(params.account_id):
+            if result.get("accountId", "0") == "0":
+                result["accountId"] = "N/A"
+        else:
+            del result["accountId"]  # Only use this for report access checking.
     return result
 
 

--- a/ppr-api/src/ppr_api/resources/v1/financing_statements.py
+++ b/ppr-api/src/ppr_api/resources/v1/financing_statements.py
@@ -644,13 +644,7 @@ def post_account_registrations(registration_num: str):
             and not AccountBcolId.crown_charge_account(account_id)
         ):
             return resource_utils.cc_forbidden_error_response(account_id)
-        if registration["accountId"] not in (account_id, account_id + "_R"):
-            extra_registration = UserExtraRegistration(account_id=account_id, registration_number=base_reg_num)
-            extra_registration.save()
-        del registration["accountId"]
-        del registration["existsCount"]
-        if "inUserList" in registration:
-            del registration["inUserList"]
+        registration = add_account_reg_update(registration, account_id, base_reg_num)
         return registration, HTTPStatus.CREATED
     except DatabaseException as db_exception:
         return resource_utils.db_exception_response(
@@ -688,7 +682,11 @@ def get_account_registrations(registration_num: str):
             and not AccountBcolId.crown_charge_account(account_id)
         ):
             return resource_utils.cc_forbidden_error_response(account_id)
-        del registration["accountId"]
+        if is_staff_account(account_id):
+            if registration.get("accountId", "0") == "0":
+                registration["accountId"] = "N/A"
+        else:
+            del registration["accountId"]
         del registration["existsCount"]
         return registration, HTTPStatus.OK
     except DatabaseException as db_exception:
@@ -866,3 +864,20 @@ def post_reg_report_callback(registration_id: int):
             HTTPStatus.INTERNAL_SERVER_ERROR,
             str(default_err),
         )
+
+
+def add_account_reg_update(registration: dict, account_id: str, base_reg_num: str) -> dict:
+    """Update the response registration, conditionally create extra registration record."""
+    if registration["accountId"] not in (account_id, account_id + "_R"):
+        extra_registration = UserExtraRegistration(account_id=account_id, registration_number=base_reg_num)
+        extra_registration.save()
+    if is_staff_account(account_id):
+        if registration.get("accountId", "0") == "0":
+            registration["accountId"] = "N/A"
+    else:
+        del registration["accountId"]
+    if "existsCount" in registration:
+        del registration["existsCount"]
+    if "inUserList" in registration:
+        del registration["inUserList"]
+    return registration


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27009

*Description of changes:*
PPR Changes conditionally include for BC Registries staff the registration account ID.
- Include in response when fetching a registration to add to the table: GET /ppr/api/v1/financing-statements/registrations/{reg_number} 
- Include in response when adding a registrations to the table: POST /ppr/api/v1/financing-statements/registrations/{reg_number} 
- Include in response when fetching account list of registrations: GET /ppr/api/v1/financing-statements/registrations

MHR Changesconditionally include for BC Registries staff the registration account ID.
- Include in response when fetching a registration to add to the table: GET /mhr/api/v1/other-registrations/{mhr_number}
- Include in response when adding a registrations to the table: POST /mhr/api/v1/other-registrations/{mhr_number}
- Include in response when fetching account list of registrations: GET /mhr/api/v1/registrations 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
