### PR TITLE
31584 - Support more registration types to use credit card payment

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.2"
+version = "2.1.3"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/resources/cc_payment_utils.py
+++ b/mhr-api/src/mhr_api/resources/cc_payment_utils.py
@@ -343,7 +343,7 @@ def create_change_registration(draft: MhrDraft, current_reg: MhrRegistration) ->
     draft_json = draft.draft
     if draft.registration_type == MhrRegistrationTypes.PERMIT.value:
         new_reg = create_permit_registration(draft_json, current_reg, new_reg)
-    elif draft.registration_type == MhrRegistrationTypes.TRANS.value:
+    elif draft.registration_type in (MhrRegistrationTypes.TRANS.value, MhrRegistrationTypes.TRAND.value):
         new_reg = create_transfer_registration(draft_json, current_reg, new_reg)
     elif draft.registration_type in (
         MhrRegistrationTypes.EXEMPTION_NON_RES.value,

--- a/mhr-api/src/mhr_api/resources/cc_payment_utils.py
+++ b/mhr-api/src/mhr_api/resources/cc_payment_utils.py
@@ -336,12 +336,35 @@ def create_exemption_registration(
     return new_reg
 
 
+def create_admin_registration(
+    json_data: dict, current_reg: MhrRegistration, new_reg: MhrRegistration
+) -> MhrRegistration:
+    """Create new admin registration (cancel permit) from the draft."""
+    if json_data.get("note") and json_data["note"].get("givingNoticeParty"):
+        notice_json = json_data["note"]["givingNoticeParty"]
+        new_reg.parties.append(MhrParty.create_from_json(notice_json, MhrPartyTypes.CONTACT, new_reg.id))
+    doc: MhrDocument = new_reg.documents[0]
+    if json_data.get("note"):
+        new_reg.notes = [
+            MhrNote.create_from_json(json_data.get("note"), new_reg.id, doc.id, new_reg.registration_ts, new_reg.id)
+        ]
+    if json_data.get("location"):
+        new_reg.locations.append(MhrLocation.create_from_json(json_data.get("location"), new_reg.id))
+    new_reg.save()
+    change_utils.save_permit(current_reg, json_data, new_reg.id)
+    return new_reg
+
+
 def create_change_registration(draft: MhrDraft, current_reg: MhrRegistration) -> MhrRegistration:
     """Create new change registration from the draft."""
     new_reg: MhrRegistration = create_basic_registration(draft)
     new_reg.documents[0].registration_id = current_reg.id
     draft_json = draft.draft
-    if draft.registration_type == MhrRegistrationTypes.PERMIT.value:
+    if draft.registration_type in (
+        MhrRegistrationTypes.PERMIT.value,
+        MhrRegistrationTypes.PERMIT_EXTENSION.value,
+        MhrRegistrationTypes.AMENDMENT.value,
+    ):
         new_reg = create_permit_registration(draft_json, current_reg, new_reg)
     elif draft.registration_type in (MhrRegistrationTypes.TRANS.value, MhrRegistrationTypes.TRAND.value):
         new_reg = create_transfer_registration(draft_json, current_reg, new_reg)
@@ -350,5 +373,10 @@ def create_change_registration(draft: MhrDraft, current_reg: MhrRegistration) ->
         MhrRegistrationTypes.EXEMPTION_RES.value,
     ):
         new_reg = create_exemption_registration(draft_json, current_reg, new_reg)
+    elif (
+        draft.registration_type == MhrRegistrationTypes.REG_STAFF_ADMIN.value
+        and draft.draft.get("documentType") == MhrDocumentTypes.CANCEL_PERMIT.value
+    ):
+        new_reg = create_admin_registration(draft_json, current_reg, new_reg)
     logger.info(f"New reg id={new_reg.id} type={new_reg.registration_type}, mhr#={new_reg.mhr_number}")
     return new_reg

--- a/mhr-api/src/mhr_api/resources/registration_utils.py
+++ b/mhr-api/src/mhr_api/resources/registration_utils.py
@@ -393,6 +393,11 @@ def pay_and_save_admin(  # pylint: disable=too-many-arguments,too-many-positiona
         payment, pay_ref = pay_staff(req, request_json, trans_type, current_reg.mhr_number)
     else:
         payment, pay_ref = pay(req, request_json, account_id, trans_type, current_reg.mhr_number)
+        if pay_ref.get("ccPayment"):
+            logger.info("Payment response CC method.")
+            request_json = setup_cc_draft(request_json, pay_ref, account_id, token.get("username", None), user_group)
+            return cc_payment_utils.save_change_cc_draft(current_reg, request_json)
+
     invoice_id = pay_ref["invoiceId"]
     # Try to save the registration: failure throws an exception.
     try:

--- a/mhr-api/src/mhr_api/resources/v1/admin_registrations.py
+++ b/mhr-api/src/mhr_api/resources/v1/admin_registrations.py
@@ -134,6 +134,8 @@ def save_registration(req: request, request_json: dict, current_reg: MhrRegistra
     registration = reg_utils.pay_and_save_admin(
         req, current_reg, request_json, account_id, group, get_transaction_type(request_json)
     )
+    if registration.reg_json and registration.reg_json.get("paymentPending"):
+        return jsonify(registration.reg_json), HTTPStatus.ACCEPTED
     logger.debug(f"building admin reg response json for {mhr_number}")
     registration.change_registrations = [current_reg, *current_reg.change_registrations]
     response_json = registration.json

--- a/mhr-api/src/mhr_api/resources/v1/pay_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/pay_callback.py
@@ -320,7 +320,7 @@ def complete_registration(draft: MhrDraft, base_reg: MhrRegistration, request_js
             existing_status: str = base_reg.status_type
             new_reg = cc_payment_utils.create_change_registration(draft, base_reg)
             queue_permit(draft, base_reg, new_reg, current_location, existing_status)
-        elif reg_type == MhrRegistrationTypes.TRANS:
+        elif reg_type in (MhrRegistrationTypes.TRANS, MhrRegistrationTypes.TRAND):
             base_reg.current_view = True
             current_owners = reg_utils.get_active_owners(base_reg)
             new_reg = cc_payment_utils.create_change_registration(draft, base_reg)

--- a/mhr-api/src/mhr_api/resources/v1/pay_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/pay_callback.py
@@ -19,10 +19,18 @@ from flask import Blueprint, request
 from flask_cors import cross_origin
 
 from mhr_api.exceptions import DatabaseException
-from mhr_api.models import EventTracking, MhrDraft, MhrRegistration, MhrReviewRegistration, SearchResult
+from mhr_api.models import (
+    EventTracking,
+    MhrDraft,
+    MhrRegistration,
+    MhrReviewRegistration,
+    SearchResult,
+    registration_json_utils,
+)
 from mhr_api.models.mhr_draft import DRAFT_PAY_PENDING_PREFIX, DRAFT_STAFF_REVIEW_PREFIX
 from mhr_api.models.registration_json_utils import cleanup_owner_groups, sort_owner_groups
 from mhr_api.models.type_tables import (
+    MhrDocumentTypes,
     MhrOwnerStatusTypes,
     MhrRegistrationStatusTypes,
     MhrRegistrationTypes,
@@ -252,6 +260,19 @@ def queue_permit(
     queue_report(new_reg, draft, response_json, ReportTypes.MHR_TRANSPORT_PERMIT, current_json)
 
 
+def queue_admin_reg(
+    draft: MhrDraft, current_reg: MhrRegistration, new_reg: MhrRegistration, current_json: dict, existing_status
+):
+    """Set up the registration verification report generation (cancel permit)."""
+    new_reg.change_registrations = [current_reg, *current_reg.change_registrations]
+    response_json = new_reg.json
+    response_json = registration_json_utils.set_home_status_json(current_reg, response_json, existing_status)
+    if draft.draft.get("documentType") == MhrDocumentTypes.CANCEL_PERMIT:
+        response_json["previousLocation"] = current_json.get("location")
+
+    queue_report(new_reg, draft, response_json, ReportTypes.MHR_REGISTRATION_STAFF, current_json)
+
+
 def queue_transfer(draft: MhrDraft, current_reg: MhrRegistration, new_reg: MhrRegistration, current_owners):
     """Set up the registration verification report generation."""
     new_reg.change_registrations = [current_reg, *current_reg.change_registrations]
@@ -314,7 +335,11 @@ def complete_registration(draft: MhrDraft, base_reg: MhrRegistration, request_js
         if reg_type == MhrRegistrationTypes.MHREG:
             new_reg = cc_payment_utils.create_new_registration(draft)
             queue_new_reg(draft, base_reg, new_reg)
-        elif reg_type == MhrRegistrationTypes.PERMIT:
+        elif reg_type in (
+            MhrRegistrationTypes.PERMIT,
+            MhrRegistrationTypes.PERMIT_EXTENSION,
+            MhrRegistrationTypes.AMENDMENT,
+        ):
             base_reg.current_view = True
             current_location = reg_utils.get_active_location(base_reg)
             existing_status: str = base_reg.status_type
@@ -328,6 +353,15 @@ def complete_registration(draft: MhrDraft, base_reg: MhrRegistration, request_js
         elif reg_type in (MhrRegistrationTypes.EXEMPTION_RES, MhrRegistrationTypes.EXEMPTION_NON_RES):
             new_reg = cc_payment_utils.create_change_registration(draft, base_reg)
             queue_exemption(draft, base_reg, new_reg)
+        elif (
+            reg_type == MhrRegistrationTypes.REG_STAFF_ADMIN
+            and draft.draft.get("documentType") == MhrDocumentTypes.CANCEL_PERMIT.value
+        ):
+            base_reg.current_view = True
+            current_json = base_reg.new_registration_json
+            existing_status: str = base_reg.status_type
+            new_reg = cc_payment_utils.create_change_registration(draft, base_reg)
+            queue_admin_reg(draft, base_reg, new_reg, current_json, existing_status)
         msg: str = None
         if new_reg:
             msg = PAY_REG_SUCCESS_MSG.format(reg_id=new_reg.id, mhr_num=new_reg.mhr_number)

--- a/mhr-api/tests/unit/api/test_pay_callback.py
+++ b/mhr-api/tests/unit/api/test_pay_callback.py
@@ -21,7 +21,7 @@ from http import HTTPStatus
 
 import pytest
 from flask import current_app
-from registry_schemas.example_data.mhr import REGISTRATION, EXEMPTION, PERMIT, TRANSFER
+from registry_schemas.example_data.mhr import ADMIN_REGISTRATION, EXEMPTION, PERMIT, REGISTRATION, TRANSFER
 
 from mhr_api.models import MhrDraft, MhrRegistration, SearchRequest, SearchResult
 from mhr_api.models.mhr_draft import DRAFT_PAY_PENDING_PREFIX
@@ -30,7 +30,7 @@ from mhr_api.models.type_tables import MhrRegistrationStatusTypes, MhrRegistrati
 from mhr_api.resources import cc_payment_utils
 from mhr_api.resources.registration_utils import setup_cc_draft
 from mhr_api.resources.v1.pay_callback import get_search_id
-
+from tests.unit.utils.test_registration_data import LOCATION_MANUFACTURER
 
 # Valid search test data
 MHR_NUMBER_JSON = {
@@ -59,12 +59,22 @@ PUB_SUB_PAYLOAD = {
     "statusCode": "COMPLETED",
     "filingIdentifier": ""
 }
+# valid registration data
+TRANSFER_DEATH = copy.deepcopy(TRANSFER)
+TRANSFER_DEATH["registrationType"] = MhrRegistrationTypes.TRAND.value
+ADMIN_REGISTRATION_CANCELLED = copy.deepcopy(ADMIN_REGISTRATION)
+ADMIN_REGISTRATION_CANCELLED["documentType"] = "CANCEL_PERMIT"
+ADMIN_REGISTRATION_CANCELLED["location"] = copy.deepcopy(LOCATION_MANUFACTURER)
 # testdata pattern is ({desc}, {status}, {draft_json}, {mhr_num}, {reg_type}, {invoice_id})
 TEST_CALLBACK_DATA = [
     ('Valid new reg', HTTPStatus.OK, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
     ('Valid exemption', HTTPStatus.OK, EXEMPTION, "000919", MhrRegistrationTypes.EXEMPTION_RES.value, "20000101"),
     ('Valid permit', HTTPStatus.OK, PERMIT, "000900", MhrRegistrationTypes.PERMIT.value, "20000102"),
     ('Valid transfer', HTTPStatus.OK, TRANSFER, "000919", MhrRegistrationTypes.TRANS.value, "20000103"),
+    ('Valid transfer to surviving joint tenant', HTTPStatus.OK, TRANSFER_DEATH, "000901", MhrRegistrationTypes.TRAND.value, "20000104"),
+    ('Valid permit extension', HTTPStatus.OK, PERMIT, "000931", MhrRegistrationTypes.PERMIT_EXTENSION.value, "20000105"),
+    ('Valid amendment', HTTPStatus.OK, PERMIT, "000931", MhrRegistrationTypes.PERMIT_EXTENSION.value, "20000106"),
+    ('Valid permit cancelled', HTTPStatus.OK, ADMIN_REGISTRATION_CANCELLED, "000931", MhrRegistrationTypes.REG_STAFF_ADMIN.value, "20000107"),
     ('Invalid no key', HTTPStatus.UNAUTHORIZED, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
     ('Invalid missing payload', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
     ('Invalid missing status', HTTPStatus.BAD_REQUEST, REGISTRATION, None, MhrRegistrationTypes.MHREG.value, "20000100"),
@@ -93,18 +103,33 @@ def setup_registration(draft_json: dict, reg_type: str, invoice_id: str) -> dict
         del json_data['documentDescription']
         del json_data['createDateTime']
         json_data['nonResidential'] = False
-    elif reg_type == MhrRegistrationTypes.PERMIT.value:
+    elif reg_type in (
+        MhrRegistrationTypes.PERMIT.value,
+        MhrRegistrationTypes.PERMIT_EXTENSION.value,
+        MhrRegistrationTypes.AMENDMENT.value
+    ):
         del json_data['documentId']
         del json_data['documentRegistrationNumber']
         del json_data['documentDescription']
         del json_data['createDateTime']
         del json_data['payment']
         del json_data['note']
-    elif reg_type == MhrRegistrationTypes.TRANS.value:
+    elif reg_type in (
+        MhrRegistrationTypes.TRANS.value,
+        MhrRegistrationTypes.TRAND.value
+    ):
         del json_data['documentId']
         del json_data['documentDescription']
         del json_data['createDateTime']
         del json_data['payment']
+    elif reg_type == MhrRegistrationTypes.REG_STAFF_ADMIN.value:
+        del json_data['documentId']
+        del json_data['documentRegistrationNumber']
+        del json_data['documentDescription']
+        del json_data['createDateTime']
+        del json_data['updateDocumentId']
+        del json_data['payment']
+        del json_data['note']
     pay_ref: dict = copy.deepcopy(CC_PAYREF)
     if invoice_id:
         pay_ref["invoiceId"] = invoice_id
@@ -172,6 +197,7 @@ def test_pay_callback(session, client, jwt, desc, status, draft_json, mhr_num, r
         if reg_type == MhrRegistrationTypes.MHREG.value:
             new_draft: MhrDraft = MhrDraft.create_from_mhreg_json(json_data, "PS12345", "username@idir")
             new_draft.save()
+            mhr_num = new_draft.mhr_number
             json_data["mhrNumber"] = new_draft.mhr_number
             new_reg = cc_payment_utils.save_new_cc_draft(json_data, new_draft)
         else:
@@ -198,6 +224,9 @@ def test_pay_callback(session, client, jwt, desc, status, draft_json, mhr_num, r
                         headers=headers,
                         content_type='application/json')
         assert rv.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.BAD_REQUEST, HTTPStatus.OK)
+    if desc.startswith('Valid'):
+        reg = MhrRegistration.find_by_mhr_number(mhr_num, "PS12345", reg_type=reg_type)
+        assert reg
 
 
 @pytest.mark.parametrize('desc,invoice_id,search_id', TEST_SEARCH_ID_DATA)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31584

*Description of changes:*
- Fix to support credit card payment for the following registration types
    - TRAND (document type DEAT)
    - PERMIT_EXTENSION (document type REG_103E)
    - AMENDMENT (document type AMEND_PERMIT)
    - REG_STAFF_ADMIN (document type CANCEL_PERMIT)
- Update unit tests
- mhr-api version = 2.1.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
