### PR TITLE
31394 - Fix amendment response for trust indenture

### DIFF
--- a/ppr-api/pyproject.toml
+++ b/ppr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ppr-api"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/ppr-api/src/ppr_api/models/registration.py
+++ b/ppr-api/src/ppr_api/models/registration.py
@@ -199,9 +199,10 @@ class Registration(db.Model):  # pylint: disable=too-many-instance-attributes, t
             if self.financing_statement.trust_indenture:
                 for trust_indenture in self.financing_statement.trust_indenture:
                     if self.id == trust_indenture.registration_id:
-                        registration["addTrustIndenture"] = True
-                    elif self.id == trust_indenture.registration_id_end:
-                        registration["removeTrustIndenture"] = True
+                        if trust_indenture.trust_indenture == TrustIndenture.TRUST_INDENTURE_YES:
+                            registration["addTrustIndenture"] = True
+                        elif trust_indenture.trust_indenture == TrustIndenture.TRUST_INDENTURE_NO:
+                            registration["removeTrustIndenture"] = True
             if (
                 "addTrustIndenture" not in registration
                 and self.trust_indenture

--- a/ppr-api/tests/conftest.py
+++ b/ppr-api/tests/conftest.py
@@ -94,6 +94,7 @@ def session(db, request):  # pylint: disable=redefined-outer-name
 
     def commit():
         db.session.flush()
+        db.session.expire_all()
 
     # patch commit method
     old_commit = db.session.commit


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31394

*Description of changes:*

- Fix bug when a PPR amendment is submitted to update trust indenture, `addTrustIndenture` and `removeTrustIndenture` will incorrectly return in response. The ticket only describes one scenario, but this fix is to resolve all the scenarios.
- Scenarios for trust indenture changes


| Before Amendment | After Amendment | Current Response | Expected Response |
| -------------------------------- | ------------------------------- | ---------------- | ----------------- |
| N                                | N                               | add + remove     | remove            |
| N                                | Y                               | add + remove     | add               |
| Y                                | Y                               | add + remove     | add               |
| Y                                | N                               | add + remove     | remove            |

- Update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
