### PR TITLE
Add Validation for Folio Number in Staff Payment Component

### DIFF
--- a/ppr-ui/src/components/common/StaffPayment.vue
+++ b/ppr-ui/src/components/common/StaffPayment.vue
@@ -89,6 +89,7 @@
               variant="filled"
               color="primary"
               label="Folio Number (Optional)"
+              :rules="folioNumberRules"
               :disabled="staffPaymentData.option === StaffPaymentOptions.FAS
                 || staffPaymentData.option === StaffPaymentOptions.NO_FEE"
               @focus="staffPaymentData.option = StaffPaymentOptions.BCOL"
@@ -185,6 +186,12 @@ export default defineComponent({
         return [
           v => !!v || 'Enter DAT Number',
           v => /^[A-Z]{1}[0-9]{7,9}$/.test(v) || 'DAT Number must be in standard format (eg, C1234567)'
+        ]
+      }),
+      /** Validation rules for folio Number */
+      folioNumberRules: computed((): Array<ValidationRule> => {
+        return [
+          (v: string) => v.length <= 50 || 'Maximum 50 characters reached' // maximum character count
         ]
       })
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30089

*Description of changes:*
Added char counts validation for folio number in staff payment component.

<img width="1184" height="814" alt="image" src="https://github.com/user-attachments/assets/4790bfe2-46f9-41a0-8836-75f4da45835d" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
