### PR TITLE
PPR API add paging of account search history.

### DIFF
--- a/ppr-api/tests/unit/models/test_search_request.py
+++ b/ppr-api/tests/unit/models/test_search_request.py
@@ -399,11 +399,13 @@ TEST_MHR_NUMBER_DATA = [
     ('22000', '022000'),
     ('22000 ', '022000')
 ]
-# testdata pattern is ({account_id}, {from_ui}, {has_result})
+# testdata pattern is ({account_id}, {from_ui}, {page_num}, {has_result})
 TEST_ACCOUNT_DATA = [
-    ('PS12345', False, True),
-    ('PS12345', True, True),
-    ('PSXXXXX', True, False)
+    ('PS12345', False, 1, True),
+    ('PS12345', False, None, True),
+    ('PS12345', True, 1, True),
+    ('PS12345', True, 2, False),
+    ('PSXXXXX', True, 1, False)
 ]
 
 
@@ -653,10 +655,14 @@ def test_search_enddatatetime_invalid(session, client, jwt):
     print(bad_request_err.value.error)
 
 
-@pytest.mark.parametrize('account_id,from_ui,has_results', TEST_ACCOUNT_DATA)
-def test_find_by_account_id(session, account_id, from_ui, has_results):
+@pytest.mark.parametrize('account_id,from_ui,page_num,has_results', TEST_ACCOUNT_DATA)
+def test_find_by_account_id(session, account_id, from_ui, page_num, has_results):
     """Assert that the account search history list first item contains all expected elements."""
-    history = SearchRequest.find_all_by_account_id(account_id, from_ui)
+    history_params = {
+        "from_ui": from_ui,
+        "page_number": 1 if page_num is None else page_num
+    }
+    history = SearchRequest.find_all_by_account_id(account_id, history_params)
     if not has_results:
         assert len(history) == 0
     else:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29739

*Description of changes:*
- Start page number is 1. Default if no pageNumber request parameter is 1.
- The page size is 1000. Specifying the next page when there are no more results will return an empty list.
- The first item in the list if results exist contains the total history count for the account as property searchHistoryTotal.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
