### PR TITLE
PPR API client party code name change

### DIFF
--- a/ppr-api/src/ppr_api/models/client_code_registration.py
+++ b/ppr-api/src/ppr_api/models/client_code_registration.py
@@ -104,3 +104,15 @@ class ClientCodeRegistration(db.Model):
         )
         reg.client_code = code
         return reg
+
+    @staticmethod
+    def create_name_change_from_json(json_data: dict, user_id: str, code: ClientCode):
+        """Create a client party code name change registration from dict/json."""
+        reg: ClientCodeRegistration = ClientCodeRegistration(
+            create_ts=model_utils.now_ts(),
+            request_data=json_data,
+            user_id=user_id,
+            client_code_type=ClientCodeTypes.CHANGE_NAME,
+        )
+        reg.client_code = code
+        return reg

--- a/ppr-api/tests/postman/ppr-api-unit.postman_collection.json
+++ b/ppr-api/tests/postman/ppr-api-unit.postman_collection.json
@@ -2051,6 +2051,100 @@
 					"response": []
 				},
 				{
+					"name": "Change party code name staff branch",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"accountId\": \"5731\",\n    \"code\": \"71630001\",\n    \"businessName\": \"TEST BUSINESS NAME CHANGE 1\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url_ppr}}/api/v1/party-codes/accounts/names",
+							"host": [
+								"{{base_url_ppr}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"party-codes",
+								"accounts",
+								"names"
+							]
+						},
+						"description": "Get party by code example"
+					},
+					"response": []
+				},
+				{
+					"name": "Change party code name staff head office",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"accountId\": \"5731\",\n    \"headOfficeCode\": \"7163\",\n    \"businessName\": \"TEST BUSINESS NAME CHANGE 2\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url_ppr}}/api/v1/party-codes/accounts/names",
+							"host": [
+								"{{base_url_ppr}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"party-codes",
+								"accounts",
+								"names"
+							]
+						},
+						"description": "Get party by code example"
+					},
+					"response": []
+				},
+				{
 					"name": "Get party code by securities act account",
 					"request": {
 						"method": "GET",

--- a/ppr-api/tests/unit/models/test_client_code.py
+++ b/ppr-api/tests/unit/models/test_client_code.py
@@ -19,7 +19,7 @@ Test-Suite to ensure that the ClientCode Model is working as expected.
 import copy
 import pytest
 
-from ppr_api.models import Address, ClientCode
+from ppr_api.models import Address, ClientCode, ClientCodeHistorical
 from ppr_api.utils.logging import logger
 
 
@@ -35,14 +35,14 @@ TEST_CODE_NEW =   {
     },
     "emailAddress": "test-1@test-ptc.com",
     "contact": {
-      "name": "Example Contact 1",
+      "name": "EXAMPLE CONTACT 1",
       "areaCode": "250",
       "phoneNumber": "3564500"
     }
 }
 TEST_CODE_NEW_BRANCH =   {
     "accountId": "1234",
-    "businessName": "PETERBILT TRUCKS PACIFIC INC. - Branch 1",
+    "businessName": "PETERBILT TRUCKS PACIFIC INC. - BRANCH 1",
     "address": {
       "street": "1234 JAMES ST",
       "city": "SAANICH",
@@ -52,7 +52,7 @@ TEST_CODE_NEW_BRANCH =   {
     },
     "emailAddress": "test-2@test-ptc.com",
     "contact": {
-      "name": "Example Contact 2",
+      "name": "EXAMPLE CONTACT 2",
       "areaCode": "250",
       "phoneNumber": "3564501"
     }
@@ -336,3 +336,31 @@ def test_create_branch_from_json(session):
     request_address = TEST_CODE_NEW_BRANCH.get("address")
     logger.debug(f"request address {request_address}")
     assert request_address == address.json
+
+
+def test_create_historical(session):
+    """Assert that creating a client code historical object from a client code works as expected."""
+    code: ClientCode = ClientCode(
+        id=10001,
+        head_id=1,
+        name='BUSINESS NAME',
+        contact_name='CONTACT',
+        contact_area_cd='250',
+        contact_phone_number='1234567',
+        email_id='test@gmail.com',
+        account_id='1234',
+        address_id=200000000,
+        bconline_account=123456
+    )
+    hist_type: str = ClientCodeHistorical.HistoricalTypes.NAME.value
+    hist_code: ClientCodeHistorical = ClientCodeHistorical.create_from_client_code(code, hist_type)
+    assert hist_code.branch_id == code.id
+    assert hist_code.head_id == code.head_id
+    assert hist_code.name == code.name
+    assert hist_code.contact_name == code.contact_name
+    assert hist_code.contact_area_cd == code.contact_area_cd
+    assert hist_code.contact_phone_number == code.contact_phone_number
+    assert hist_code.email_id == code.email_id
+    assert hist_code.bconline_account == code.bconline_account
+    assert hist_code.address_id == code.address_id
+    assert hist_code.historical_type == hist_type


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29138

*Description of changes:*
- Create new PATCH endpoint for a client party code name change PATCH /ppr/api/v1/party-codes/accounts/names.
- Initially no fee. Use PPR fee code SPMUP with address change ticket. Default no fee for staff.
- Update unit tests and postman collection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
