### PR TITLE
PPR API RL registration cleanup.

### DIFF
--- a/ppr-api/src/ppr_api/models/registration.py
+++ b/ppr-api/src/ppr_api/models/registration.py
@@ -672,13 +672,7 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes, t
         registration.registration_type = reg_type
         registration.ver_bypassed = "Y"
 
-        if reg_type == model_utils.REG_TYPE_REPAIRER_LIEN:
-            if "lienAmount" in json_data:
-                registration.lien_value = json_data["lienAmount"].strip()
-            if "surrenderDate" in json_data:
-                registration.surrender_date = model_utils.ts_from_date_iso_format(json_data["surrenderDate"])
-            registration.life = model_utils.REPAIRER_LIEN_YEARS
-        elif "lifeInfinite" in json_data and json_data["lifeInfinite"]:
+        if "lifeInfinite" in json_data and json_data["lifeInfinite"]:
             registration.life = model_utils.LIFE_INFINITE
         elif registration.registration_type_cl in (model_utils.REG_CLASS_CROWN, model_utils.REG_CLASS_MISC):
             registration.life = model_utils.LIFE_INFINITE

--- a/ppr-api/src/ppr_api/models/utils.py
+++ b/ppr-api/src/ppr_api/models/utils.py
@@ -101,6 +101,7 @@ REG_TYPE_NEW_FINANCING_EXCLUDED = {
     "TG": "TG",
     "TL": "TL",
     "TM": "TM",
+    "RL": "RL",
 }
 
 # Mapping from API draft type to DB registration class
@@ -821,22 +822,6 @@ def report_retry_elapsed(last_ts: _datetime):
     test_ts = (last_ts + timedelta(minutes=15)).replace(tzinfo=timezone.utc)
     # logger.info('Comparing now ' + now.isoformat() + ' with last ts ' + test_ts.isoformat())
     return now > test_ts
-
-
-def is_rl_enabled() -> bool:
-    """If a repairer's lien act timestamp exists, verify the current timestamp is before."""
-    reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.RL.value)
-    if reg_type and reg_type.act_ts:
-        return now_ts().timestamp() < reg_type.act_ts.timestamp()
-    return True
-
-
-def is_cl_enabled() -> bool:
-    """If a commercial liens act timestamp exists, verify the current timestamp is later."""
-    reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
-    if reg_type and reg_type.act_ts:
-        return now_ts().timestamp() > reg_type.act_ts.timestamp()
-    return True
 
 
 def is_rl_transition() -> bool:

--- a/ppr-api/src/ppr_api/resources/financing_utils.py
+++ b/ppr-api/src/ppr_api/resources/financing_utils.py
@@ -76,9 +76,6 @@ def save_rl_transition(registration_class: str, financing_statement: FinancingSt
     base_reg: Registration = financing_statement.registration[0]
     if not base_reg or base_reg.registration_type != RegistrationTypes.RL.value:
         return
-    if not model_utils.is_rl_transition():
-        logger.info(f"RL registration on {base_reg.registration_num} before CLA transition: reg type unchanged.")
-        return
     logger.info(f"RL registration on {base_reg.registration_num} after CLA transition: reg type changing to CL.")
     base_reg.registration_type = RegistrationTypes.CL.value
     try:

--- a/ppr-api/src/ppr_api/resources/utils.py
+++ b/ppr-api/src/ppr_api/resources/utils.py
@@ -486,8 +486,6 @@ def get_payment_type_financing(registration):
     elif registration.registration_type == RegistrationTypes.FR.value:
         pay_trans_type = TransactionTypes.FINANCING_FR.value
         fee_quantity = 1
-    elif registration.registration_type == RegistrationTypes.RL.value:
-        fee_quantity = 1
     elif registration.registration_type == RegistrationTypes.CL.value:
         if registration.life != model_utils.LIFE_INFINITE:
             pay_trans_type = TransactionTypes.FINANCING_CL.value

--- a/ppr-api/tests/unit/api/test_amendment.py
+++ b/ppr-api/tests/unit/api/test_amendment.py
@@ -427,7 +427,6 @@ TEST_CREATE_SE_DATA = [
 ]
 # testdata pattern is ({desc}, {test data}, {roles}, {status}, {after_cla}, {reg_num})
 TEST_CREATE_RL_DATA = [
-    ('Valid before CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, False, 'TEST0017'),
     ('Valid after CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, True, 'TEST0017'),
 ]
 
@@ -461,10 +460,7 @@ def test_create_amendment_rl(session, client, jwt, desc, json_data, roles, statu
     if status == HTTPStatus.CREATED:
         statement: FinancingStatement = FinancingStatement.find_by_registration_number(reg_num, 'PS12345', True)
         reg_type: str = statement.registration[0].registration_type
-        if after_cla:
-            assert reg_type == RegistrationTypes.CL.value
-        else:
-            assert reg_type == RegistrationTypes.RL.value
+        assert reg_type == RegistrationTypes.CL.value
 
 
 @pytest.mark.parametrize('desc,json_data,reg_num,account_id,status', TEST_CREATE_SE_DATA)

--- a/ppr-api/tests/unit/api/test_discharge.py
+++ b/ppr-api/tests/unit/api/test_discharge.py
@@ -191,7 +191,6 @@ TEST_GET_STATEMENT2 = [
 ]
 # testdata pattern is ({desc}, {test data}, {roles}, {status}, {after_cla}, {reg_num})
 TEST_CREATE_RL_DATA = [
-    ('Valid before CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, False, 'TEST0017'),
     ('Valid after CLA', STATEMENT_VALID, [PPR_ROLE, STAFF_ROLE], HTTPStatus.CREATED, True, 'TEST0017'),
 ]
 
@@ -225,10 +224,7 @@ def test_create_discharge_rl(session, client, jwt, desc, json_data, roles, statu
     if status == HTTPStatus.CREATED:
         statement: FinancingStatement = FinancingStatement.find_by_registration_number(reg_num, 'PS12345', True)
         reg_type: str = statement.registration[0].registration_type
-        if after_cla:
-            assert reg_type == RegistrationTypes.CL.value
-        else:
-            assert reg_type == RegistrationTypes.RL.value
+        assert reg_type == RegistrationTypes.CL.value
 
 
 @pytest.mark.parametrize('desc,json_data,roles,status,has_account,reg_num', TEST_CREATE_DATA)

--- a/ppr-api/tests/unit/api/test_financing.py
+++ b/ppr-api/tests/unit/api/test_financing.py
@@ -415,7 +415,6 @@ TEST_PAY_DETAILS_REGISTRATION = [
 # testdata pattern is ({reg_type}, {registration_number}, {detail_desc}, {life})
 TEST_PAY_DETAILS_FINANCING = [
     ('SA', 'TEST0001', 'PPSA SECURITY AGREEMENT Length: 2 years', 2),
-    ('RL', 'TEST0002', 'REPAIRERS LIEN Length: 180 days', 0)
 ]
 # testdata pattern is ({reg_type}, {life_years}, {quantity}, {pay_trans_type})
 TEST_PAY_TYPE_FINANCING = [
@@ -425,7 +424,6 @@ TEST_PAY_TYPE_FINANCING = [
     ('FS', 2, 2, TransactionTypes.FINANCING_LIFE_YEAR.value),
     ('LT', 1, 1, TransactionTypes.FINANCING_NO_FEE.value),
     ('MH', 1, 1, TransactionTypes.FINANCING_NO_FEE.value),
-    ('RL', 0, 1, TransactionTypes.FINANCING_LIFE_YEAR.value),
     ('SG', 3, 3, TransactionTypes.FINANCING_LIFE_YEAR.value),
     ('SA', 5, 5, TransactionTypes.FINANCING_LIFE_YEAR.value),
     ('SA', 99, 1, TransactionTypes.FINANCING_INFINITE.value),

--- a/ppr-api/tests/unit/models/test_financing_statement.py
+++ b/ppr-api/tests/unit/models/test_financing_statement.py
@@ -48,7 +48,6 @@ TEST_REGISTRATION_DATA = [
     ('SA', 'PS12345', False),
     ('SA', 'PS12345', True),
     ('SE', 'PS00002', True),
-    ('RL', 'PS12345', False),
     ('OT', 'PS12345', False),
     ('SA', None, False)
 ]
@@ -84,7 +83,6 @@ TEST_DEBTOR_NAMES_DATA = [
 TEST_LIFE_EXPIRY_DATA = [
     ('SA', 5, False, 5),
     ('SA', None, True, 99),
-    ('RL', 1, False, model_utils.REPAIRER_LIEN_YEARS),
     ('MH', 1, False, model_utils.LIFE_INFINITE),
     ('LT', None, True, model_utils.LIFE_INFINITE),
     ('FR', 5, False, model_utils.LIFE_INFINITE),
@@ -95,14 +93,11 @@ TEST_LIFE_EXPIRY_DATA = [
 TEST_VERIFICATION_EXPIRY_DATA = [
     ('TEST0016', 'SA', False, '2026-09-04T06:59:59+00:00', 5),
     ('TEST0016', 'SA', True, '2041-09-04T06:59:59+00:00', 20),
-    ('TEST0017', 'RL', False, '2022-02-27T07:59:59+00:00', 0),
-    ('TEST0017', 'RL', True, '2023-02-23T07:59:59+00:00', 0)
 ]
 
 # testdata pattern is ({reg_num}, {reg_type}, {expiry_ts}, {renewal2_ts}, {renewal1_ts})
 TEST_HISTORY_EXPIRY_DATA = [
     ('TEST0016', 'SA', '2041-09-04T06:59:59+00:00', '2036-09-04T06:59:59+00:00', '2041-09-04T06:59:59+00:00')
-#    ('TEST0017', 'RL', '2023-02-23T07:59:59+00:00', '2022-08-27T06:59:59+00:00', '2023-02-23T07:59:59+00:00')
 ]
 
 @pytest.mark.parametrize('reg_type,account_id,create_draft', TEST_REGISTRATION_DATA)

--- a/ppr-api/tests/unit/models/test_registration.py
+++ b/ppr-api/tests/unit/models/test_registration.py
@@ -226,7 +226,6 @@ TEST_ACCOUNT_ADD_REGISTRATION_DATA = [
 TEST_LIFE_EXPIRY_DATA = [
     ('SA', 5, False, 5),
     ('SA', None, True, 99),
-    ('RL', 1, False, model_utils.REPAIRER_LIEN_YEARS),
     ('MH', 1, False, model_utils.LIFE_INFINITE),
     ('LT', None, True, model_utils.LIFE_INFINITE),
     ('FR', 5, False, model_utils.LIFE_INFINITE),
@@ -238,7 +237,6 @@ TEST_EXPIRY_DATA = [
     ('TEST0016', 'SA', '2041-09-04T06:59:59+00:00'),
     ('TEST0016R1', 'RE', '2036-09-04T06:59:59+00:00'),
     ('TEST0016R2', 'RE', '2041-09-04T06:59:59+00:00')
-#    ('TEST0017', 'RL', '2023-02-23T07:59:59+00:00'),
 #    ('TEST0017R1', 'RE', '2022-08-27T06:59:59+00:00'),
 #    ('TEST0017R2', 'RE', '2023-02-23T07:59:59+00:00')
 ]
@@ -675,7 +673,7 @@ def test_save_discharge(session):
 
 
 def test_save_renewal(session):
-    """Assert that creating a renewal statement on a non-RL financing statement contains all expected elements."""
+    """Assert that creating a renewal registration on a financing statement contains all expected elements."""
     json_data = copy.deepcopy(RENEWAL_STATEMENT)
     del json_data['createDateTime']
     del json_data['renewalRegistrationNumber']
@@ -709,44 +707,8 @@ def test_save_renewal(session):
     assert result['registeringParty']
 
 
-def test_save_renewal_rl(session):
-    """Assert that creating a renewal statement on a RL financing statement contains all expected elements."""
-    json_data = copy.deepcopy(RENEWAL_STATEMENT)
-    del json_data['createDateTime']
-    del json_data['renewalRegistrationNumber']
-    del json_data['payment']
-    del json_data['expiryDate']
-
-    financing_statement = FinancingStatement.find_by_financing_id(200000001)
-    assert financing_statement
-
-    registration = Registration.create_from_json(json_data,
-                                                 'RENEWAL',
-                                                 financing_statement,
-                                                 'TEST0002',
-                                                 'PS12345')
-#    print(registration.financing_id)
-#    print(registration.json)
-    registration.save()
-    assert registration.financing_id == 200000001
-    assert registration.id
-    assert registration.registration_num
-    assert registration.registration_type
-    assert registration.registration_ts
-    assert registration.account_id
-    assert registration.client_reference_id
-
-    result = registration.json
-    assert result
-    assert result['baseRegistrationNumber']
-    assert result['renewalRegistrationNumber']
-    assert result['createDateTime']
-    assert result['registeringParty']
-    assert result['courtOrderInformation']
-
-
 def test_save_amendment(session):
-    """Assert that creating an amendment statement on a non-RL financing statement contains all expected elements."""
+    """Assert that creating an amendment statement on a financing statement contains all expected elements."""
     json_data = copy.deepcopy(AMENDMENT_STATEMENT)
     del json_data['createDateTime']
     del json_data['amendmentRegistrationNumber']
@@ -873,7 +835,7 @@ def test_save_amendment_trust(session):
 
 
 def test_save_amendment_from_draft(session):
-    """Assert that creating an amendment statement from a draft on a non-RL financing statement.
+    """Assert that creating an amendment statement from a draft on a financing statement.
 
     Verify it contains all expected elements.
     """

--- a/ppr-api/tests/unit/models/test_utils.py
+++ b/ppr-api/tests/unit/models/test_utils.py
@@ -98,49 +98,10 @@ TEST_DATA_EXPIRY = [
     ('2022-09-01T00:00:01-07:00', 16, '2038-09-02T06:59:59+00:00'),
     ('2022-09-01T00:00:01-07:00', 25, '2047-09-02T06:59:59+00:00')
 ]
-# testdata pattern is ({registration_ts}, {expiry_ts})
-TEST_DATA_EXPIRY_RL = [
-    ('2021-08-31T06:59:59+00:00', '2022-02-27T07:59:59+00:00'),
-    ('2021-09-01T06:59:59+00:00', '2022-02-28T07:59:59+00:00'),
-    ('2021-09-02T06:59:59+00:00', '2022-03-01T07:59:59+00:00'),
-    ('2021-09-13T06:59:59+00:00', '2022-03-12T07:59:59+00:00'),
-    ('2021-09-14T06:59:59+00:00', '2022-03-13T07:59:59+00:00'),
-    ('2021-09-30T06:59:59+00:00', '2022-03-29T06:59:59+00:00'),
-    ('2021-10-01T06:59:59+00:00', '2022-03-30T06:59:59+00:00'),
-    ('2021-10-31T06:59:59+00:00', '2022-04-29T06:59:59+00:00'),
-    ('2021-11-07T06:59:59+00:00', '2022-05-06T06:59:59+00:00'),
-    ('2021-11-08T07:59:59+00:00', '2022-05-07T06:59:59+00:00'),
-    ('2021-12-01T07:59:59+00:00', '2022-05-30T06:59:59+00:00'),
-    ('2022-01-01T07:59:59+00:00', '2022-06-30T06:59:59+00:00'),
-    ('2022-02-01T07:59:59+00:00', '2022-07-31T06:59:59+00:00'),
-    ('2022-03-01T07:59:59+00:00', '2022-08-28T06:59:59+00:00'),
-    ('2022-03-13T07:59:59+00:00', '2022-09-09T06:59:59+00:00'),
-    ('2022-03-14T06:59:59+00:00', '2022-09-10T06:59:59+00:00'),
-    ('2022-04-01T06:59:59+00:00', '2022-09-28T06:59:59+00:00'),
-    ('2022-05-01T06:59:59+00:00', '2022-10-28T06:59:59+00:00'),
-    ('2022-05-10T06:59:59+00:00', '2022-11-06T06:59:59+00:00'),
-    ('2022-05-11T06:59:59+00:00', '2022-11-07T07:59:59+00:00'),
-    ('2022-06-01T06:59:59+00:00', '2022-11-28T07:59:59+00:00'),
-    ('2022-07-01T06:59:59+00:00', '2022-12-28T07:59:59+00:00'),
-    ('2022-08-01T06:59:59+00:00', '2023-01-28T07:59:59+00:00')
-]
 # testdata pattern is ({registration_ts}, {add_1}, {add_2}, {add_3}, {expiry_ts})
 TEST_DATA_EXPIRY_ADD = [
     ('2021-08-31T00:00:01-07:00', 10, 5, 2, '2038-09-01T06:59:59+00:00'),
     ('2021-01-31T00:00:01-08:00', 2, 3, 5, '2031-02-01T07:59:59+00:00')
-]
-# testdata pattern is ({desc}, {registration_ts}, {renew_count}, {expiry_ts})
-TEST_DATA_EXPIRY_RENEW_RL = [
-    ('Registration', '2021-08-31T00:00:01-07:00', 0, '2022-02-27T07:59:59+00:00'),
-    ('1 renewal', '2021-08-31T00:00:01-07:00', 1, '2022-08-26T06:59:59+00:00'),
-    ('2 renewals', '2021-08-31T00:00:01-07:00', 2, '2023-02-22T07:59:59+00:00')
-]
-# testdata pattern is ({desc}, {renew_count}, {expiry_days})
-TEST_DATA_EXPIRY_RL_DAYS = [
-    ('Registration', 0, 180),
-    ('1 renewal', 1, 360),
-    ('2 renewals', 2, 540),
-    ('3 renewals', 3, 720)
 ]
 
 # testdata pattern is ({desc}, {registration_ts}, {life_years}, {hour}, {expiry_ts})
@@ -196,18 +157,6 @@ TEST_DATA_DOC_STORAGE_NAME = [
     ('Amendment', 'TEST0007', 'amendment-200000008-TEST0007.pdf')
 ]
 # testdata pattern is (today_offset, valid)
-TEST_DATA_VALID_RL = [
-    (None, True),
-    (1, True),
-    (-1, False),
-]
-# testdata pattern is (today_offset, valid)
-TEST_DATA_VALID_CL = [
-    (None, True),
-    (1, False),
-    (-1, True),
-]
-# testdata pattern is (today_offset, valid)
 TEST_DATA_TRANSITION_RL = [
     (None, False),
     (1, False),
@@ -220,16 +169,6 @@ def test_expiry_date(session, registration_ts, offset, expiry_ts):
     """Assert that computing expiry ts from registraton ts works as expected."""
     # reg_ts = model_utils.ts_from_iso_format(registration_ts)
     expiry_test = model_utils.expiry_dt_from_years(offset, registration_ts)
-    expiry_iso = model_utils.format_ts(expiry_test)
-    # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
-    assert expiry_ts == expiry_iso
-
-
-@pytest.mark.parametrize('registration_ts,expiry_ts', TEST_DATA_EXPIRY_RL)
-def test_expiry_date_rl(session, registration_ts, expiry_ts):
-    """Assert that computing an RL expiry ts from registraton ts works as expected."""
-    reg_ts = model_utils.ts_from_iso_format(registration_ts)
-    expiry_test = model_utils.expiry_dt_repairer_lien(reg_ts)
     expiry_iso = model_utils.format_ts(expiry_test)
     # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
     assert expiry_ts == expiry_iso
@@ -257,35 +196,6 @@ def test_expiry_date_add(session, registration_ts, add_1, add_2, add_3, expiry_t
     expiry_iso = model_utils.format_ts(expiry_add_3)
     # print(registration_ts + ', ' + model_utils.format_ts(reg_ts) + ', '  + expiry_iso)
     assert expiry_ts == expiry_iso
-
-
-@pytest.mark.parametrize('desc,registration_ts,renew_count,expiry_ts', TEST_DATA_EXPIRY_RENEW_RL)
-def test_expiry_date_renew_rl(session, desc, registration_ts, renew_count, expiry_ts):
-    """Assert that computing multiple RL renewal expiry ts from registration ts works as expected."""
-    reg_ts = model_utils.ts_from_iso_format(registration_ts)
-    expiry_test = model_utils.expiry_dt_repairer_lien(reg_ts)
-    # print(model_utils.format_ts(expiry_test))
-    if renew_count > 0:
-        for x in range(renew_count):
-            expiry_test = model_utils.expiry_dt_repairer_lien(expiry_test)
-            # print(model_utils.format_ts(expiry_test))
-
-    expiry_iso = model_utils.format_ts(expiry_test)
-    assert expiry_ts == expiry_iso
-
-
-@pytest.mark.parametrize('desc,renew_count,expiry_days', TEST_DATA_EXPIRY_RL_DAYS)
-def test_expiry_rl_days(session, desc, renew_count, expiry_days):
-    """Assert that computing multiple renewal days to expiry works as expected."""
-    expiry_test = model_utils.expiry_dt_repairer_lien()
-    now = model_utils.now_ts()
-    # print(model_utils.format_ts(expiry_test))
-    if renew_count > 0:
-        for x in range(renew_count):
-            expiry_test = model_utils.expiry_dt_repairer_lien(expiry_test)
-            # print(model_utils.format_ts(expiry_test))
-    ts_delta = expiry_test - now
-    assert ts_delta.days == expiry_days
 
 
 def test_expiry_dt_from_years():
@@ -564,32 +474,6 @@ def test_mail_doc_storage_name(session):
     search: SearchRequest = SearchRequest(id=2000, search_ts=model_utils.now_ts())
     name = model_utils.get_mail_doc_storage_name(reg_ts, 1000, 2000)
     assert test_name == name
-
-
-@pytest.mark.parametrize('today_offset,valid', TEST_DATA_VALID_RL)
-def test_rl_enabled(session, today_offset, valid):
-    """Assert that checking a RL act timestamp for type validity works as expected."""
-    if today_offset:
-        now_offset = model_utils.now_ts_offset(today_offset, True)
-        reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.RL.value)
-        reg_type.act_ts = now_offset
-        session.add(reg_type)
-        session.commit()
-    test_valid = model_utils.is_rl_enabled()
-    assert test_valid == valid
-
-
-@pytest.mark.parametrize('today_offset,valid', TEST_DATA_VALID_CL)
-def test_cl_enabled(session, today_offset, valid):
-    """Assert that checking a CL act timestamp for type validity works as expected."""
-    if today_offset:
-        now_offset = model_utils.now_ts_offset(today_offset, True)
-        reg_type: RegistrationType = RegistrationType.find_by_registration_type(RegistrationTypes.CL.value)
-        reg_type.act_ts = now_offset
-        session.add(reg_type)
-        session.commit()
-    test_valid = model_utils.is_cl_enabled()
-    assert test_valid == valid
 
 
 @pytest.mark.parametrize('today_offset,valid', TEST_DATA_TRANSITION_RL)

--- a/ppr-api/tests/unit/utils/test_registration_validator.py
+++ b/ppr-api/tests/unit/utils/test_registration_validator.py
@@ -328,105 +328,6 @@ RENEWAL_SA_INVALID = {
       'effectOfOrder': 'Court Order to renew Repairers Lien.'
     }
 }
-RENEWAL_RL_VALID = {
-    'baseRegistrationNumber': 'TEST0017',
-    'clientReferenceId': 'A-00000402',
-    'authorizationReceived': True,
-    'debtorName': {
-        'businessName': 'TEST BUS 2 DEBTOR'
-    },
-    'registeringParty': {
-        'businessName': 'ABC SEARCHING COMPANY',
-        'address': {
-            'street': '222 SUMMER STREET',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'country': 'CA',
-            'postalCode': 'V8W 2V8'
-        },
-        'emailAddress': 'bsmith@abc-search.com'
-    },
-    'courtOrderInformation': {
-      'courtName': 'Supreme Court of British Columbia.',
-      'courtRegistry': 'VICTORIA',
-      'fileNumber': 'BC123495',
-      'orderDate': '2021-09-05T07:01:00+00:00',
-      'effectOfOrder': 'Court Order to renew Repairers Lien.'
-    }
-}
-RENEWAL_RL_MISSING = {
-    'baseRegistrationNumber': 'TEST0017',
-    'clientReferenceId': 'A-00000402',
-    'authorizationReceived': True,
-    'debtorName': {
-        'businessName': 'TEST BUS 2 DEBTOR'
-    },
-    'registeringParty': {
-        'businessName': 'ABC SEARCHING COMPANY',
-        'address': {
-            'street': '222 SUMMER STREET',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'country': 'CA',
-            'postalCode': 'V8W 2V8'
-        },
-        'emailAddress': 'bsmith@abc-search.com'
-    }
-}
-RENEWAL_RL_INVALID_DATE = {
-    'baseRegistrationNumber': 'TEST0017',
-    'clientReferenceId': 'A-00000402',
-    'authorizationReceived': True,
-    'debtorName': {
-        'businessName': 'TEST BUS 2 DEBTOR'
-    },
-    'registeringParty': {
-        'businessName': 'ABC SEARCHING COMPANY',
-        'address': {
-            'street': '222 SUMMER STREET',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'country': 'CA',
-            'postalCode': 'V8W 2V8'
-        },
-        'emailAddress': 'bsmith@abc-search.com'
-    },
-    'lifeYears': 5,
-    'courtOrderInformation': {
-      'courtName': 'Supreme Court of British Columbia.',
-      'courtRegistry': 'VICTORIA',
-      'fileNumber': 'BC123495',
-      'orderDate': '2021-08-05T07:01:00+00:00',
-      'effectOfOrder': 'Court Order to renew Repairers Lien.'
-    }
-}
-RENEWAL_RL_LIFE_INFINITE = {
-    'baseRegistrationNumber': 'TEST0017',
-    'clientReferenceId': 'A-00000402',
-    'authorizationReceived': True,
-    'debtorName': {
-        'businessName': 'TEST BUS 2 DEBTOR'
-    },
-    'registeringParty': {
-        'businessName': 'ABC SEARCHING COMPANY',
-        'address': {
-            'street': '222 SUMMER STREET',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'country': 'CA',
-            'postalCode': 'V8W 2V8'
-        },
-        'emailAddress': 'bsmith@abc-search.com'
-    },
-    'lifeInfinite': True,
-    'courtOrderInformation': {
-      'courtName': 'Supreme Court of British Columbia.',
-      'courtRegistry': 'VICTORIA',
-      'fileNumber': 'BC123495',
-      'orderDate': '2021-09-05T07:01:00+00:00',
-      'effectOfOrder': 'Court Order to renew Repairers Lien.'
-    }
-}
 ADD_SECURITIES_ACT_NOTICES = [
     {
         'securitiesActNoticeType': 'LIEN',
@@ -481,14 +382,10 @@ TEST_AUTHORIZATION_DATA = [
 TEST_RENEWAL_DATA = [
     ('TEST0001', RENEWAL_SA_VALID, True, None, None),
     ('TEST0001', RENEWAL_SA_INFINITE_VALID, True, None, None),
-    ('TEST0017', RENEWAL_RL_VALID, True, 1, None),
     ('TEST0001', RENEWAL_SA_INVALID, False, None, 'CourtOrderInformation is not allowed'),
     ('TEST0012', RENEWAL_SA_VALID, False, None, validator.RENEWAL_INVALID),
     ('TEST0001', RENEWAL_SA_LIFE_MISSING, False, None, validator.LIFE_MISSING),
     ('TEST0001', RENEWAL_SA_LIFE_INVALID, False, None, validator.LIFE_INVALID),
-    ('TEST0017', RENEWAL_RL_MISSING, False, 1, validator.COURT_ORDER_MISSING),
-    ('TEST0017', RENEWAL_RL_LIFE_INFINITE, False, 1, validator.LI_NOT_ALLOWED),
-    ('TEST0017', RENEWAL_RL_INVALID_DATE, False, 1, validator.COURT_ORDER_INVALID_DATE),
     ('TEST0017', RENEWAL_SA_VALID, True, -1, None),
     ('TEST0017', RENEWAL_SA_INFINITE_VALID, True, -1, None),
     ('TEST0017', RENEWAL_SA_INVALID, False, -1, 'CourtOrderInformation is not allowed'),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29182

*Description of changes:*
- Remove code related to new RL registrations.
- Make the RL registration type one of the deprecated types - remove code that checks the CL go live timestamp.
-  Update new registration and renewal validation rules to remove RL checks
- Update unit tests - remove new RL registrations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
