### PR TITLE
PPR API process credit card payments

### DIFF
--- a/ppr-api/migrations/versions/0001_rebase_2024-10.py
+++ b/ppr-api/migrations/versions/0001_rebase_2024-10.py
@@ -1252,7 +1252,9 @@ def upgrade():
         { 'event_tracking_type': 'EMAIL_REPORT', 'event_tracking_desc': 'Email delivery of report.' },
         { 'event_tracking_type': 'REGISTRATION_REPORT', 'event_tracking_desc': 'Registration Verification Statement generation and storage.' },
         { 'event_tracking_type': 'MHR_REG_REPORT', 'event_tracking_desc': 'MHR registration report generation and storage.' },
-        { 'event_tracking_type': 'REG_HIST_JOB', 'event_tracking_desc': 'Job to updated account IDs when registrations become historical.' }
+        { 'event_tracking_type': 'REG_HIST_JOB', 'event_tracking_desc': 'Job to updated account IDs when registrations become historical.' },
+        { 'event_tracking_type': 'PPR_PAYMENT', 'event_tracking_desc': 'PPR registration payment status (credit card).' },
+        { 'event_tracking_type': 'MHR_PAYMENT', 'event_tracking_desc': 'MHR registration payment status (credit card).' }
       ]
     )
     op.bulk_insert(securities_act_type,

--- a/ppr-api/pyproject.toml
+++ b/ppr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ppr-api"
-version = "1.3.6"
+version = "1.3.7"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/ppr-api/src/ppr_api/models/event_tracking.py
+++ b/ppr-api/src/ppr_api/models/event_tracking.py
@@ -32,6 +32,7 @@ class EventTracking(db.Model):  # pylint: disable=too-many-instance-attributes
         SURFACE_MAIL = "SURFACE_MAIL"
         EMAIL_REPORT = "EMAIL_REPORT"
         REGISTRATION_REPORT = "REGISTRATION_REPORT"
+        PPR_PAYMENT = "PPR_PAYMENT"
 
     __tablename__ = "event_tracking"
 

--- a/ppr-api/src/ppr_api/models/registration.py
+++ b/ppr-api/src/ppr_api/models/registration.py
@@ -177,6 +177,8 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes, t
     )
 
     document_number: str = None
+    # Use for pending payments
+    reg_json = None
 
     @property
     def json(self) -> dict:
@@ -733,7 +735,6 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes, t
 
         if "clientReferenceId" in json_data:
             registration.client_reference_id = json_data["clientReferenceId"]
-
         # Create or update draft.
         draft = Registration.find_draft(json_data, registration.registration_type_cl, reg_type)
         reg_vals = Registration.get_generated_values(draft)
@@ -862,7 +863,6 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes, t
                     and not eval_party.registration_id_end
                 ):
                     party = eval_party
-
         return party
 
     @staticmethod

--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -454,6 +454,10 @@ def __build_account_reg_result(
     result["legacy"] = result.get("accountId") == "0"
     if model_utils.is_financing(reg_class) and not api_filter:
         result["expand"] = False
+        if params.from_ui:
+            status: str = str(row[17])
+            if status and status == "L":
+                result["paymentPending"] = True
     result = set_path(params, result, reg_num, base_reg_num, int(row[15]))
     result = update_summary_optional(result, params.account_id, params.sbc_staff)
     if result["registrationType"] == RegistrationTypes.CL.value:

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -442,7 +442,8 @@ QUERY_ACCOUNT_DRAFTS_DATE_CLAUSE = """
 
 QUERY_ACCOUNT_DRAFTS_BASE = """
 SELECT document_number, create_ts, registration_type, registration_type_cl, registration_desc, base_reg_num, draft_type,
-       last_update_ts, client_reference_id, registering_party, secured_party, registering_name, account_id
+       last_update_ts, client_reference_id, registering_party, secured_party, registering_name, account_id,
+       (SELECT d.user_id FROM drafts d WHERE d.id = adv.id) AS user_id
   FROM account_draft_vw adv
  WHERE account_id = :query_account
    AND NOT EXISTS (SELECT r.draft_id FROM registrations r WHERE r.account_id = adv.account_id AND r.draft_id = adv.id)
@@ -465,7 +466,8 @@ SELECT COUNT(id) AS reg_count
 QUERY_ACCOUNT_BASE_REG_BASE = """
 SELECT registration_number, registration_ts, registration_type, registration_type_cl, account_id,
        registration_desc, base_reg_number, state, expire_days, last_update_ts, registering_party,
-       secured_party, client_reference_id, registering_name, orig_account_id, pending_count, vehicle_count
+       secured_party, client_reference_id, registering_name, orig_account_id, pending_count, vehicle_count,
+       (SELECT r.ver_bypassed FROM registrations r WHERE r.id = arv.registration_id) as locked_status
   FROM account_registration_vw arv
  WHERE arv.account_id = :query_account
    AND arv.registration_type_cl IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')

--- a/ppr-api/src/ppr_api/models/vehicle_collateral.py
+++ b/ppr-api/src/ppr_api/models/vehicle_collateral.py
@@ -101,10 +101,9 @@ class VehicleCollateral(db.Model):  # pylint: disable=too-many-instance-attribut
         collateral = {"vehicleId": self.id, "type": self.vehicle_type}
         if self.year:
             collateral["year"] = self.year
-        if self.make:
-            collateral["make"] = self.make
-        if self.model:
-            collateral["model"] = self.model
+        # Conditionally set empty to pass schema validation when removing.
+        collateral["make"] = self.make if self.make else ""
+        collateral["model"] = self.model if self.model else ""
         if self.serial_number:
             collateral["serialNumber"] = self.serial_number
         if self.mhr_number:

--- a/ppr-api/src/ppr_api/resources/cc_payment_utils.py
+++ b/ppr-api/src/ppr_api/resources/cc_payment_utils.py
@@ -1,0 +1,305 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper methods for saving draft and registration info when payment is by credit card."""
+from http import HTTPStatus
+
+from sqlalchemy.sql import text
+
+from ppr_api.models import (
+    CourtOrder,
+    Draft,
+    EventTracking,
+    FinancingStatement,
+    GeneralCollateral,
+    Party,
+    Registration,
+    SecuritiesActNotice,
+    TrustIndenture,
+    VehicleCollateral,
+    db,
+    registration_utils,
+)
+from ppr_api.models import utils as model_utils
+from ppr_api.models.draft import DRAFT_PAY_PENDING_PREFIX
+from ppr_api.models.registration import ACCOUNT_DRAFT_USED_SUFFIX, MiscellaneousTypes
+from ppr_api.resources.financing_utils import save_rl_transition
+from ppr_api.utils.logging import logger
+
+DRAFT_QUERY_PKEYS = """
+select get_draft_document_number() AS doc_num,
+       nextval('draft_id_seq') AS draft_id
+"""
+REG_STATUS_LOCKED = "L"
+TRACKING_MESSAGES = {
+    "00": "00: default credit card payment update error for invoice id={invoice_id}.",
+    "01": "01: credit card payment set up complete for invoice id={invoice_id}.",
+    "02": "02: credit card payment update set up error for invoice id={invoice_id}.",
+    "03": "03: credit card payment update error no draft found for invoice id={invoice_id}.",
+    "04": "04: credit card payment update error no registration for invoice id={invoice_id}.",
+    "05": "05: credit card payment update pay status CANCELLED for invoice id={invoice_id}.",
+    "09": "09: credit card payment completed successfully for invoice id={invoice_id}.",
+    "10": "10: create registration successful for cc payment invoice id={invoice_id}.",
+}
+
+
+def track_event(code: str, invoice_id: str, status_code: int, message: str = None):
+    """Capture a cc payment event in the event tracking table."""
+    msg: str = TRACKING_MESSAGES[code].format(invoice_id=invoice_id)
+    if message:
+        msg += " " + message
+    if status_code not in (HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.ACCEPTED):
+        logger.error(msg)
+    else:
+        logger.info(msg)
+    EventTracking.create(int(invoice_id), EventTracking.EventTrackingTypes.PPR_PAYMENT, status_code, msg)
+    return msg
+
+
+def create_new_draft(json_data: dict, registration_class: str, base_reg_num: str = None) -> Draft:
+    """Get db generated identifiers for a new MHR draft record.
+
+    Get draft_number and draft ID.
+    """
+    draft: Draft = Draft()
+    draft.draft = json_data
+    draft.account_id = json_data.get("accountId")
+    draft.create_ts = model_utils.now_ts()
+    draft.registration_type_cl = registration_class
+    if draft.registration_type_cl in (model_utils.REG_CLASS_AMEND, model_utils.REG_CLASS_AMEND_COURT):
+        json_data = model_utils.cleanup_amendment(json_data)
+        draft.registration_type = model_utils.amendment_change_type(json_data)
+        if draft.registration_type == model_utils.REG_TYPE_AMEND_COURT:
+            draft.registration_type_cl = model_utils.REG_CLASS_AMEND_COURT
+    elif draft.registration_type_cl == model_utils.REG_CLASS_RENEWAL:
+        draft.registration_type = model_utils.REG_TYPE_RENEWAL
+    elif draft.registration_type_cl == model_utils.REG_CLASS_DISCHARGE:
+        draft.registration_type = model_utils.REG_TYPE_DISCHARGE
+    if base_reg_num:
+        draft.registration_number = base_reg_num
+    query = text(DRAFT_QUERY_PKEYS)
+    result = db.session.execute(query)
+    row = result.first()
+    draft.document_number = DRAFT_PAY_PENDING_PREFIX + str(row[0])
+    draft.id = int(row[1])
+    logger.info(f"New draft created id={draft.id} doc number={draft.document_number}")
+    return draft
+
+
+def save_change_cc_draft(base_reg: Registration, json_data: dict, new_reg: Registration) -> Registration:
+    """
+    Change registration with credit card payment create/update draft. Returns an unsaved registration
+    with response JSON.
+
+    Args:
+        base_reg (Registration): current registration being updated.
+        json_data (dict): Request payload updated with some extra registration information (payment).
+        registration (Registration): Minimal registration with registration type and class.
+    """
+    # Create or update draft.
+    draft: Draft = None
+    if json_data.get("documentId"):
+        draft = Draft.find_by_document_number(json_data["documentId"].strip(), False)
+    json_data["paymentPending"] = True
+    json_data["baseRegistrationNumber"] = base_reg.registration_num
+    json_data["registrationType"] = new_reg.registration_type
+    if draft:
+        draft.draft = json_data
+        draft.document_number = DRAFT_PAY_PENDING_PREFIX + draft.document_number
+    else:
+        draft = create_new_draft(json_data, new_reg.registration_type_cl, base_reg.registration_num)
+    draft.update_ts = model_utils.now_ts()
+    draft.user_id = json_data["payment"].get("invoiceId")
+    draft.registration_number = base_reg.registration_num
+    draft.save()
+    new_reg.draft = draft
+    new_reg.reg_json = json_data
+    # Lock the base registration here:
+    base_reg.ver_bypassed = REG_STATUS_LOCKED
+    logger.info(f"Locking base reg# {base_reg.registration_num}.")
+    base_reg.save()
+    track_event("01", int(json_data["payment"].get("invoiceId")), HTTPStatus.OK, "Change registration draft saved.")
+    return new_reg
+
+
+def save_new_cc_draft(json_data: dict, new_reg: Registration) -> Registration:
+    """
+    New registration with credit card payment create/update draft. Returns an unsaved registration
+    with response JSON.
+
+    Args:
+        json_data (dict): Request payload updated with some extra registration information (payment).
+        registration (Registration): Minimal registration with registration type and class.
+    """
+    # Create or update draft.
+    draft: Draft = None
+    if json_data.get("documentId"):
+        draft = Draft.find_by_document_number(json_data["documentId"].strip(), False)
+    json_data["paymentPending"] = True
+    if draft:
+        draft.draft = json_data
+        draft.document_number = DRAFT_PAY_PENDING_PREFIX + draft.document_number
+    else:
+        json_data["registrationType"] = new_reg.registration_type
+        draft = create_new_draft(json_data, new_reg.registration_type_cl, None)
+    draft.registration_type = new_reg.registration_type
+    draft.update_ts = model_utils.now_ts()
+    draft.user_id = json_data["payment"].get("invoiceId")
+    draft.save()
+    new_reg.draft = draft
+    new_reg.reg_json = json_data
+    statement: FinancingStatement = FinancingStatement()
+    statement.registration = [new_reg]
+    track_event("01", int(json_data["payment"].get("invoiceId")), HTTPStatus.OK, "New registration draft saved.")
+    return statement
+
+
+def create_new_statement(draft: Draft) -> FinancingStatement:
+    """Create new financing statement base registration from the draft."""
+    json_data: dict = draft.draft
+    statement: FinancingStatement = FinancingStatement(state_type=model_utils.STATE_ACTIVE)
+    statement.parties = Party.create_from_financing_json(json_data, None)
+    new_reg: Registration = create_financing_registration(draft)
+    statement.registration = [new_reg]
+    statement.life = statement.registration[0].life
+    if new_reg.registration_type == model_utils.REG_TYPE_REPAIRER_LIEN:
+        statement.expire_date = model_utils.expiry_dt_repairer_lien()
+    elif statement.life and statement.life != model_utils.LIFE_INFINITE:
+        statement.expire_date = model_utils.expiry_dt_from_years(statement.life)
+
+    if new_reg.registration_type == model_utils.REG_TYPE_OTHER and "otherTypeDescription" in json_data:
+        statement.crown_charge_other = json_data["otherTypeDescription"]
+
+    statement.trust_indenture = TrustIndenture.create_from_json(json_data, new_reg.id)
+    if "vehicleCollateral" in json_data:
+        statement.vehicle_collateral = VehicleCollateral.create_from_financing_json(json_data, new_reg.id)
+    if "generalCollateral" in json_data:
+        statement.general_collateral = GeneralCollateral.create_from_financing_json(json_data, new_reg.id)
+
+    for party in statement.parties:
+        party.registration_id = new_reg.id
+    statement.save()
+    logger.info(f"New fs reg id={new_reg.id} {new_reg.registration_type} #={new_reg.registration_num}")
+    return statement
+
+
+def create_change_registration(draft: Draft, statement: FinancingStatement) -> Registration:
+    """Create new change registration from the draft."""
+    registration: Registration = create_basic_registration(draft, statement)
+    json_data: dict = draft.draft
+    registration_id = registration.id
+    financing_reg_type = statement.registration[0].registration_type
+    if registration.registration_type_cl == model_utils.REG_CLASS_RENEWAL:
+        registration_utils.set_renewal_life(registration, json_data, financing_reg_type)
+    # Repairer's lien renewal or amendment can have court order information.
+    if (
+        registration.registration_type in (model_utils.REG_TYPE_AMEND_COURT, model_utils.REG_TYPE_RENEWAL)
+        and "courtOrderInformation" in json_data
+    ):
+        registration.court_order = CourtOrder.create_from_json(json_data["courtOrderInformation"], registration_id)
+    if registration.registration_type_cl in (
+        model_utils.REG_CLASS_AMEND,
+        model_utils.REG_CLASS_AMEND_COURT,
+        model_utils.REG_CLASS_CHANGE,
+    ):
+        # Possibly add vehicle collateral
+        registration.vehicle_collateral = VehicleCollateral.create_from_statement_json(
+            json_data, registration_id, registration.financing_id
+        )
+        # Possibly add general collateral
+        registration.general_collateral = GeneralCollateral.create_from_statement_json(
+            json_data, registration_id, registration.financing_id
+        )
+        # Possibly add/remove a trust indenture
+        if ("addTrustIndenture" in json_data and json_data["addTrustIndenture"]) or (
+            "removeTrustIndenture" in json_data and json_data["removeTrustIndenture"]
+        ):
+            registration.trust_indenture = TrustIndenture.create_from_amendment_json(
+                registration.financing_id, registration.id
+            )
+            if "removeTrustIndenture" in json_data and json_data["removeTrustIndenture"]:
+                registration.trust_indenture.trust_indenture = TrustIndenture.TRUST_INDENTURE_NO
+        if json_data.get("addSecuritiesActNotices") and financing_reg_type == MiscellaneousTypes.SECURITIES_NOTICE:
+            registration.securities_act_notices = SecuritiesActNotice.create_from_statement_json(
+                json_data, registration_id
+            )
+        # Close out deleted parties and collateral, trust indenture, and securities act notices.
+        Registration.delete_from_json(json_data, registration, statement)
+    registration.save()
+    save_rl_transition(registration.registration_type_cl, statement, registration.id)
+    logger.info(f"New reg id={registration.id} {registration.registration_type} #={registration.registration_num}")
+    return registration
+
+
+def create_basic_registration(draft: Draft, statement: FinancingStatement) -> Registration:
+    """Create new registration from the draft with common properties."""
+    json_data = draft.draft
+    registration: Registration = Registration.get_generated_values(draft)
+    registration.financing_id = statement.id
+    registration.financing_statement = statement
+    registration.account_id = draft.account_id
+    registration.user_id = json_data.get("username")
+    registration.registration_ts = model_utils.now_ts()
+    registration.pay_invoice_id = int(json_data["payment"].get("invoiceId"))
+    registration.pay_path = json_data["payment"].get("receipt")
+    registration.registration_type = draft.registration_type
+    registration.registration_type_cl = draft.registration_type_cl
+    registration.base_registration_num = draft.registration_number
+    registration_utils.set_registration_basic_info(registration, json_data, draft.registration_type_cl)
+    draft.draft = json_data
+    draft.account_id = draft.account_id + ACCOUNT_DRAFT_USED_SUFFIX
+    registration.draft = draft
+    # All registrations have at least one party (registering).
+    registration.parties = Party.create_from_statement_json(
+        json_data, registration.registration_type_cl, registration.financing_id
+    )
+    return registration
+
+
+def create_financing_registration(draft: Draft) -> Registration:
+    """Create new base registration from the draft with common properties."""
+    json_data = draft.draft
+    registration: Registration = Registration.get_generated_values(draft)
+    registration.account_id = draft.account_id
+    registration.user_id = json_data.get("username")
+    registration.registration_ts = model_utils.now_ts()
+    registration.pay_invoice_id = int(json_data["payment"].get("invoiceId"))
+    registration.pay_path = json_data["payment"].get("receipt")
+    registration.registration_type = draft.registration_type
+    registration.registration_type_cl = draft.registration_type_cl
+    registration.ver_bypassed = "Y"
+    if registration.registration_type == model_utils.REG_TYPE_REPAIRER_LIEN:
+        if "lienAmount" in json_data:
+            registration.lien_value = json_data["lienAmount"].strip()
+        if "surrenderDate" in json_data:
+            registration.surrender_date = model_utils.ts_from_date_iso_format(json_data["surrenderDate"])
+        registration.life = model_utils.REPAIRER_LIEN_YEARS
+    elif "lifeInfinite" in json_data and json_data["lifeInfinite"]:
+        registration.life = model_utils.LIFE_INFINITE
+    elif registration.registration_type_cl in (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC):
+        registration.life = model_utils.LIFE_INFINITE
+    elif registration.registration_type in (
+        model_utils.REG_TYPE_MARRIAGE_SEPARATION,
+        model_utils.REG_TYPE_TAX_MH,
+        model_utils.REG_TYPE_LAND_TAX_MH,
+    ):
+        registration.life = model_utils.LIFE_INFINITE
+    elif "lifeYears" in json_data:
+        registration.life = json_data["lifeYears"]
+    if "clientReferenceId" in json_data:
+        registration.client_reference_id = json_data["clientReferenceId"]
+    draft.account_id = draft.account_id + ACCOUNT_DRAFT_USED_SUFFIX
+    registration.draft = draft
+    if draft.registration_type == MiscellaneousTypes.SECURITIES_NOTICE and json_data.get("securitiesActNotices"):
+        registration = registration_utils.create_securities_act_notices(registration, json_data)
+    return registration

--- a/ppr-api/src/ppr_api/resources/v1/callbacks.py
+++ b/ppr-api/src/ppr_api/resources/v1/callbacks.py
@@ -21,17 +21,30 @@ from flask_cors import cross_origin
 from ppr_api.callback.document_storage.storage_service import DocumentTypes, GoogleStorageService
 from ppr_api.callback.utils.exceptions import ReportDataException, ReportException, StorageException
 from ppr_api.exceptions import DatabaseException
-from ppr_api.models import MailReport
+from ppr_api.models import Draft, FinancingStatement, MailReport, Registration
 from ppr_api.models import utils as model_utils
 from ppr_api.reports import get_callback_pdf
 from ppr_api.reports.v2.report_utils import ReportTypes
+from ppr_api.resources import cc_payment_utils
 from ppr_api.resources import utils as resource_utils
+from ppr_api.services.payment import StatusCodes
 from ppr_api.utils.logging import logger
 
 bp = Blueprint("CALLBACKS1", __name__, url_prefix="/api/v1/callbacks")  # pylint: disable=invalid-name
 START_TS_PARAM = "startDateTime"
 END_TS_PARAM = "endDateTime"
 JOB_ID_PARAM = "jobId"
+PAY_STATUS_MISSING_MSG = "Expected payment status missing in payload."
+PAY_STATUS_INVALID_MSG = "Payment status {pay_status} not an allowed value."
+PAY_CANCELLED_MSG = "Payment status cancelled/deleted: draft reverted."
+PAY_NO_REG_MSG = "Change no financing statement found for base reg num={reg_num}."
+PAY_REG_SUCCESS_MSG = "Registration created fs id={fs_id} reg_id={reg_id} reg num={reg_num}."
+ALLOWED_PAY_STATUS = [
+    StatusCodes.CANCELLED.value,
+    StatusCodes.COMPLETED.value,
+    StatusCodes.DELETED.value,
+    StatusCodes.PAID.value,
+]
 
 
 @bp.route("/mail-report", methods=["POST", "OPTIONS"])
@@ -116,6 +129,119 @@ def get_mail_list():
         return resource_utils.db_exception_response(db_exception, None, "GET callback mail reports list DB error.")
     except Exception as default_err:  # noqa: B902; return nicer default error
         return resource_utils.default_exception_response(default_err)
+
+
+@bp.route("/pay/<string:invoice_id>", methods=["POST", "OPTIONS"])
+@cross_origin(origin="*")
+def post_payment_callback(invoice_id: str):  # pylint: disable=too-many-return-statements
+    """Resource to complete a credit card payment request."""
+    try:
+        logger.info(f"Payment callback starting invoice id={invoice_id}.")
+        if invoice_id is None:
+            return resource_utils.path_param_error_response("invoice ID")
+        # Authenticate with request api key
+        if not resource_utils.valid_api_key(request):
+            return resource_utils.unauthorized_error_response("MHR pay callback invalid key.")
+        # Verify the payload pay api status:
+        request_json = request.get_json(silent=True)
+        pay_status: str = request_json.get("statusCode") if request_json else None
+        logger.info(f"pay callback request payload={request_json}")
+        if not pay_status:
+            return pay_callback_error("02", invoice_id, HTTPStatus.BAD_REQUEST, PAY_STATUS_MISSING_MSG)
+        elif pay_status not in ALLOWED_PAY_STATUS:
+            error_msg: str = PAY_STATUS_INVALID_MSG.format(pay_status=pay_status)
+            return pay_callback_error("02", invoice_id, HTTPStatus.BAD_REQUEST, error_msg)
+        draft: Draft = Draft.find_by_invoice_id(invoice_id)
+        if not draft:
+            return pay_callback_error("03", invoice_id, HTTPStatus.NOT_FOUND)
+        statement: FinancingStatement = None
+        if draft.registration_number:
+            statement = FinancingStatement.find_by_registration_number(
+                draft.registration_number, draft.account_id, True, True
+            )
+        if not statement and draft.registration_number:
+            error_msg: str = PAY_NO_REG_MSG.format(reg_num=draft.registration_number)
+            return pay_callback_error("04", invoice_id, HTTPStatus.NOT_FOUND, error_msg)
+        logger.info(f"Request valid for invoice id={invoice_id}, creating registration.")
+        cc_payment_utils.track_event("09", invoice_id, HTTPStatus.OK, None)
+        return complete_registration(draft, statement, request_json)
+    except DatabaseException as db_exception:
+        return resource_utils.db_exception_response(db_exception, None, "POST pay callback event")
+    except Exception as default_err:  # noqa: B902; return nicer default error
+        return pay_callback_error("00", invoice_id, HTTPStatus.INTERNAL_SERVER_ERROR, str(default_err))
+
+
+def pay_callback_error(code: str, key_id: int, status_code, message: str = None):
+    """Return the payment event listener callback error response based on the code."""
+    error: str = cc_payment_utils.track_event(code, key_id, status_code, message)
+    return resource_utils.error_response(status_code, error)
+
+
+def complete_registration(draft: Draft, statement: FinancingStatement, request_json: dict):
+    """Process the registration based on the payload status and draft registration type."""
+    invoice_id: str = draft.user_id
+    try:
+        if statement:
+            update_registration_status(statement.registration[0])
+        else:
+            logger.info("No existing financing statemen: unlock base registration skipped.")
+        status: str = request_json.get("statusCode")
+        reg_type: str = draft.registration_type
+        reg_class: str = draft.registration_type_cl
+        logger.info(f"Completing registration for pay status={status} reg type={reg_type} class={reg_class}")
+        if request_json.get("statusCode") in (StatusCodes.CANCELLED.value, StatusCodes.DELETED.value):
+            cc_payment_utils.track_event("05", draft.user_id, HTTPStatus.OK, PAY_CANCELLED_MSG)
+            return update_draft(draft)
+        new_reg: Registration = None
+        report_json: dict = None
+        report_type: str = ReportTypes.FINANCING_STATEMENT_REPORT.value
+        if reg_class == model_utils.REG_CLASS_RENEWAL:
+            new_reg: Registration = cc_payment_utils.create_change_registration(draft, statement)
+            report_json = new_reg.verification_json("renewalRegistrationNumber")
+        elif reg_class in (model_utils.REG_CLASS_AMEND, model_utils.REG_CLASS_AMEND_COURT):
+            new_reg: Registration = cc_payment_utils.create_change_registration(draft, statement)
+            resource_utils.queue_secured_party_verification(new_reg)
+            report_json = new_reg.verification_json("amendmentRegistrationNumber")
+        elif reg_class in (model_utils.REG_CLASS_PPSA, model_utils.REG_CLASS_MISC, model_utils.REG_CLASS_CROWN):
+            statement: FinancingStatement = cc_payment_utils.create_new_statement(draft)
+            new_reg = statement.registration[0]
+            report_json = statement.json
+
+        resource_utils.enqueue_registration_report(new_reg, report_json, report_type)
+        msg = PAY_REG_SUCCESS_MSG.format(
+            fs_id=new_reg.financing_id, reg_id=new_reg.id, reg_num=new_reg.registration_num
+        )
+        cc_payment_utils.track_event("10", draft.user_id, HTTPStatus.OK, msg)
+        return update_draft(draft)
+    except Exception as default_err:  # noqa: B902; return nicer default error
+        return pay_callback_error("00", invoice_id, HTTPStatus.INTERNAL_SERVER_ERROR, str(default_err))
+
+
+def update_registration_status(base_reg: Registration):
+    """For a change registration unlock the home. Update the ."""
+    if base_reg and base_reg.ver_bypassed == cc_payment_utils.REG_STATUS_LOCKED:
+        base_reg.ver_bypassed = "N"
+        base_reg.save()
+        logger.info(f"Unlocked base_registration {base_reg.registration_num}")
+
+
+def update_draft(draft: Draft):
+    """Update the draft to post registration state instead of payment pending."""
+    draft_json = draft.draft
+    draft.user_id = draft_json.get("username", None)
+    if draft_json.get("username"):
+        del draft_json["username"]
+    if draft_json.get("accountId"):
+        del draft_json["accountId"]
+    if "paymentPending" in draft_json:
+        del draft_json["paymentPending"]
+    draft.draft = draft_json
+    doc_num: str = str(draft.document_number)
+    if doc_num.startswith(cc_payment_utils.DRAFT_PAY_PENDING_PREFIX):
+        draft.document_number = doc_num[1:]
+    draft.save()
+    logger.info(f"Updated draft id={draft.id} number={draft.document_number} userid={draft.user_id}")
+    return {}, HTTPStatus.OK
 
 
 def mail_callback_error(mail_report: MailReport, status_code: int = 500, message: str = None):

--- a/ppr-api/src/ppr_api/services/payment/client/__init__.py
+++ b/ppr-api/src/ppr_api/services/payment/client/__init__.py
@@ -95,15 +95,17 @@ PAYMENT_CERTIFIED_STAFF_SEARCH_REQUEST_TEMPLATE = {
 }
 
 PAYMENT_REFUND_TEMPLATE = {"reason": "Immediate transaction rollback."}
+CC_REQUEST_PAYMENT_INFO = {"methodOfPayment": "DIRECT_PAY"}
+EXCLUDED_CC_FILING_TYPES = ["SERCH", "SSRCH", "PPRCD"]
 
 PATH_PAYMENT = "payment-requests"
 PATH_REFUND = "payment-requests/{invoice_id}/refunds"
 PATH_INVOICE = "payment-requests/{invoice_id}"
 PATH_RECEIPT = "payment-requests/{invoice_id}/receipts"
 
-VALID_RESPONSE_STATUS = [StatusCodes.PAID.value, StatusCodes.APPROVED.value]
-VALID_RESPONSE_STATUS_INTERNAL = [StatusCodes.PAID.value, StatusCodes.APPROVED.value, StatusCodes.COMPLETED.value]
-VALID_RESPONSE_STATUS_CC = [StatusCodes.PAID.value, StatusCodes.CREATED.value]
+VALID_PAYMENT_METHOD_CC = [PaymentMethods.CC.value, PaymentMethods.DIRECT_PAY.value]
+VALID_RESPONSE_STATUS = [StatusCodes.PAID.value, StatusCodes.APPROVED.value, StatusCodes.COMPLETED.value]
+VALID_RESPONSE_STATUS_CC = StatusCodes.CREATED
 INVALID_STATUS_JSON = {"status_code": HTTPStatus.PAYMENT_REQUIRED}
 INVALID_STATUS_MSG = "Payment request failed: payment method {pay_method} returned invalid status {invoice_status}."
 
@@ -169,12 +171,27 @@ class BaseClient:
         self.jwt = jwt
         self.account_id = account_id
         self.api_key = api_key
+        self.cc_payment = False
         if details and "label" in details and "value" in details:
             self.detail_label = details["label"]
             self.detail_value = details["value"]
         else:
             self.detail_label = None
             self.detail_value = None
+        if details and "ccPayment" in details:
+            self.cc_payment = details.get("ccPayment")
+
+    def valid_payment_status(self, pay_method: str, pay_status: str, data: dict) -> bool:
+        """Verify the response status and payment method pair."""
+        if pay_method not in VALID_PAYMENT_METHOD_CC and pay_status in VALID_RESPONSE_STATUS:
+            return True
+        if pay_method in VALID_PAYMENT_METHOD_CC and pay_status == VALID_RESPONSE_STATUS_CC:
+            filing_type = data["filingInfo"]["filingTypes"][0].get("filingTypeCode")
+            if filing_type not in EXCLUDED_CC_FILING_TYPES:
+                return True
+            logger.error(f"Filing type {filing_type} not allowed for credit card payments.")
+        logger.error(f"Invalid response payload status code {pay_status} for payment method {pay_method}")
+        return False
 
     def call_api(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
@@ -214,26 +231,8 @@ class BaseClient:
             response_json = json.loads(response.text)
             pay_method: str = response_json.get("paymentMethod", "")
             invoice_status: str = response_json.get("statusCode", "")
-            if method != HttpVerbs.POST or (
-                pay_method
-                in (
-                    PaymentMethods.INTERNAL.value,
-                    PaymentMethods.DRAWDOWN.value,
-                    PaymentMethods.PAD.value,
-                    PaymentMethods.EJV.value,
-                )
-                and invoice_status == StatusCodes.COMPLETED.value
-            ):
-                return response_json
-            if pay_method != PaymentMethods.CC.value and invoice_status not in VALID_RESPONSE_STATUS:
+            if method == HttpVerbs.POST and not self.valid_payment_status(pay_method, invoice_status, data):
                 logger.error(f"Invalid response payload status code {invoice_status} for payment method {pay_method}")
-                msg: str = INVALID_STATUS_MSG.format(pay_method=pay_method, invoice_status=invoice_status)
-                error_json = INVALID_STATUS_JSON
-                error_json["type"] = pay_method
-                error_json["detail"] = msg
-                raise SBCPaymentException(msg, error_json)
-            if pay_method == PaymentMethods.CC.value and invoice_status not in VALID_RESPONSE_STATUS_CC:
-                logger.error(f"Invalid response payload status code {invoice_status} for CC payment")
                 msg: str = INVALID_STATUS_MSG.format(pay_method=pay_method, invoice_status=invoice_status)
                 error_json = INVALID_STATUS_JSON
                 error_json["type"] = pay_method
@@ -352,6 +351,18 @@ class SBCPaymentClient(BaseClient):
 
         return data
 
+    def update_payload_data(self, data: dict) -> dict:
+        """Explicitly set payment request as CC payment if requested."""
+        if self.cc_payment:
+            logger.info("Setting pay api payload payment method as CC.")
+            data["paymentInfo"] = CC_REQUEST_PAYMENT_INFO
+        if self.detail_label and self.detail_value:
+            data["details"][0]["label"] = self.detail_label
+            data["details"][0]["value"] = self.detail_value
+        else:
+            del data["details"]
+        return data
+
     def create_payment(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self, transaction_type, quantity=1, ppr_id=None, client_reference_id=None, processing_fee=None
     ):
@@ -359,30 +370,16 @@ class SBCPaymentClient(BaseClient):
         data = SBCPaymentClient.create_payment_data(
             transaction_type, quantity, ppr_id, client_reference_id, processing_fee
         )
-        if self.detail_label and self.detail_value:
-            data["details"][0]["label"] = self.detail_label
-            data["details"][0]["value"] = self.detail_value
-        else:
-            del data["details"]
+        data = self.update_payload_data(data)
         # logger.debug('create paymnent payload:')
         # logger.debug(json.dumps(data))
         invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data)
-        invoice_id = str(invoice_data["id"])
-        receipt_path = self.api_url.replace("https://", "")
-        receipt_path = receipt_path[receipt_path.find("/") : None] + PATH_RECEIPT.format(invoice_id=invoice_id)
-        # Return the pay reference to include in the API response.
-        pay_reference = {"invoiceId": invoice_id, "receipt": receipt_path}
-
-        return pay_reference
+        return SBCPaymentClient.build_pay_reference(invoice_data, self.api_url)
 
     def create_payment_staff_search(self, transaction_info, client_reference_id=None):
         """Submit a staff search payment request for the PPR API transaction."""
         data = SBCPaymentClient.create_payment_staff_search_data(transaction_info, client_reference_id)
-        if self.detail_label and self.detail_value:
-            data["details"][0]["label"] = self.detail_label
-            data["details"][0]["value"] = self.detail_value
-        else:
-            del data["details"]
+        data = self.update_payload_data(data)
         logger.debug("staff search create payment payload for account: " + self.account_id)
         logger.debug(json.dumps(data))
         invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
@@ -393,11 +390,7 @@ class SBCPaymentClient(BaseClient):
         data = SBCPaymentClient.create_payment_staff_registration_data(
             transaction_info, client_reference_id, processing_fee
         )
-        if self.detail_label and self.detail_value:
-            data["details"][0]["label"] = self.detail_label
-            data["details"][0]["value"] = self.detail_value
-        else:
-            del data["details"]
+        data = self.update_payload_data(data)
         logger.info("staff registration create payment payload: ")
         logger.info(json.dumps(data))
         invoice_data = self.call_api(HttpVerbs.POST, PATH_PAYMENT, data, include_account=True)
@@ -451,5 +444,10 @@ class SBCPaymentClient(BaseClient):
         receipt_path = receipt_path[receipt_path.find("/") : None] + PATH_RECEIPT.format(invoice_id=invoice_id)
         # Return the pay reference to include in the API response.
         pay_reference = {"invoiceId": invoice_id, "receipt": receipt_path}
-
+        if invoice_data.get("paymentMethod", "") in (PaymentMethods.CC.value, PaymentMethods.DIRECT_PAY.value):
+            logger.info(f"Setting up cc payment pay reference for invoice {invoice_id}.")
+            pay_reference["ccPayment"] = True
+            pay_reference["paymentActionRequired"] = invoice_data.get("isPaymentActionRequired")
+            # Replace with env var {PAYMENT_PORTAL_URL}
+            pay_reference["paymentPortalURL"] = "{PAYMENT_PORTAL_URL}/{invoice_id}/{return_URL}"
         return pay_reference

--- a/ppr-api/tests/unit/api/test_callback.py
+++ b/ppr-api/tests/unit/api/test_callback.py
@@ -21,8 +21,15 @@ from http import HTTPStatus
 
 import pytest
 from flask import current_app
+from registry_schemas.example_data.ppr import (
+    AMENDMENT_STATEMENT,
+    FINANCING_STATEMENT,
+    RENEWAL_STATEMENT,
+)
 
-from ppr_api.models import FinancingStatement, Registration
+from ppr_api.models import FinancingStatement, Registration, utils as model_utils
+from ppr_api.resources import cc_payment_utils, utils as resource_utils
+from ppr_api.resources.financing_utils import setup_cc_draft
 from ppr_api.resources.utils import get_payment_details, get_payment_details_financing, \
      get_payment_type_financing
 from ppr_api.services.authz import COLIN_ROLE, PPR_ROLE, STAFF_ROLE, BCOL_HELP, GOV_ACCOUNT_ROLE
@@ -32,6 +39,19 @@ from tests.unit.services.utils import create_header, create_header_account, crea
 
 MOCK_URL_NO_KEY = 'https://test.api.connect.gov.bc.ca/mockTarget/auth/api/v1/'
 MOCK_PAY_URL = 'https://test.api.connect.gov.bc.ca/mockTarget/pay/api/v1/'
+CC_PAYREF = {
+     "invoiceId": "88888888",
+     "receipt": "receipt",
+     "ccPayment": True,
+     "paymentActionRequired": True,
+     "paymentPortalURL": "{PAYMENT_PORTAL_URL}/{invoice_id}/{return_URL}"
+}
+PUB_SUB_PAYLOAD = {
+    "corpTypeCode": "PPR",
+    "id": "88888888",
+    "statusCode": "COMPLETED",
+    "filingIdentifier": ""
+}
 # testdata pattern is ({desc}, {status}, {registration_id}, {party_id})
 TEST_MAIL_CALLBACK_DATA = [
     ('Missing reg id', HTTPStatus.BAD_REQUEST, None, 9999999),
@@ -50,6 +70,17 @@ TEST_MAIL_LIST_DATA = [
     ('Valid start', HTTPStatus.OK, '2023-01-31T00:00:01-08:00', None),
     ('Valid start with job id', HTTPStatus.OK, '2023-01-31T00:00:01-08:00', None),
     ('Unauthorized', HTTPStatus.UNAUTHORIZED, None, None)
+]
+# testdata pattern is ({desc}, {status}, {draft_json}, {reg_num}, {fs_id}, {reg_class}, {invoice_id})
+TEST_PAY_CALLBACK_DATA = [
+    ('Valid new reg', HTTPStatus.OK, FINANCING_STATEMENT, None, None, model_utils.REG_CLASS_PPSA, "20000100"),
+    ('Valid amendment', HTTPStatus.OK, AMENDMENT_STATEMENT, "TEST0001", 200000000, model_utils.REG_CLASS_AMEND, "20000101"),
+    ('Valid renewal', HTTPStatus.OK, RENEWAL_STATEMENT, "TEST0005", 200000004, model_utils.REG_CLASS_RENEWAL, "20000102"),
+    ('Invalid no key', HTTPStatus.UNAUTHORIZED, FINANCING_STATEMENT, None, None, model_utils.REG_CLASS_PPSA, "20000100"),
+    ('Invalid missing payload', HTTPStatus.BAD_REQUEST, FINANCING_STATEMENT, None, None, model_utils.REG_CLASS_PPSA, "20000100"),
+    ('Invalid missing status', HTTPStatus.BAD_REQUEST, FINANCING_STATEMENT, None, None, model_utils.REG_CLASS_PPSA, "20000100"),
+    ('Invalid status', HTTPStatus.BAD_REQUEST, FINANCING_STATEMENT, None,  None, model_utils.REG_CLASS_PPSA, "20000100"),
+    ('Invalid used', HTTPStatus.OK, FINANCING_STATEMENT, None,  None, model_utils.REG_CLASS_PPSA, "20000100"),
 ]
 
 
@@ -121,6 +152,114 @@ def test_list_mail_report(session, client, jwt, desc, status, start_ts, end_ts):
             assert result.get('docStorageRef')
             if desc == 'Valid start with job id':
                 assert result.get('jobId')
+
+
+@pytest.mark.parametrize('desc,status,draft_json,reg_num,fs_id,reg_class,invoice_id', TEST_PAY_CALLBACK_DATA)
+def test_pay_callback(session, client, jwt, desc, status, draft_json, reg_num, fs_id, reg_class, invoice_id):
+    """Assert that creating a new cc payment registration from a callback works as expected."""
+    if not current_app.config.get('SUBSCRIPTION_API_KEY'):
+        return
+    headers = None
+    if status != HTTPStatus.UNAUTHORIZED:
+        apikey = current_app.config.get('SUBSCRIPTION_API_KEY')
+        if apikey:
+            headers = {
+                'x-apikey': apikey
+            }
+    if status not in (HTTPStatus.UNAUTHORIZED, HTTPStatus.BAD_REQUEST):
+        json_data = setup_registration(draft_json, reg_class, invoice_id, reg_num)
+
+        account_id: str = "PS12345"
+        new_reg: Registration = None
+        statement: FinancingStatement = None
+        if fs_id:
+            statement = FinancingStatement.find_by_financing_id(fs_id)
+        if model_utils.REG_CLASS_PPSA == reg_class:
+            save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id)
+            new_fs = cc_payment_utils.save_new_cc_draft(json_data, save_reg)
+            new_reg = new_fs.registration[0]
+        elif model_utils.REG_CLASS_AMEND == reg_class:
+            json_data["baseRegistrationNumber"] = reg_num
+            for party in statement.parties:
+                if party.registration_id != 200000000 and not party.registration_id_end:
+                    if party.party_type == 'DB' or party.party_type == 'DI':
+                        json_data['deleteDebtors'][0]['partyId'] = party.id
+                    elif party.party_type == 'SP':
+                        json_data['deleteSecuredParties'][0]['partyId'] = party.id
+            for gc in statement.general_collateral:
+                if gc.registration_id != 200000000 and not gc.registration_id_end:
+                    json_data['deleteGeneralCollateral'][0]['collateralId'] = gc.id
+            for vc in statement.vehicle_collateral:
+                if vc.registration_id != 200000000 and not vc.registration_id_end:
+                    json_data['deleteVehicleCollateral'][0]['vehicleId'] = vc.id
+            save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id, reg_class)
+            new_reg = cc_payment_utils.save_change_cc_draft(statement.registration[0],
+                                                                        json_data,
+                                                                        save_reg)
+        else:
+            json_data["baseRegistrationNumber"] = reg_num
+            save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id, reg_class)
+            new_reg = cc_payment_utils.save_change_cc_draft(statement.registration[0],
+                                                                        json_data,
+                                                                        save_reg)
+        assert new_reg
+
+    payload = copy.deepcopy(PUB_SUB_PAYLOAD) if desc != "Invalid missing payload" else {}
+    if payload:
+        payload["id"] = invoice_id
+    if desc == 'Invalid missing status':
+        del payload["statusCode"]
+    elif desc == 'Invalid status':
+        payload["statusCode"] = "CREATED"
+    rv = client.post('/api/v1/callbacks/pay/' + str(invoice_id),
+                     json=payload,
+                     headers=headers,
+                     content_type='application/json')
+    # check
+    assert rv.status_code == status
+    if desc == 'Invalid used':
+        rv = client.post('/api/v1/pay-callback/' + str(invoice_id),
+                        json=payload,
+                        headers=headers,
+                        content_type='application/json')
+        assert rv.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.BAD_REQUEST)
+
+
+def setup_registration(draft_json: dict, reg_class: str, invoice_id: str, reg_num: str) -> dict:
+    """Set up registration for cc processing."""
+    json_data = copy.deepcopy(draft_json)
+    account_id: str = "PS12345"
+    if model_utils.REG_CLASS_PPSA == reg_class:
+        del json_data['createDateTime']
+        del json_data['baseRegistrationNumber']
+        del json_data['payment']
+        del json_data['lifeInfinite']
+        del json_data['expiryDate']
+        del json_data['documentId']
+        del json_data['lienAmount']
+        del json_data['surrenderDate']
+    elif model_utils.REG_CLASS_AMEND == reg_class:
+        del json_data['createDateTime']
+        del json_data['amendmentRegistrationNumber']
+        del json_data['payment']
+        del json_data['addTrustIndenture']
+        del json_data['removeTrustIndenture']
+        if json_data.get("courtOrderInformation"):
+            del json_data["courtOrderInformation"]
+        json_data["baseRegistrationNumber"] = reg_num
+    else:
+        del json_data['createDateTime']
+        del json_data['renewalRegistrationNumber']
+        del json_data['payment']
+        del json_data['courtOrderInformation']
+        json_data["baseRegistrationNumber"] = reg_num
+    if "documentId" in json_data:
+        del json_data["documentId"]
+    pay_ref: dict = copy.deepcopy(CC_PAYREF)
+    if invoice_id:
+        pay_ref["invoiceId"] = invoice_id
+    json_data = setup_cc_draft(json_data, pay_ref, account_id, "username@idir")
+    return json_data
 
 
 def is_ci_testing() -> bool:

--- a/ppr-api/tests/unit/api/test_cc_utils.py
+++ b/ppr-api/tests/unit/api/test_cc_utils.py
@@ -1,0 +1,254 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the credit card payment helper functions.
+
+Test-Suite to ensure that the credit card payment helper functions are working as expected.
+"""
+import copy
+
+import pytest
+from flask import current_app
+from registry_schemas.example_data.ppr import (
+    AMENDMENT_STATEMENT,
+    FINANCING_STATEMENT,
+    DRAFT_AMENDMENT_STATEMENT,
+    DRAFT_FINANCING_STATEMENT,
+    RENEWAL_STATEMENT,
+)
+
+from ppr_api.models import Draft, FinancingStatement, Registration, utils as model_utils
+from ppr_api.models.draft import DRAFT_PAY_PENDING_PREFIX
+from ppr_api.models.type_tables import RegistrationTypes
+from ppr_api.resources import cc_payment_utils, utils as resource_utils
+from ppr_api.resources.financing_utils import setup_cc_draft
+
+
+CC_PAYREF = {
+     "invoiceId": "88888888",
+     "receipt": "receipt",
+     "ccPayment": True,
+     "paymentActionRequired": True,
+     "paymentPortalURL": "{PAYMENT_PORTAL_URL}/{invoice_id}/{return_URL}"
+}
+# testdata pattern is ({pay_ref}, {account_id}, {username}, {draft_json}, {create_draft}, {base_reg_num}, {reg_type})
+TEST_CHANGE_DATA = [
+    (CC_PAYREF, "PS12345", "username", AMENDMENT_STATEMENT, False, "TEST0001", RegistrationTypes.AM.value),
+    (CC_PAYREF, "PS12345", "username", AMENDMENT_STATEMENT, True, "TEST0001", RegistrationTypes.AM.value)
+]
+TEST_NEW_DATA = [
+    (CC_PAYREF, "PS12345", "username", FINANCING_STATEMENT, False, RegistrationTypes.SA.value)
+]
+# testdata pattern is ({draft_json}, {reg_num}, {fs_id}, {reg_class}, {invoice_id})
+TEST_REGISTRATION_DATA = [
+    (FINANCING_STATEMENT, None, None, model_utils.REG_CLASS_PPSA, "20000200"),
+    (AMENDMENT_STATEMENT, "TEST0001", 200000000, model_utils.REG_CLASS_AMEND, "20000201"),
+    (RENEWAL_STATEMENT, "TEST0005", 200000004, model_utils.REG_CLASS_RENEWAL, "20000202")
+]
+
+
+@pytest.mark.parametrize('pay_ref,account_id,username,draft_json,create_draft,reg_type', TEST_NEW_DATA)
+def test_new_registration(session, pay_ref, account_id, username, draft_json, create_draft, reg_type):
+    """Assert that a new home registration is set up correctly for a credit card payment client registration."""
+    json_data = copy.deepcopy(draft_json)
+    json_data['type'] = reg_type
+    del json_data['createDateTime']
+    del json_data['baseRegistrationNumber']
+    del json_data['payment']
+    del json_data['lifeInfinite']
+    del json_data['expiryDate']
+    del json_data['documentId']
+    del json_data['lienAmount']
+    del json_data['surrenderDate']
+    json_data = setup_cc_draft(json_data, pay_ref, account_id, username)
+    if create_draft:
+        new_draft_json = copy.deepcopy(DRAFT_FINANCING_STATEMENT)
+        draft: Draft = Draft.create_from_json(new_draft_json, account_id)
+        draft.save()
+        assert draft.document_number
+        json_data['documentId'] = draft.document_number
+    save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id)
+    new_fs: FinancingStatement = cc_payment_utils.save_new_cc_draft(json_data, save_reg)
+    assert not new_fs.id
+    new_reg: Registration = new_fs.registration[0]
+    assert not new_reg.id
+    assert new_reg.draft
+    assert new_reg.reg_json
+    draft: Draft = new_reg.draft
+    assert draft.document_number.startswith(DRAFT_PAY_PENDING_PREFIX)
+    assert draft.user_id == pay_ref.get("invoiceId")
+    assert not draft.registration_number
+    assert draft.registration_type == reg_type
+    reg_json = new_reg.reg_json
+    assert reg_json.get("paymentPending")
+    assert reg_json["payment"] == pay_ref
+    assert reg_json.get("accountId") == account_id
+    assert reg_json.get("username") == username
+    assert reg_json.get("registrationType") == reg_type
+    assert not reg_json.get("registrationNumber")
+
+
+@pytest.mark.parametrize('pay_ref,account_id,username,draft_json,create_draft,base_reg_num,reg_type', TEST_CHANGE_DATA)
+def test_change_registration(session, pay_ref, account_id, username, draft_json, create_draft, base_reg_num, reg_type):
+    """Assert that a change registration is set up correctly for a credit card payment client registration."""
+    json_data = copy.deepcopy(draft_json)
+    del json_data['createDateTime']
+    del json_data['amendmentRegistrationNumber']
+    del json_data['payment']
+    del json_data['addTrustIndenture']
+    del json_data['removeTrustIndenture']
+    if json_data.get("courtOrderInformation"):
+        del json_data["courtOrderInformation"]
+    if "documentId" in json_data:
+        del json_data["documentId"]
+    json_data = setup_cc_draft(json_data, pay_ref, account_id, username)
+    financing_statement = FinancingStatement.find_by_financing_id(200000000)
+    assert financing_statement
+    for party in financing_statement.parties:
+        if party.registration_id != 200000000 and not party.registration_id_end:
+            if party.party_type == 'DB' or party.party_type == 'DI':
+                json_data['deleteDebtors'][0]['partyId'] = party.id
+            elif party.party_type == 'SP':
+                json_data['deleteSecuredParties'][0]['partyId'] = party.id
+
+    for gc in financing_statement.general_collateral:
+        if gc.registration_id != 200000000 and not gc.registration_id_end:
+            json_data['deleteGeneralCollateral'][0]['collateralId'] = gc.id
+
+    for vc in financing_statement.vehicle_collateral:
+        if vc.registration_id != 200000000 and not vc.registration_id_end:
+            json_data['deleteVehicleCollateral'][0]['vehicleId'] = vc.id
+
+    if create_draft:
+        new_draft_json = copy.deepcopy(DRAFT_AMENDMENT_STATEMENT)
+        draft = Draft.create_from_json(new_draft_json, account_id)
+        draft.save()
+        assert draft.document_number
+        json_data['documentId'] = draft.document_number
+
+    save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id, model_utils.REG_CLASS_AMEND)
+    new_reg: Registration = cc_payment_utils.save_change_cc_draft(financing_statement.registration[0],
+                                                                  json_data,
+                                                                  save_reg)
+    assert not new_reg.id
+    assert new_reg.draft
+    assert new_reg.reg_json
+    draft: Draft = new_reg.draft
+    assert draft.document_number.startswith(DRAFT_PAY_PENDING_PREFIX)
+    assert draft.user_id == pay_ref.get("invoiceId")
+    assert draft.registration_number == base_reg_num
+    reg_json = new_reg.reg_json
+    assert reg_json.get("paymentPending")
+    assert reg_json["payment"] == pay_ref
+    assert reg_json.get("accountId") == account_id
+    assert reg_json.get("username") == username
+    assert reg_json.get("registrationType") == reg_type
+    assert reg_json.get("baseRegistrationNumber") == base_reg_num
+    test_reg: Registration = Registration.find_by_registration_number(base_reg_num, account_id, True)
+    assert test_reg.ver_bypassed == cc_payment_utils.REG_STATUS_LOCKED
+
+
+@pytest.mark.parametrize('draft_json,reg_num,fs_id,reg_class,invoice_id', TEST_REGISTRATION_DATA)
+def test_create_registration(session, draft_json, reg_num, fs_id, reg_class, invoice_id):
+    """Assert that creating a new cc payment registration from a callback works as expected."""
+    json_data = setup_registration(draft_json, reg_class, invoice_id)
+    account_id: str = "PS12345"
+    new_reg: Registration = None
+    statement: FinancingStatement = None
+    if fs_id:
+        statement = FinancingStatement.find_by_financing_id(fs_id)
+    if model_utils.REG_CLASS_PPSA == reg_class:
+        save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id)
+        new_fs = cc_payment_utils.save_new_cc_draft(json_data, save_reg)
+        new_reg = new_fs.registration[0]
+    elif model_utils.REG_CLASS_AMEND == reg_class:
+        json_data["baseRegistrationNumber"] = reg_num
+        for party in statement.parties:
+            if party.registration_id != 200000000 and not party.registration_id_end:
+                if party.party_type == 'DB' or party.party_type == 'DI':
+                    json_data['deleteDebtors'][0]['partyId'] = party.id
+                elif party.party_type == 'SP':
+                    json_data['deleteSecuredParties'][0]['partyId'] = party.id
+        for gc in statement.general_collateral:
+            if gc.registration_id != 200000000 and not gc.registration_id_end:
+                json_data['deleteGeneralCollateral'][0]['collateralId'] = gc.id
+        for vc in statement.vehicle_collateral:
+            if vc.registration_id != 200000000 and not vc.registration_id_end:
+                json_data['deleteVehicleCollateral'][0]['vehicleId'] = vc.id
+        save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id, reg_class)
+        new_reg = cc_payment_utils.save_change_cc_draft(statement.registration[0],
+                                                                    json_data,
+                                                                    save_reg)
+    else:
+        json_data["baseRegistrationNumber"] = reg_num
+        save_reg: Registration = resource_utils.create_new_pay_registration(json_data, account_id, reg_class)
+        new_reg = cc_payment_utils.save_change_cc_draft(statement.registration[0],
+                                                                    json_data,
+                                                                    save_reg)
+    assert new_reg
+    draft: Draft = Draft.find_by_invoice_id(invoice_id)
+    assert draft
+    if model_utils.REG_CLASS_PPSA == reg_class:
+        statement = cc_payment_utils.create_new_statement(draft)
+        assert statement.id
+        new_reg = statement.registration[0]
+    else:
+        statement = FinancingStatement.find_by_registration_number(
+                draft.registration_number, draft.account_id, True, True
+            )
+        assert statement
+        new_reg = cc_payment_utils.create_change_registration(draft, statement)
+        assert new_reg.base_registration_num == reg_num
+    assert new_reg.id
+    assert new_reg.registration_num
+
+
+def setup_registration(draft_json: dict, reg_class: str, invoice_id: str) -> dict:
+    """Set up registration for cc processing."""
+    json_data = copy.deepcopy(draft_json)
+    account_id: str = "PS12345"
+    if model_utils.REG_CLASS_PPSA == reg_class:
+        del json_data['createDateTime']
+        del json_data['baseRegistrationNumber']
+        del json_data['payment']
+        del json_data['lifeInfinite']
+        del json_data['expiryDate']
+        del json_data['documentId']
+        del json_data['lienAmount']
+        del json_data['surrenderDate']
+    elif model_utils.REG_CLASS_AMEND == reg_class:
+        del json_data['createDateTime']
+        del json_data['amendmentRegistrationNumber']
+        del json_data['payment']
+        del json_data['addTrustIndenture']
+        del json_data['removeTrustIndenture']
+        if json_data.get("courtOrderInformation"):
+            del json_data["courtOrderInformation"]
+    else:
+        del json_data['createDateTime']
+        del json_data['renewalRegistrationNumber']
+        del json_data['payment']
+        del json_data['courtOrderInformation']
+    if "documentId" in json_data:
+        del json_data["documentId"]
+    pay_ref: dict = copy.deepcopy(CC_PAYREF)
+    if invoice_id:
+        pay_ref["invoiceId"] = invoice_id
+    json_data = setup_cc_draft(json_data, pay_ref, account_id, "ppr_staff")
+    return json_data
+
+
+def is_ci_testing() -> bool:
+    """Check unit test environment: exclude most reports for CI testing."""
+    return  current_app.config.get("DEPLOYMENT_ENV", "testing") == "testing"

--- a/ppr-api/tests/unit/api/test_financing_utils.py
+++ b/ppr-api/tests/unit/api/test_financing_utils.py
@@ -27,12 +27,17 @@ from ppr_api.resources import financing_utils as fs_utils
 from ppr_api.services.payment.client import SBCPaymentClient
 
 
+CC_PAYREF = {"invoiceId": "88888888", "receipt": "receipt", "ccPayment": True}
 # testdata pattern is ({desc}, {status}, {reg_id}, is_create)
 TEST_REGISTRATION_GET_DATA = [
     ('Valid POST', HTTPStatus.CREATED, 200000011, True),
     ('Valid GET', HTTPStatus.OK, 200000011, False),
     ('Pending', HTTPStatus.ACCEPTED, 200000000, False),
     ('Pending', HTTPStatus.ACCEPTED, 200000000, True),
+]
+# testdata pattern is ({pay_ref}, {account_id}, {username}, {usergroup})
+TEST_SETUP_CC_PAYMENT= [
+    (CC_PAYREF, "1234", "username", "ppr_staff")
 ]
 
 
@@ -80,6 +85,17 @@ def test_get_registration_callback_report(session, client, jwt):
     # check
     assert status == HTTPStatus.OK
     assert response_data == {}
+
+
+@pytest.mark.parametrize('pay_ref, account_id, username, usergroup',TEST_SETUP_CC_PAYMENT)
+def test_cc_payment_setup(session, client, jwt, pay_ref, account_id, username, usergroup):
+    """Assert that setting up the pay api invoice information by doc type works as expected."""
+    reg_json = {}
+    reg_json = fs_utils.setup_cc_draft(reg_json, pay_ref, account_id, username)
+    assert reg_json.get("payment")
+    assert reg_json["payment"] == pay_ref
+    assert reg_json.get("accountId") == account_id
+    assert reg_json.get("username") == username
 
 
 def is_ci_testing() -> bool:

--- a/ppr-api/tests/unit/models/test_event_tracking.py
+++ b/ppr-api/tests/unit/models/test_event_tracking.py
@@ -49,7 +49,9 @@ TEST_DATA_CREATE = [
     ('Notification', 200000011, EventTracking.EventTrackingTypes.API_NOTIFICATION, int(HTTPStatus.OK), 'message'),
     ('Email', 200000012, EventTracking.EventTrackingTypes.EMAIL, int(HTTPStatus.OK), 'message'),
     ('Surface mail', 200000013, EventTracking.EventTrackingTypes.SURFACE_MAIL, int(HTTPStatus.OK), 'message'),
-    ('Email report', 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT, int(HTTPStatus.OK), 'message')
+    ('Email report', 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT, int(HTTPStatus.OK), 'message'),
+    ('CC payment', 200000015, EventTracking.EventTrackingTypes.PPR_PAYMENT, int(HTTPStatus.OK),
+     'Payment pending initial state.')
 ]
 # testdata pattern is ({description}, {results_size}, {key_id}, {type}, extra_key)
 TEST_DATA_KEY_ID_TYPE_EXTRA = [

--- a/ppr-api/tests/unit/services/test_payment.py
+++ b/ppr-api/tests/unit/services/test_payment.py
@@ -16,6 +16,7 @@
 
 Test-Suite to ensure that the client for the pay-api service is working as expected.
 """
+import copy
 import json
 import os
 from http import HTTPStatus
@@ -23,8 +24,8 @@ from http import HTTPStatus
 import pytest
 from flask import current_app
 
-from ppr_api.services.payment.client import SBCPaymentClient, ApiRequestError
-from ppr_api.services.payment import TransactionTypes
+from ppr_api.services.payment.client import SBCPaymentClient, ApiRequestError, CC_REQUEST_PAYMENT_INFO
+from ppr_api.services.payment import PaymentMethods, StatusCodes, TransactionTypes
 from ppr_api.services.payment.payment import Payment
 from ppr_api.services.payment.exceptions import SBCPaymentException
 from ppr_api.services.authz import PPR_ROLE
@@ -41,22 +42,71 @@ PAY_DETAILS_REGISTRATION = {
     'label': 'Reg Number',
     'value': '100468B'
 }
-# testdata pattern is ({pay_trans_type}, {quantity}, {filing_type})
-TEST_PAY_TYPE_FILING_TYPE = [
-    (TransactionTypes.FINANCING_CL.value, 5, 'CLREG'),
-    (TransactionTypes.FINANCING_LIFE_YEAR.value, 5, 'FSREG'),
-    (TransactionTypes.SEARCH.value, 1, 'SERCH'),
-    (TransactionTypes.AMENDMENT.value, 1, 'FSCHG'),
-    (TransactionTypes.CHANGE.value, 1, 'FSCHG'),
-    (TransactionTypes.DISCHARGE.value, 1, 'FSDIS'),
-    (TransactionTypes.FINANCING_FR.value, 1, 'FLREG'),
-    (TransactionTypes.FINANCING_NO_FEE.value, 1, 'NCREG'),
-    (TransactionTypes.FINANCING_INFINITE.value, 1, 'INFRG'),
-    (TransactionTypes.FINANCING_CL_INFINITE.value, 1, 'INFRG'),
-    (TransactionTypes.RENEWAL_INFINITE.value, 1, 'INFRN'),
-    (TransactionTypes.RENEWAL_LIFE_YEAR.value, 3, 'FSREN')
+PAY_DETAILS_CC = {
+    'label': 'CC TEST',
+    'value': 'UNIT TESTING',
+    'ccPayment': True
+}
+PAYMENT_REQUEST_TEMPLATE = {
+    "filingInfo": {
+        "filingIdentifier": "",
+        "folioNumber": "",
+        "filingTypes": [{"filingTypeCode": "", "priority": False, "futureEffective": False, "quantity": 1}],
+    },
+    "businessInfo": {"corpType": "PPR"},
+    "details": [{"label": "", "value": ""}],
+}
+
+# testdata pattern is ({valid}, {filing_type}, {pay_method}, {pay_status})
+TEST_PAY_METHOD_STATUS = [
+    (True, 'SERCH', PaymentMethods.DRAWDOWN.value, StatusCodes.COMPLETED.value),
+    (True, 'SSRCH', PaymentMethods.EJV.value, StatusCodes.COMPLETED.value),
+    (True, 'PPRCD', PaymentMethods.PAD.value, StatusCodes.COMPLETED.value),
+    (True, 'FSCHG', PaymentMethods.DRAWDOWN.value, StatusCodes.APPROVED.value),
+    (True, 'FSREG', PaymentMethods.EJV.value, StatusCodes.APPROVED.value),
+    (True, 'FSREN', PaymentMethods.PAD.value, StatusCodes.APPROVED.value),
+    (True, 'FSDIS', PaymentMethods.INTERNAL.value, StatusCodes.APPROVED.value),
+    (True, 'FSCHG', PaymentMethods.DRAWDOWN.value, StatusCodes.PAID.value),
+    (True, 'FSREG', PaymentMethods.EJV.value, StatusCodes.PAID.value),
+    (True, 'FSREN', PaymentMethods.PAD.value, StatusCodes.PAID.value),
+    (True, 'FSDIS', PaymentMethods.INTERNAL.value, StatusCodes.PAID.value),
+    (True, 'FSCHG', PaymentMethods.CC.value, StatusCodes.CREATED.value),
+    (True, 'FSREG', PaymentMethods.CC.value, StatusCodes.CREATED.value),
+    (True, 'FSREN', PaymentMethods.CC.value, StatusCodes.CREATED.value),
+    (True, 'FSDIS', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (True, 'FSCHG', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (True, 'FSREG', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (True, 'FSREN', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (True, 'FSDIS', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (False, 'SERCH', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (False, 'SSRCH', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (False, 'PPRCD', PaymentMethods.DIRECT_PAY.value, StatusCodes.CREATED.value),
+    (False, 'SERCH', PaymentMethods.CC.value, StatusCodes.CREATED.value),
+    (False, 'SSRCH', PaymentMethods.CC.value, StatusCodes.CREATED.value),
+    (False, 'PPRCD', PaymentMethods.CC.value, StatusCodes.CREATED.value),
 ]
-# testdata pattern is ({pay_trans_type}, {routingSlip}, {bcolNumber}, 'datNUmber', 'waiveFees')
+# testdata pattern is ({pay_trans_type}, {quantity}, {filing_type}, {cc})
+TEST_PAY_TYPE_FILING_TYPE = [
+    (TransactionTypes.FINANCING_CL.value, 5, 'CLREG', False),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, 5, 'FSREG', False),
+    (TransactionTypes.SEARCH.value, 1, 'SERCH', False),
+    (TransactionTypes.AMENDMENT.value, 1, 'FSCHG', False),
+    (TransactionTypes.CHANGE.value, 1, 'FSCHG', False),
+    (TransactionTypes.DISCHARGE.value, 1, 'FSDIS', False),
+    (TransactionTypes.FINANCING_FR.value, 1, 'FLREG', False),
+    (TransactionTypes.FINANCING_NO_FEE.value, 1, 'NCREG', False),
+    (TransactionTypes.FINANCING_INFINITE.value, 1, 'INFRG', False),
+    (TransactionTypes.FINANCING_CL_INFINITE.value, 1, 'INFRG', False),
+    (TransactionTypes.RENEWAL_INFINITE.value, 1, 'INFRN', False),
+    (TransactionTypes.RENEWAL_LIFE_YEAR.value, 3, 'FSREN', False),
+    (TransactionTypes.FINANCING_CL.value, 5, 'CLREG', True),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, 5, 'FSREG', True),
+    (TransactionTypes.AMENDMENT.value, 1, 'FSCHG', True),
+    (TransactionTypes.FINANCING_INFINITE.value, 1, 'INFRG', True),
+    (TransactionTypes.RENEWAL_INFINITE.value, 1, 'INFRN', True),
+    (TransactionTypes.RENEWAL_LIFE_YEAR.value, 3, 'FSREN', True),
+ ]
+# testdata pattern is ({pay_trans_type}, {routingSlip}, {bcolNumber}, {datNUmber}, {waiveFees})
 TEST_PAY_STAFF_SEARCH = [
     (TransactionTypes.SEARCH_STAFF_NO_FEE.value, None, None, None, True),
     (TransactionTypes.SEARCH_STAFF.value, '12345', None, None, False),
@@ -67,24 +117,29 @@ TEST_PAY_STAFF_SEARCH = [
     (TransactionTypes.SEARCH_STAFF_CERTIFIED.value, None, '62345', None, False),
     (TransactionTypes.SEARCH_STAFF_CERTIFIED.value, None, '62345', '72345', False)
 ]
-# testdata pattern is ({pay_trans_type}, {routingSlip}, {bcolNumber}, 'datNUmber', 'waiveFees')
+# testdata pattern is ({pay_trans_type}, {routingSlip}, {bcolNumber}, {datNUmber}, {waiveFees}, {cc})
 TEST_PAY_STAFF_REGISTRATION = [
-    (TransactionTypes.DISCHARGE.value, None, None, None, True),
-    (TransactionTypes.FINANCING_NO_FEE.value, None, None, None, True),
-    (TransactionTypes.FINANCING_INFINITE.value, None, None, None, True),
-    (TransactionTypes.FINANCING_CL_INFINITE.value, None, None, None, True),
-    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, None, None, True),
-    (TransactionTypes.FINANCING_LIFE_YEAR.value, '12345', None, None, False),
-    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, '62345', None, False),
-    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, '62345', '72345', False),
-    (TransactionTypes.FINANCING_CL.value, None, None, None, True),
-    (TransactionTypes.FINANCING_CL.value, '12345', None, None, False),
-    (TransactionTypes.FINANCING_CL.value, None, '62345', None, False),
-    (TransactionTypes.FINANCING_CL.value, None, '62345', '72345', False),
-    (TransactionTypes.RENEWAL_LIFE_YEAR.value, None, None, None, True),
-    (TransactionTypes.AMENDMENT.value, '12345', None, None, False),
-    (TransactionTypes.AMENDMENT.value, None, None, None, True),
-    (TransactionTypes.RENEWAL_INFINITE.value, None, '62345', '72345', False)
+    (TransactionTypes.DISCHARGE.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_NO_FEE.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_INFINITE.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_CL_INFINITE.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, '12345', None, None, False, False),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, '62345', None, False, False),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, '62345', '72345', False, False),
+    (TransactionTypes.FINANCING_CL.value, None, None, None, True, False),
+    (TransactionTypes.FINANCING_CL.value, '12345', None, None, False, False),
+    (TransactionTypes.FINANCING_CL.value, None, '62345', None, False, False),
+    (TransactionTypes.FINANCING_CL.value, None, '62345', '72345', False, False),
+    (TransactionTypes.RENEWAL_LIFE_YEAR.value, None, None, None, True, False),
+    (TransactionTypes.AMENDMENT.value, '12345', None, None, False, False),
+    (TransactionTypes.AMENDMENT.value, None, None, None, True, False),
+    (TransactionTypes.RENEWAL_INFINITE.value, None, '62345', '72345', False, False),
+    (TransactionTypes.FINANCING_INFINITE.value, None, None, None, False, True),
+    (TransactionTypes.FINANCING_LIFE_YEAR.value, None, None, None, False, True),
+    (TransactionTypes.RENEWAL_LIFE_YEAR.value, None, None, None, False, True),
+    (TransactionTypes.RENEWAL_INFINITE.value, None, None, None, False, True),
+    (TransactionTypes.AMENDMENT.value, None, None, None, False, True),
 ]
 
 
@@ -161,9 +216,9 @@ def test_payment_staff_search_mock(client, jwt, pay_trans_type, routing_slip, bc
     assert pay_data['receipt']
 
 
-@pytest.mark.parametrize('pay_trans_type,routing_slip,bcol_number,dat_number,waive_fees', TEST_PAY_STAFF_REGISTRATION)
+@pytest.mark.parametrize('pay_trans_type,routing_slip,bcol_number,dat_number,waive_fees,cc', TEST_PAY_STAFF_REGISTRATION)
 def test_payment_data_staff_registration(client, jwt, pay_trans_type, routing_slip, bcol_number, dat_number,
-                                         waive_fees):
+                                         waive_fees, cc):
     """Assert that the staff payment payment-request body is as expected for a pay transaction type."""
     transaction_info = {
         'transactionType': pay_trans_type,
@@ -178,8 +233,15 @@ def test_payment_data_staff_registration(client, jwt, pay_trans_type, routing_sl
         transaction_info['bcolAccountNumber'] = bcol_number
     if dat_number:
         transaction_info['datNumber'] = dat_number
+ 
+    token = helper_create_jwt(jwt, [PPR_ROLE])
+    details: dict = PAY_DETAILS_REGISTRATION if not cc else PAY_DETAILS_CC
+    pay_client = SBCPaymentClient(jwt=token, account_id='PS12345', details=details)
+ 
     # test
-    data = SBCPaymentClient.create_payment_staff_registration_data(transaction_info, 'UT-PAY-0001')
+    data = pay_client.create_payment_staff_registration_data(transaction_info, 'UT-PAY-0001')
+    data = pay_client.update_payload_data(data)
+
     # check
     assert data
     assert len(data['filingInfo']['filingTypes']) == 1
@@ -198,15 +260,20 @@ def test_payment_data_staff_registration(client, jwt, pay_trans_type, routing_sl
         assert 'accountInfo' in data and data['accountInfo']['bcolAccountNumber'] == bcol_number
         if dat_number:
             assert data['accountInfo']['datNumber'] == dat_number
+    if cc:
+        assert data.get("paymentInfo") == CC_REQUEST_PAYMENT_INFO
+    else:
+        assert not data.get("paymentInfo")
 
 
-@pytest.mark.parametrize('pay_trans_type,routing_slip,bcol_number,dat_number,waive_fees', TEST_PAY_STAFF_REGISTRATION)
+@pytest.mark.parametrize('pay_trans_type,routing_slip,bcol_number,dat_number,waive_fees,cc', TEST_PAY_STAFF_REGISTRATION)
 def test_payment_staff_registration_mock(client, jwt, pay_trans_type, routing_slip, bcol_number, dat_number,
-                                         waive_fees):
+                                         waive_fees,cc):
     """Assert that a pay-api staff registration payment request works as expected with the mock service endpoint."""
     # setup
     token = helper_create_jwt(jwt, [PPR_ROLE])
-    payment = Payment(jwt=token, account_id=None, details=PAY_DETAILS_REGISTRATION)
+    details: dict = PAY_DETAILS_REGISTRATION if not cc else PAY_DETAILS_CC
+    payment = Payment(jwt=token, account_id=None, details=details)
     payment.api_url = MOCK_URL_NO_KEY
     transaction_info = {
         'transactionType': pay_trans_type,
@@ -229,15 +296,27 @@ def test_payment_staff_registration_mock(client, jwt, pay_trans_type, routing_sl
     assert pay_data
     assert pay_data['invoiceId']
     assert pay_data['receipt']
+    if cc:
+        assert pay_data.get("ccPayment")
+        assert "paymentActionRequired" in pay_data
+        assert "paymentPortalURL" in pay_data
+    else:
+        assert "ccPayment" not in pay_data
+        assert "paymentActionRequired" not in pay_data
+        assert "paymentPortalURL" not in pay_data
 
 
-@pytest.mark.parametrize('pay_trans_type,quantity,filing_type', TEST_PAY_TYPE_FILING_TYPE)
-def test_payment_filing_type(client, jwt, pay_trans_type, quantity, filing_type):
+@pytest.mark.parametrize('pay_trans_type,quantity,filing_type,cc', TEST_PAY_TYPE_FILING_TYPE)
+def test_payment_filing_type(client, jwt, pay_trans_type, quantity, filing_type, cc):
     """Assert that the payment-request body filing type is as expected for a pay transaction type."""
     # setup
+    token = helper_create_jwt(jwt, [PPR_ROLE])
+    details: dict = PAY_DETAILS_REGISTRATION if not cc else PAY_DETAILS_CC
+    pay_client = SBCPaymentClient(jwt=token, account_id='PS12345', details=details)
 
     # test
-    data = SBCPaymentClient.create_payment_data(pay_trans_type, quantity, '200000000', 'UT-PAY-0001')
+    data = pay_client.create_payment_data(pay_trans_type, quantity, '200000000', 'UT-PAY-0001')
+    data = pay_client.update_payload_data(data)
     # check
     assert data
     assert data['filingInfo']['filingIdentifier'] == '200000000'
@@ -246,6 +325,10 @@ def test_payment_filing_type(client, jwt, pay_trans_type, quantity, filing_type)
     assert data['filingInfo']['filingTypes'][0]['quantity'] == quantity
     assert data['filingInfo']['filingTypes'][0]['filingTypeCode'] == filing_type
     assert data['businessInfo']['corpType'] == 'PPR'
+    if cc:
+        assert data.get("paymentInfo") == CC_REQUEST_PAYMENT_INFO
+    else:
+        assert not data.get("paymentInfo")
 
 
 def test_payment_data_all(client, jwt):
@@ -441,6 +524,17 @@ def test_sa_get_token(client, jwt):
     # check
     assert jwt
     assert len(jwt) > 0
+
+
+@pytest.mark.parametrize('valid, filing_type, pay_method, pay_status', TEST_PAY_METHOD_STATUS)
+def test_verify_pay_status(session, client, jwt, valid, filing_type, pay_method, pay_status):
+    """Assert that checking the response status works as expected."""
+    token = helper_create_jwt(jwt, [PPR_ROLE])
+    pay_client = SBCPaymentClient(jwt=token, account_id='PS12345')
+    req_json = copy.deepcopy(PAYMENT_REQUEST_TEMPLATE)
+    req_json["filingInfo"]["filingTypes"][0]["filingTypeCode"] = filing_type
+    result = pay_client.valid_payment_status(pay_method, pay_status, req_json)
+    assert result == valid
 
 
 def is_ci_testing() -> bool:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27261

*Description of changes:*
See ticket for details.
- Optional new request parameter (ccPayment=true) for all public registration endpoints to indicate CC payment (if preferred account payment is not CC). UI should know the payment method in advance to handle the mhr api response and redirect user to the CC payment url. 
- Save draft record without marking it as consumed if pay api call is successful.
- Associate the pay api response invoice id with the draft.
- For change registrations lock the base registration to prevent further changes until payment completes.
- Return to the UI the pay api response invoice ID. Response HTTP status is 202 accepted; new payload paymentPending property is set to true.
- Create new endpoint to receive payment complete requests and create the registration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
