### PR TITLE
29845 fix bug: prevent party name persisting after cancel

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/composables/parties/useSecuredParty.ts
+++ b/ppr-ui/src/composables/parties/useSecuredParty.ts
@@ -10,8 +10,8 @@ import { isObjectEqual } from '@/utils/validation-helper'
 import { storeToRefs } from 'pinia'
 import { SecuredPartyRestrictedList } from '@/resources'
 
-const initPerson = { first: '', middle: '', last: '' }
-const initAddress = {
+const createInitPerson = () => ({ first: '', middle: '', last: '' })
+const createInitAddress = () => ({
   street: '',
   streetAdditional: '',
   city: '',
@@ -19,7 +19,7 @@ const initAddress = {
   country: null,
   postalCode: '',
   deliveryInstructions: ''
-}
+})
 const { isPartiesValid } = useParty()
 
 export const useSecuredParty = (context?) => {
@@ -34,9 +34,9 @@ export const useSecuredParty = (context?) => {
   const localState = reactive({
     currentSecuredParty: {
       businessName: '',
-      personName: initPerson,
+      personName: createInitPerson(),
       emailAddress: '',
-      address: initAddress
+      address: createInitAddress()
     } as PartyIF,
     currentIsBusiness: null,
     partyType: null,
@@ -59,7 +59,7 @@ export const useSecuredParty = (context?) => {
       if (localState.currentSecuredParty.businessName) {
         localState.currentIsBusiness = true
         localState.partyType = SecuredPartyTypes.BUSINESS
-        localState.currentSecuredParty.personName = Object.assign({}, initPerson)
+        localState.currentSecuredParty.personName = createInitPerson()
       }
     } else if (activeIndex >= 0) {
       // deep copy so original object doesn't get modified
@@ -70,16 +70,16 @@ export const useSecuredParty = (context?) => {
       if (localState.currentSecuredParty.businessName) {
         localState.currentIsBusiness = true
         localState.partyType = SecuredPartyTypes.BUSINESS
-        localState.currentSecuredParty.personName = Object.assign({}, initPerson)
+        localState.currentSecuredParty.personName = createInitPerson()
       }
     } else {
       localState.partyType = null
       const blankSecuredParty = {
         businessName: '',
-        personName: Object.assign({}, initPerson),
+        personName: createInitPerson(),
         birthDate: '',
         emailAddress: '',
-        address: Object.assign({}, initAddress)
+        address: createInitAddress()
       }
       localState.currentSecuredParty = blankSecuredParty
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/29845

*Description of changes:*
Root cause: the cancel logic was reusing a shared “default” person-name object (same reference) in the composable, so when the form mutated first/last name, those values stuck on that shared object and showed up again after Cancel instead of resetting to blank.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
