### PR TITLE
MHR, PPR API add consumedDraftNumber to account registrations.

### DIFF
--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -877,7 +877,7 @@ def __build_summary(row, account_id: str, staff: bool, add_in_user_list: bool = 
         "documentRegistrationNumber": str(row[9]),
         "registrationType": str(row[5]),
         "locationType": str(row[22]),
-        "draftNumber": str(row[26]) if row[26] else "",
+        "consumedDraftNumber": str(row[26]) if row[26] else "",
     }
     summary = __get_report_path(account_id, staff, summary, row, timestamp)
     if add_in_user_list and summary["registrationType"] in (

--- a/mhr-api/src/mhr_api/resources/v1/pay_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/pay_callback.py
@@ -82,7 +82,9 @@ def post_payment_callback(invoice_id: str):  # pylint: disable=too-many-return-s
         draft: MhrDraft = MhrDraft.find_by_invoice_id(invoice_id)
         if not draft:
             # Handles payment notification update previously successful.
-            return pay_callback_error("03", invoice_id, HTTPStatus.NOT_FOUND)
+            # PAY API is sending notifications for other payment methods, just log as a warning.
+            logger.warning(f"No draft or search ID found matching invoice {invoice_id}, ignoring notification.")
+            return {}, HTTPStatus.OK
         base_reg: MhrRegistration = None
         if draft.mhr_number:
             base_reg = MhrRegistration.find_all_by_mhr_number(draft.mhr_number, draft.account_id, True)

--- a/mhr-api/tests/unit/api/test_pay_callback.py
+++ b/mhr-api/tests/unit/api/test_pay_callback.py
@@ -194,7 +194,7 @@ def test_pay_callback(session, client, jwt, desc, status, draft_json, mhr_num, r
                         json=payload,
                         headers=headers,
                         content_type='application/json')
-        assert rv.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.BAD_REQUEST)
+        assert rv.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.BAD_REQUEST, HTTPStatus.OK)
 
 
 @pytest.mark.parametrize('desc,invoice_id,search_id', TEST_SEARCH_ID_DATA)

--- a/mhr-api/tests/unit/api/test_registrations.py
+++ b/mhr-api/tests/unit/api/test_registrations.py
@@ -297,7 +297,7 @@ def test_get_account_registrations(session, client, jwt, desc, roles, status, ha
             assert registration['path'] is not None
             if registration['registrationDescription'] == 'REGISTER NEW UNIT':
                 assert 'lienRegistrationType' in registration
-            assert registration.get("draftNumber")
+            assert registration.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,has_submitting,roles,status,has_account,mhr_num', TEST_CREATE_DATA)
@@ -482,7 +482,7 @@ def test_get_account_registrations_sort(session, client, jwt, desc, roles, statu
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
-        assert registration.get("draftNumber")
+        assert registration.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,account_id,roles,status,filter_name,filter_value', TEST_GET_ACCOUNT_DATA_FILTER)
@@ -508,7 +508,7 @@ def test_get_account_registrations_filter(session, client, jwt, desc, account_id
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
-        assert registration.get("draftNumber")
+        assert registration.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,account_id,roles,status,collapse,filter_start,filter_end',
@@ -540,7 +540,7 @@ def test_get_account_registrations_filter_date(session, client, jwt, desc, accou
         assert registration['clientReferenceId'] is not None
         assert registration['ownerNames'] is not None
         assert registration['path'] is not None
-        assert registration.get("draftNumber")
+        assert registration.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,start_ts,end_ts,status,has_key,download_link',TEST_BATCH_MANUFACTURER_MHREG_DATA)

--- a/mhr-api/tests/unit/models/test_registration_utils.py
+++ b/mhr-api/tests/unit/models/test_registration_utils.py
@@ -340,7 +340,7 @@ def test_find_account_sort_order(session, account_id, sort_criteria, sort_order,
         assert registration['path'] is not None
         assert registration['documentId'] is not None
         assert not registration.get('inUserList')
-        assert registration.get("draftNumber")
+        assert registration.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('account_id,collapse,filter_name,filter_value,mhr_numbers,expected_clause',
@@ -490,4 +490,4 @@ def test_find_account_filter(session, account_id, collapse, filter_name, filter_
             assert registration.get("accountId")
         else:
             assert not registration.get("accountId")
-        assert registration.get("draftNumber")
+        assert registration.get("consumedDraftNumber")

--- a/ppr-api/src/ppr_api/models/registration_utils.py
+++ b/ppr-api/src/ppr_api/models/registration_utils.py
@@ -634,7 +634,7 @@ def __build_account_reg_result(
         "securedParties": str(row[11]),
         "clientReferenceId": str(row[12]),
         "registeringName": str(row[13]) if row[13] else "",
-        "draftNumber": str(row[18]) if row[18] else "",
+        "consumedDraftNumber": str(row[18]) if row[18] else "",
     }
     if not api_filter:
         result["vehicleCount"] = int(row[16])
@@ -680,7 +680,7 @@ def build_add_reg_result(row, account_id: str, base_reg_num: str, reg_num: str) 
         "registeringName": str(row[13]) if row[13] else "",
         "accountId": str(row[14]),
         "vehicleCount": int(row[16]),
-        "draftNumber": str(row[19]) if row[19] else "",
+        "consumedDraftNumber": str(row[19]) if row[19] else "",
     }
     result["legacy"] = result.get("accountId") == "0"
     if not row[7]:  # Report not generated

--- a/ppr-api/src/ppr_api/resources/v1/callbacks.py
+++ b/ppr-api/src/ppr_api/resources/v1/callbacks.py
@@ -159,7 +159,9 @@ def post_payment_callback(invoice_id: str):  # pylint: disable=too-many-return-s
 
         draft: Draft = Draft.find_by_invoice_id(invoice_id)
         if not draft:
-            return pay_callback_error("03", invoice_id, HTTPStatus.NOT_FOUND)
+            # PAY API is sending notifications for other payment methods, just log as a warning.
+            logger.warning(f"No draft or search ID found matching invoice {invoice_id}, ignoring notification.")
+            return {}, HTTPStatus.OK
         statement: FinancingStatement = None
         if draft.registration_number:
             statement = FinancingStatement.find_by_registration_number(

--- a/ppr-api/tests/unit/api/test_financing.py
+++ b/ppr-api/tests/unit/api/test_financing.py
@@ -599,7 +599,7 @@ def test_get_account_registrations_list(session, client, jwt, desc, roles, statu
     if status == HTTPStatus.OK:
         json_data = response.json
         for reg in json_data:
-            assert reg.get("draftNumber")
+            assert reg.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,roles,status,account_id,reg_num', TEST_USER_LIST)
@@ -621,7 +621,7 @@ def test_account_add_registration(session, client, jwt, desc, roles, status, acc
     assert response.status_code == status
     if desc == 'Valid Request User':
         json_data = response.json
-        assert json_data.get("draftNumber")
+        assert json_data.get("consumedDraftNumber")
         registration: Registration = Registration.find_by_registration_number(reg_num, account_id, True)
         assert registration.account_id == account_id
 
@@ -666,7 +666,7 @@ def test_account_get_registration(session, client, jwt, desc, roles, status, acc
     if status == HTTPStatus.OK:
         json_data = response.json
         assert json_data.get("baseRegistrationNumber")
-        assert json_data.get("draftNumber")
+        assert json_data.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,roles,status,has_account, reg_num', TEST_GET_STATEMENT)
@@ -714,13 +714,13 @@ def test_get_account_registrations_collapsed(session, client, jwt):
     assert len(json_data) > 0
     for statement in json_data:
         assert statement['registrationClass'] in ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
-        assert statement.get("draftNumber")
+        assert statement.get("consumedDraftNumber")
         if statement['registrationNumber'] == 'TEST0001':
             assert statement['changes']
             for change in statement['changes']:
                 assert change['baseRegistrationNumber'] == 'TEST0001'
                 assert change['registrationClass'] not in ('PPSALIEN', 'MISCLIEN', 'CROWNLIEN')
-                assert change.get("draftNumber")
+                assert change.get("consumedDraftNumber")
 
 
 @pytest.mark.parametrize('desc,reg_number,current_state,param_value', TEST_CURRENT_STATE)

--- a/ppr-api/tests/unit/models/test_registration_utils.py
+++ b/ppr-api/tests/unit/models/test_registration_utils.py
@@ -409,7 +409,7 @@ def test_find_all_by_account_id_filter(session, reg_num, reg_type, client_ref, r
         assert statement['baseRegistrationNumber']
         if reg_num == 'TEST0018A':
             assert len(statement['changes']) > 0
-        assert statement.get("draftNumber")
+        assert statement.get("consumedDraftNumber")
         if 'changes' in statement:
             for change in statement['changes']:
                 # current_app.logger.info('reg_num=' + change.get('registrationNumber'))
@@ -431,7 +431,7 @@ def test_find_all_by_account_id_filter(session, reg_num, reg_type, client_ref, r
                     assert change.get('accountId')
                 else:
                     assert 'accountId' not in change
-                assert change.get("draftNumber")
+                assert change.get("consumedDraftNumber")
                 #if change['baseRegistrationNumber'] in ('TEST0019', 'TEST0021'):
                 #    assert not change['path']
                 #elif change.get('registrationNumber', '') in ('TEST00D4', 'TEST00R5', 'TEST0007'):
@@ -480,7 +480,7 @@ def test_find_all_by_account_id_api_filter(session, reg_num, client_ref, start_t
         elif not is_ci_testing():
             assert statement['path']
         assert statement['baseRegistrationNumber']
-        assert statement.get("draftNumber")
+        assert statement.get("consumedDraftNumber")
         if reg_num == 'TEST0018A':
             assert len(statement['changes']) > 0
         if 'changes' in statement:
@@ -499,7 +499,7 @@ def test_find_all_by_account_id_api_filter(session, reg_num, client_ref, start_t
                 if not is_ci_testing():
                     assert 'path' in change
                 assert 'legacy' in change
-                assert change.get("draftNumber")
+                assert change.get("consumedDraftNumber")
                 # if change['baseRegistrationNumber'] in ('TEST0019', 'TEST0021'):
                 #    assert not change['path']
                 # elif change.get('registrationNumber', '') == 'TEST00D4':


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29100

*Description of changes:*
- For MHR add consumedDraftNumber to the GET /mhr/api/v1/registrations endpoint.
- For PPR add consumedDraftNumber (draft documentId) to the GET /mhr/api/v1/registrations endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
