### PR TITLE
MHR, PPR API add draftNumber to account registrations.

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.0.14"
+version = "2.0.15"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/queries.py
+++ b/mhr-api/src/mhr_api/models/queries.py
@@ -120,7 +120,13 @@ SELECT mhr_number, status_type, registration_ts, submitting_name, client_referen
                     AND r.user_id = u.username
                  ORDER BY u.id DESC
                  FETCH FIRST 1 ROWS ONLY)
-            ELSE NULL END staff_account_id
+            ELSE NULL END staff_account_id,
+       CASE WHEN arv.account_id != '0'
+            THEN (SELECT d.draft_number
+                   FROM mhr_drafts d, mhr_registrations r
+                  WHERE arv.registration_id = r.id
+                    AND r.draft_id = d.id)
+            ELSE NULL END draft_number
   FROM mhr_account_reg_vw arv
 """
 

--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -877,6 +877,7 @@ def __build_summary(row, account_id: str, staff: bool, add_in_user_list: bool = 
         "documentRegistrationNumber": str(row[9]),
         "registrationType": str(row[5]),
         "locationType": str(row[22]),
+        "draftNumber": str(row[26]) if row[26] else "",
     }
     summary = __get_report_path(account_id, staff, summary, row, timestamp)
     if add_in_user_list and summary["registrationType"] in (

--- a/mhr-api/tests/unit/api/test_registrations.py
+++ b/mhr-api/tests/unit/api/test_registrations.py
@@ -178,9 +178,6 @@ TEST_BATCH_MANUFACTURER_MHREG_DATA = [
     ('Valid default interval may have data', None, None, HTTPStatus.OK, True, False)
 ]
 # testdata pattern is ({desc}, {roles}, {status}, {sort_criteria}, {sort_direction})
-TEST_GET_ACCOUNT_DATA_SORT2 = [
-    ('Sort mhr number', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.MHR_NUMBER_PARAM, None)
-]
 TEST_GET_ACCOUNT_DATA_SORT = [
     ('Sort mhr number', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.MHR_NUMBER_PARAM, None),
     ('Sort reg type asc', [MHR_ROLE, STAFF_ROLE], HTTPStatus.OK, reg_utils.REG_TYPE_PARAM, reg_utils.SORT_ASCENDING),
@@ -300,6 +297,7 @@ def test_get_account_registrations(session, client, jwt, desc, roles, status, ha
             assert registration['path'] is not None
             if registration['registrationDescription'] == 'REGISTER NEW UNIT':
                 assert 'lienRegistrationType' in registration
+            assert registration.get("draftNumber")
 
 
 @pytest.mark.parametrize('desc,has_submitting,roles,status,has_account,mhr_num', TEST_CREATE_DATA)
@@ -484,6 +482,7 @@ def test_get_account_registrations_sort(session, client, jwt, desc, roles, statu
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
+        assert registration.get("draftNumber")
 
 
 @pytest.mark.parametrize('desc,account_id,roles,status,filter_name,filter_value', TEST_GET_ACCOUNT_DATA_FILTER)
@@ -509,6 +508,7 @@ def test_get_account_registrations_filter(session, client, jwt, desc, account_id
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
+        assert registration.get("draftNumber")
 
 
 @pytest.mark.parametrize('desc,account_id,roles,status,collapse,filter_start,filter_end',
@@ -540,6 +540,7 @@ def test_get_account_registrations_filter_date(session, client, jwt, desc, accou
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
+        assert registration.get("draftNumber")
 
 
 @pytest.mark.parametrize('desc,start_ts,end_ts,status,has_key,download_link',TEST_BATCH_MANUFACTURER_MHREG_DATA)

--- a/mhr-api/tests/unit/models/test_registration_utils.py
+++ b/mhr-api/tests/unit/models/test_registration_utils.py
@@ -340,6 +340,7 @@ def test_find_account_sort_order(session, account_id, sort_criteria, sort_order,
         assert registration['path'] is not None
         assert registration['documentId'] is not None
         assert not registration.get('inUserList')
+        assert registration.get("draftNumber")
 
 
 @pytest.mark.parametrize('account_id,collapse,filter_name,filter_value,mhr_numbers,expected_clause',
@@ -489,3 +490,4 @@ def test_find_account_filter(session, account_id, collapse, filter_name, filter_
             assert registration.get("accountId")
         else:
             assert not registration.get("accountId")
+        assert registration.get("draftNumber")

--- a/ppr-api/pyproject.toml
+++ b/ppr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ppr-api"
-version = "1.3.7"
+version = "1.3.8"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -301,6 +301,12 @@ SELECT registration_number, registration_ts, registration_type, registration_typ
                  ORDER BY u.id DESC
                  FETCH FIRST 1 ROWS ONLY)
             ELSE NULL END staff_account_id,
+       CASE WHEN arv.account_id != '0'
+            THEN (SELECT d.document_number
+                   FROM drafts d, registrations r
+                  WHERE arv.registration_id = r.id
+                    AND r.draft_id = d.id)
+            ELSE NULL END draft_number,
        (SELECT r.ver_bypassed FROM registrations r WHERE r.id = arv.registration_id) as locked_status
   FROM account_registration_vw arv
  WHERE arv.account_id = :query_account
@@ -325,7 +331,14 @@ SELECT registration_number, registration_ts, registration_type, registration_typ
                     AND r.user_id = u.username
                  ORDER BY u.id DESC
                  FETCH FIRST 1 ROWS ONLY)
-            ELSE NULL END staff_account_id
+            ELSE NULL END staff_account_id,
+       CASE WHEN arv1.account_id != '0'
+            THEN (SELECT d.document_number
+                   FROM drafts d, registrations r
+                  WHERE arv1.registration_id = r.id
+                    AND r.draft_id = d.id)
+            ELSE NULL END draft_number,
+       (SELECT r.ver_bypassed FROM registrations r WHERE r.id = arv1.registration_id) as locked_status
   FROM account_registration_vw arv1
  WHERE arv1.account_id = :query_account
    AND arv1.registration_type_cl IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')
@@ -372,7 +385,13 @@ SELECT registration_number, registration_ts, registration_type, registration_typ
                     AND r.user_id = u.username
                  ORDER BY u.id DESC
                  FETCH FIRST 1 ROWS ONLY)
-            ELSE NULL END staff_account_id
+            ELSE NULL END staff_account_id,
+       CASE WHEN account_id != '0'
+            THEN (SELECT d.document_number
+                   FROM drafts d, registrations r
+                  WHERE registration_id = r.id
+                    AND r.draft_id = d.id)
+            ELSE NULL END draft_number
   FROM account_registration_vw
  WHERE registration_type_cl NOT IN ('CROWNLIEN', 'MISCLIEN', 'PPSALIEN')
    AND (account_id = :query_account OR base_account_id = :query_account)

--- a/ppr-api/tests/unit/models/test_registration_utils.py
+++ b/ppr-api/tests/unit/models/test_registration_utils.py
@@ -409,6 +409,7 @@ def test_find_all_by_account_id_filter(session, reg_num, reg_type, client_ref, r
         assert statement['baseRegistrationNumber']
         if reg_num == 'TEST0018A':
             assert len(statement['changes']) > 0
+        assert statement.get("draftNumber")
         if 'changes' in statement:
             for change in statement['changes']:
                 # current_app.logger.info('reg_num=' + change.get('registrationNumber'))
@@ -430,6 +431,7 @@ def test_find_all_by_account_id_filter(session, reg_num, reg_type, client_ref, r
                     assert change.get('accountId')
                 else:
                     assert 'accountId' not in change
+                assert change.get("draftNumber")
                 #if change['baseRegistrationNumber'] in ('TEST0019', 'TEST0021'):
                 #    assert not change['path']
                 #elif change.get('registrationNumber', '') in ('TEST00D4', 'TEST00R5', 'TEST0007'):
@@ -478,6 +480,7 @@ def test_find_all_by_account_id_api_filter(session, reg_num, client_ref, start_t
         elif not is_ci_testing():
             assert statement['path']
         assert statement['baseRegistrationNumber']
+        assert statement.get("draftNumber")
         if reg_num == 'TEST0018A':
             assert len(statement['changes']) > 0
         if 'changes' in statement:
@@ -496,6 +499,7 @@ def test_find_all_by_account_id_api_filter(session, reg_num, client_ref, start_t
                 if not is_ci_testing():
                     assert 'path' in change
                 assert 'legacy' in change
+                assert change.get("draftNumber")
                 # if change['baseRegistrationNumber'] in ('TEST0019', 'TEST0021'):
                 #    assert not change['path']
                 # elif change.get('registrationNumber', '') == 'TEST00D4':


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29100

*Description of changes:*
Account registrations add identifier to link registration with a payment pending draft by draft number. Pending registrations have a draft number with a prefix of 'P'. The prefix is removed when the payment completes and the registration is created.
- For MHR add draftNumber to the GET /mhr/api/v1/registrations endpoint.
- For PPR add draftNumber (draft documentId) to the GET /mhr/api/v1/registrations endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
