### PR TITLE
MHR API add summary invoiceId, cancel pending registration.

### DIFF
--- a/mhr-api/migrations/versions/0001_rebase_2024-10.py
+++ b/mhr-api/migrations/versions/0001_rebase_2024-10.py
@@ -1251,7 +1251,9 @@ def upgrade():
         { 'event_tracking_type': 'EMAIL_REPORT', 'event_tracking_desc': 'Email delivery of report.' },
         { 'event_tracking_type': 'REGISTRATION_REPORT', 'event_tracking_desc': 'Registration Verification Statement generation and storage.' },
         { 'event_tracking_type': 'MHR_REG_REPORT', 'event_tracking_desc': 'MHR registration report generation and storage.' },
-        { 'event_tracking_type': 'REG_HIST_JOB', 'event_tracking_desc': 'Job to updated account IDs when registrations become historical.' }
+        { 'event_tracking_type': 'REG_HIST_JOB', 'event_tracking_desc': 'Job to updated account IDs when registrations become historical.' },
+        { 'event_tracking_type': 'PPR_PAYMENT', 'event_tracking_desc': 'PPR registration payment status (credit card).' },
+        { 'event_tracking_type': 'MHR_PAYMENT', 'event_tracking_desc': 'MHR registration payment status (credit card).' }
       ]
     )
     op.bulk_insert(securities_act_type,

--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.0.11"
+version = "2.0.12"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/event_tracking.py
+++ b/mhr-api/src/mhr_api/models/event_tracking.py
@@ -33,6 +33,8 @@ class EventTracking(db.Model):  # pylint: disable=too-many-instance-attributes
         EMAIL_REPORT = "EMAIL_REPORT"
         REGISTRATION_REPORT = "REGISTRATION_REPORT"
         MHR_REGISTRATION_REPORT = "MHR_REG_REPORT"
+        MHR_PAYMENT = "MHR_PAYMENT"
+        PPR_PAYMENT = "PPR_PAYMENT"
 
     __tablename__ = "event_tracking"
 

--- a/mhr-api/src/mhr_api/resources/v1/drafts.py
+++ b/mhr-api/src/mhr_api/resources/v1/drafts.py
@@ -20,9 +20,12 @@ from flask_cors import cross_origin
 from registry_schemas import utils as schema_utils
 
 from mhr_api.exceptions import BusinessException, DatabaseException
-from mhr_api.models import MhrDraft
+from mhr_api.models import MhrDraft, MhrRegistration
+from mhr_api.models.mhr_draft import DRAFT_PAY_PENDING_PREFIX
 from mhr_api.models.registration_utils import AccountRegistrationParams
+from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrRegistrationTypes
 from mhr_api.resources import utils as resource_utils
+from mhr_api.resources.cc_payment_utils import track_event
 from mhr_api.services.authz import authorized, is_staff
 from mhr_api.utils.auth import jwt
 from mhr_api.utils.logging import logger
@@ -137,7 +140,10 @@ def put_drafts(draft_number: str):  # pylint: disable=too-many-return-statements
         # Verify request JWT and account ID
         if not authorized(account_id, jwt):
             return resource_utils.unauthorized_error_response(account_id)
-
+        if draft_number.startswith(DRAFT_PAY_PENDING_PREFIX):
+            error_msg: str = f"Draft number {draft_number} is in a pending state: update not allowed."
+            logger.error(error_msg)
+            return resource_utils.bad_request_response(error_msg)
         request_json = request.get_json(silent=True)
         # Save draft statement update: BusinessException raised if failure.
         draft = MhrDraft.update(request_json, draft_number)
@@ -177,3 +183,68 @@ def delete_drafts(draft_number: str):  # pylint: disable=too-many-return-stateme
         return resource_utils.db_exception_response(db_exception, account_id, "DELETE draft id=" + draft_number)
     except Exception as default_exception:  # noqa: B902; return nicer default error
         return resource_utils.default_exception_response(default_exception)
+
+
+@bp.route("/cancel/<string:draft_number>", methods=["PATCH", "OPTIONS"])
+@cross_origin(origin="*")
+@jwt.requires_auth
+def cancel_pending_drafts(draft_number: str):
+    """Delete a draft registration by draft number."""
+    try:
+        logger.info(f"cancel_pending_drafts draft_number={draft_number}")
+        if draft_number is None:
+            return resource_utils.path_param_error_response("draft number")
+        # Quick check: must be staff or provide an account ID.
+        account_id = resource_utils.get_account_id(request)
+        if account_id is None:
+            return resource_utils.account_required_response()
+        # Verify request JWT and account ID
+        staff: bool = is_staff(jwt)
+        if not staff and not authorized(account_id, jwt):
+            return resource_utils.unauthorized_error_response(account_id)
+        if not draft_number.startswith(DRAFT_PAY_PENDING_PREFIX):
+            error_msg: str = f"Draft number {draft_number} is not in a pending state."
+            logger.error(error_msg)
+            return resource_utils.bad_request_response(error_msg)
+        draft: MhrDraft = MhrDraft.find_by_draft_number(draft_number, False)
+        invoice_id: str = draft.user_id
+        orig_status: str = draft.draft.get("status")
+        revert_pending_draft(draft)
+        # Now unlock home if draft is not for a new home registration.
+        if draft.registration_type != MhrRegistrationTypes.MHREG.value and draft.mhr_number:
+            mhr_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(draft.mhr_number, draft.account_id, staff)
+            if mhr_reg and mhr_reg.status_type == MhrRegistrationStatusTypes.DRAFT:
+                logger.info(f"Reverting mhr {mhr_reg.mhr_number} status to {orig_status}")
+                mhr_reg.status_type = orig_status
+                mhr_reg.save()
+                logger.info(f"Home status for MHR# {mhr_reg.mhr_number} restored to {orig_status}")
+        track_event("06", invoice_id, HTTPStatus.OK, None)
+        return draft.json, HTTPStatus.OK
+    except BusinessException as exception:
+        return resource_utils.business_exception_response(exception)
+    except DatabaseException as db_exception:  # noqa: B902; return nicer default error
+        return resource_utils.db_exception_response(db_exception, account_id, "DELETE draft id=" + draft_number)
+    except Exception as default_exception:  # noqa: B902; return nicer default error
+        return resource_utils.default_exception_response(default_exception)
+
+
+def revert_pending_draft(draft: MhrDraft):
+    """Update the draft to post registration state instead of payment pending."""
+    draft_json = draft.draft
+    draft.user_id = draft_json.get("username", None)
+    if draft_json.get("username"):
+        del draft_json["username"]
+    if draft_json.get("usergroup"):
+        del draft_json["usergroup"]
+    if draft_json.get("accountId"):
+        del draft_json["accountId"]
+    if draft_json.get("status"):
+        del draft_json["status"]
+    if "paymentPending" in draft_json:
+        del draft_json["paymentPending"]
+    draft.draft = draft_json
+    draft_num: str = str(draft.draft_number)
+    if draft_num.startswith(DRAFT_PAY_PENDING_PREFIX):
+        draft.draft_number = draft_num[1:]
+    draft.save()
+    logger.info(f"Updated draft id={draft.id} number={draft.draft_number} userid={draft.user_id}")

--- a/mhr-api/tests/unit/api/test_pay_callback.py
+++ b/mhr-api/tests/unit/api/test_pay_callback.py
@@ -46,14 +46,14 @@ PUB_SUB_PAYLOAD = {
 # testdata pattern is ({desc}, {status}, {draft_json}, {mhr_num}, {reg_type}, {invoice_id})
 TEST_CALLBACK_DATA = [
     ('Valid new reg', HTTPStatus.OK, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
-#    ('Valid exemption', HTTPStatus.OK, EXEMPTION, "000919", MhrRegistrationTypes.EXEMPTION_RES.value, "20000101"),
-#    ('Valid permit', HTTPStatus.OK, PERMIT, "000900", MhrRegistrationTypes.PERMIT.value, "20000102"),
-#    ('Valid transfer', HTTPStatus.OK, TRANSFER, "000919", MhrRegistrationTypes.TRANS.value, "20000103"),
-#    ('Invalid no key', HTTPStatus.UNAUTHORIZED, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
-#    ('Invalid missing payload', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
-#    ('Invalid missing status', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
-#    ('Invalid status', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
-#    ('Invalid used', HTTPStatus.OK, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
+    ('Valid exemption', HTTPStatus.OK, EXEMPTION, "000919", MhrRegistrationTypes.EXEMPTION_RES.value, "20000101"),
+    ('Valid permit', HTTPStatus.OK, PERMIT, "000900", MhrRegistrationTypes.PERMIT.value, "20000102"),
+    ('Valid transfer', HTTPStatus.OK, TRANSFER, "000919", MhrRegistrationTypes.TRANS.value, "20000103"),
+    ('Invalid no key', HTTPStatus.UNAUTHORIZED, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
+    ('Invalid missing payload', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
+    ('Invalid missing status', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
+    ('Invalid status', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
+    ('Invalid used', HTTPStatus.OK, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
 ]
 
 

--- a/mhr-api/tests/unit/models/test_event_tracking.py
+++ b/mhr-api/tests/unit/models/test_event_tracking.py
@@ -49,7 +49,9 @@ TEST_DATA_CREATE = [
     ('Notification', 200000011, EventTracking.EventTrackingTypes.API_NOTIFICATION, int(HTTPStatus.OK), 'message'),
     ('Email', 200000012, EventTracking.EventTrackingTypes.EMAIL, int(HTTPStatus.OK), 'message'),
     ('Surface mail', 200000013, EventTracking.EventTrackingTypes.SURFACE_MAIL, int(HTTPStatus.OK), 'message'),
-    ('Email report', 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT, int(HTTPStatus.OK), 'message')
+    ('Email report', 200000014, EventTracking.EventTrackingTypes.EMAIL_REPORT, int(HTTPStatus.OK), 'message'),
+    ('CC payment', 200000015, EventTracking.EventTrackingTypes.MHR_PAYMENT, int(HTTPStatus.OK),
+     'Payment pending initial state.')
 ]
 # testdata pattern is ({description}, {results_size}, {key_id}, {type}, extra_key)
 TEST_DATA_KEY_ID_TYPE_EXTRA = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27527

*Description of changes:*
- Allow delete of a draft in a pending payment state.
- Add new endpoint to cancel a draft in a pending state, reverting to a normal draft: PATCH /mhr/api/v1/drafts/cancel/{draft_number}
- Include invoice id as "invoiceId" in the draft summary when draft is in a pending payment state (allow UI to retry payment).
- Capture cc payment status changes in the event tracking table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
