### PR TITLE
MHR API new reg pay api add reg number.

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.0.15"
+version = "2.0.16"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/mhr_draft.py
+++ b/mhr-api/src/mhr_api/models/mhr_draft.py
@@ -28,7 +28,6 @@ from mhr_api.utils.logging import logger
 
 from .db import db
 
-
 QUERY_PKEYS = """
 select get_mhr_draft_number() AS draft_num,
        nextval('mhr_draft_id_seq') AS draft_id

--- a/mhr-api/src/mhr_api/resources/v1/pay_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/pay_callback.py
@@ -86,9 +86,9 @@ def post_payment_callback(invoice_id: str):  # pylint: disable=too-many-return-s
             logger.warning(f"No draft or search ID found matching invoice {invoice_id}, ignoring notification.")
             return {}, HTTPStatus.OK
         base_reg: MhrRegistration = None
-        if draft.mhr_number:
+        if draft.mhr_number and draft.registration_type != MhrRegistrationTypes.MHREG:
             base_reg = MhrRegistration.find_all_by_mhr_number(draft.mhr_number, draft.account_id, True)
-        if not base_reg and draft.mhr_number:
+        if not base_reg and draft.mhr_number and draft.registration_type != MhrRegistrationTypes.MHREG:
             error_msg: str = PAY_NO_REG_MSG.format(mhr_num=draft.mhr_number)
             return pay_callback_error("04", invoice_id, HTTPStatus.NOT_FOUND, error_msg)
         logger.info(f"Request valid for invoice id={invoice_id} draft id={draft.id}, creating registration.")

--- a/mhr-api/tests/unit/api/test_pay_callback.py
+++ b/mhr-api/tests/unit/api/test_pay_callback.py
@@ -170,7 +170,10 @@ def test_pay_callback(session, client, jwt, desc, status, draft_json, mhr_num, r
         new_reg: MhrRegistration = None
         base_reg: MhrRegistration = None
         if reg_type == MhrRegistrationTypes.MHREG.value:
-            new_reg = cc_payment_utils.save_new_cc_draft(json_data)
+            new_draft: MhrDraft = MhrDraft.create_from_mhreg_json(json_data, "PS12345", "username@idir")
+            new_draft.save()
+            json_data["mhrNumber"] = new_draft.mhr_number
+            new_reg = cc_payment_utils.save_new_cc_draft(json_data, new_draft)
         else:
             json_data["mhrNumber"] = mhr_num
             base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_num, "PS12345", True)

--- a/mhr-api/tests/unit/models/test_mhr_registration.py
+++ b/mhr-api/tests/unit/models/test_mhr_registration.py
@@ -814,7 +814,9 @@ def test_create_new_from_json(session):
     """Assert that the new MHR registration is created from json data correctly."""
     json_data = copy.deepcopy(REGISTRATION)
     json_data['ownLand'] = True
-    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
+    draft: MhrDraft = MhrDraft.create_from_mhreg_json(json_data, 'PS12345', 'test-user')
+    json_data["mhrNumber"] = draft.mhr_number
+    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, draft, 'PS12345', 'test-user', STAFF_ROLE)
     assert registration.id > 0
     assert registration.mhr_number
     assert registration.registration_ts
@@ -827,7 +829,7 @@ def test_create_new_from_json(session):
     assert registration.draft_id == registration.draft.id
     assert registration.draft.draft_number
     assert registration.draft.registration_type == registration.registration_type
-    assert registration.draft.create_ts == registration.registration_ts
+    assert registration.draft.create_ts
     assert registration.draft.account_id == registration.account_id
     assert registration.parties
     for party in registration.parties:
@@ -878,7 +880,9 @@ def test_save_new(session):
     """Assert that saving a new MHR registration is working correctly."""
     json_data = copy.deepcopy(REGISTRATION)
     json_data['documentId'] = '88878888'
-    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, 'PS12345')
+    draft: MhrDraft = MhrDraft.create_from_mhreg_json(json_data, 'PS12345', 'test-user')
+    json_data["mhrNumber"] = draft.mhr_number
+    registration: MhrRegistration = MhrRegistration.create_new_from_json(json_data, draft, 'PS12345', 'test-user', STAFF_ROLE)
     registration.save()
     for party in registration.parties:
         assert party.compressed_name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29054

*Description of changes:*
- New MH registrations generate MHR numbers before the pay api call. Include the MHR number in the pay api payload.
- Update the pay api details info that shows up in the payment receipt and the account transactions to include the MHR number.
- Add/update unit tests.
- Add logic to reuse a MHR number when the registration fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
