### PR TITLE
Increase Bus Owner name char count

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "5.0.17",
+  "version": "5.0.18",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
+++ b/ppr-ui/src/components/mhrRegistration/HomeOwners/AddEditHomeOwner.vue
@@ -653,7 +653,7 @@ export default defineComponent({
       lastNameRules: customRules(required('Enter a last name'), maxLength(50)),
       orgNameRules: customRules(
         required('Enter a business or organization name'),
-        maxLength(70)
+        maxLength(150)
       ),
       phoneNumberRules: customRules(
         isPhone(14)


### PR DESCRIPTION
*Issue #:* /bcgov/entity##14558

*Description of changes:*
- Increase MHR Bus Owner name allowable char count to 150

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
