### PR TITLE
MHR API account registrations fix missing child registrations.

### DIFF
--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -30,6 +30,7 @@ from mhr_api.models.queries import (
     QUERY_ACCOUNT_ADD_REG_DOC,
     QUERY_ACCOUNT_ADD_REG_MHR,
     QUERY_ACCOUNT_DEFAULT,
+    QUERY_ACCOUNT_STAFF_NO_FILTER,
     QUERY_BATCH_MANUFACTURER_MHREG,
     QUERY_BATCH_MANUFACTURER_MHREG_DEFAULT,
     QUERY_PERMIT_COUNT,
@@ -868,6 +869,7 @@ def find_all_by_account_id(params: AccountRegistrationParams):
     registrations = []
     try:
         query = text(build_account_query(params))
+        # logger.info(query)
         if params.has_filter() and params.filter_reg_start_date and params.filter_reg_end_date:
             start_ts = model_utils.search_ts(params.filter_reg_start_date, True)
             end_ts = model_utils.search_ts(params.filter_reg_end_date, False)
@@ -1058,6 +1060,8 @@ def __collapse_results(results):
 def build_account_query(params: AccountRegistrationParams) -> str:
     """Build the account registration summary query."""
     query_text: str = QUERY_ACCOUNT_DEFAULT
+    if not params.has_filter() and params.account_id == STAFF_ROLE:
+        query_text = QUERY_ACCOUNT_STAFF_NO_FILTER
     if not params.has_filter() and not params.has_sort():
         query_text += DEFAULT_SORT_ORDER
         return query_text


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31696

*Description of changes:*
- Fix account registrations list missing registrations when the account registers a new home and another account creates a change registration on the home.
- Interim fix to improve PROD staff account registrations performance when no filters - only include staff registrations created in the last 14 days in the query. No date restriction on registrations added. Note: a background job that runs once a week in PROD removes all staff registrations more than 14 days old from the staff list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
