### PR TITLE
Assets Reg-Table: Account Id

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "private": true,
   "appName": "Assets UI",
   "sbcName": "SBC Common Components",

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -831,7 +831,7 @@ export default defineComponent({
                     @click="clearFilters()"
                   >
                     Clear Filters
-                    <v-icon class="pl-1 pt-1">
+                    <v-icon size="18" class="pl-3 pt-1">
                       mdi-close
                     </v-icon>
                   </v-btn>

--- a/ppr-ui/src/components/tables/RegistrationTable.vue
+++ b/ppr-ui/src/components/tables/RegistrationTable.vue
@@ -824,10 +824,10 @@ export default defineComponent({
                   />
                   <v-btn
                     v-if="header.value === 'actions' && headers.length > 1 && tableFiltersActive"
-                    class="clear-filters-btn registration-action ma-0 px-0 pl-6 pt-4"
+                    class="registration-action ma-0"
                     color="primary"
                     :ripple="false"
-                    variant="plain"
+                    variant="outlined"
                     @click="clearFilters()"
                   >
                     Clear Filters

--- a/ppr-ui/src/components/tables/common/TableRow.vue
+++ b/ppr-ui/src/components/tables/common/TableRow.vue
@@ -893,8 +893,8 @@ export default defineComponent({
       v-if="inSelectedHeaders('registeringName')"
       :class="isChild || item.expanded ? 'border-left': ''"
     >
-      <span v-if="item.registeringName">{{ getRegisteringName(item.registeringName) }}</span>
-      <span v-else>{{ item.username || 'N/A' }}</span>
+      <span v-if="item.registeringName">{{ item.accountId }}<br>{{ getRegisteringName(item.registeringName) }}</span>
+      <span v-else>{{ item.accountId }}<br>{{ item.username || 'N/A' }}</span>
     </td>
     <td
       v-if="inSelectedHeaders('registeringParty')"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26734

*Description of changes:*
- Update clear filters style
- Include account id in the Username or Registered By columns (Mhr or Ppr)
- Api response returns ppr-staff to protect the staff users account id, if they were the completing party.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
