### PR TITLE
31730 MHR API - improve GET account registrations performance

### DIFF
--- a/mhr-api/manage.py
+++ b/mhr-api/manage.py
@@ -76,6 +76,7 @@ def create_test_data():
     sorted_names = sorted(filenames)
     for filename in sorted_names:
         execute_script(db.session, os.path.join(os.getcwd(), ("test_data/postgres_data_files_ppr/" + filename)))
+    execute_script(db.session, os.path.join(os.getcwd(), "test_data/postgres_create_last.sql"))
 
 
 if __name__ == "__main__":

--- a/mhr-api/migrations/versions/0006_add_meta_into_mhr_registrations.py
+++ b/mhr-api/migrations/versions/0006_add_meta_into_mhr_registrations.py
@@ -1,0 +1,24 @@
+"""0006_add_meta_into_mhr_registrations
+
+Revision ID: aed708d88460
+Revises: 793f7c153047
+Create Date: 2026-01-08 09:55:10.085326
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'aed708d88460'
+down_revision = '793f7c153047'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('mhr_registrations', sa.Column('summary_snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade():
+    op.drop_column('mhr_registrations', 'summary_snapshot')

--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.3"
+version = "2.1.4"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/database/patch/mhr-summary-snapshot.sh
+++ b/mhr-api/src/database/patch/mhr-summary-snapshot.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Backfill mhr_registrations.summary_snapshot from mhr_account_reg_vw.
+# Skip registrations with duplicate notes, which cause subqueries in the view
+# to fail with:
+#   "more than one row returned by a subquery used as an expression".
+
+set -u
+
+read -s -p "Postgres password: " PGPASSWORD
+echo
+export PGPASSWORD
+
+# Update (host, port, database, user) if needed 
+PSQL="psql -v ON_ERROR_STOP=1 -h localhost -p 5432 -d ppr -U postgres -At"
+
+total=0
+iter=0
+
+trap 'unset PGPASSWORD' EXIT
+
+while true; do
+  iter=$((iter+1))
+  start=$(date +%s)
+
+  out="$($PSQL -c "
+WITH skipped_candidates AS (
+  SELECT registration_id
+  FROM mhr_notes
+  GROUP BY registration_id
+  HAVING COUNT(*) > 1
+),
+batch AS (
+  SELECT r.id
+  FROM mhr_registrations r
+  WHERE r.summary_snapshot IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM skipped_candidates sc WHERE sc.registration_id = r.id
+  )
+  ORDER BY r.id DESC
+  LIMIT 2000
+),
+snaps AS (
+  SELECT b.id, to_jsonb(v) AS payload
+  FROM batch b
+  JOIN mhr_account_reg_vw v ON v.registration_id = b.id
+)
+UPDATE mhr_registrations r
+SET summary_snapshot = s.payload
+FROM snaps s
+WHERE r.id = s.id
+RETURNING r.id;
+" )"
+  rc=$?
+
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  if [ $rc -ne 0 ]; then
+    echo "$(date '+%F %T') | iter=$iter | ERROR (unexpected): batch_time=${elapsed}s"
+    echo "$out"
+    break
+  fi
+
+  rows=$(printf "%s" "$out" | wc -l | tr -d ' ')
+  total=$((total + rows))
+  echo "$(date '+%F %T') | iter=$iter | updated=$rows | batch_time=${elapsed}s | total=$total"
+
+  [ "$rows" -eq 0 ] && break
+done

--- a/mhr-api/src/mhr_api/__init__.py
+++ b/mhr-api/src/mhr_api/__init__.py
@@ -125,6 +125,7 @@ def setup_test_data():
                 db.session,
                 os.path.join(os.getcwd(), ("test_data/postgres_data_files_ppr/" + filename)),
             )
+        execute_script(db.session, os.path.join(os.getcwd(), "test_data/postgres_create_last.sql"))
     except Exception as err:  # pylint: disable=broad-except # noqa F841;
         logger.error(f"setup_test_data failed: {str(err)}")
 

--- a/mhr-api/src/mhr_api/models/mhr_registration.py
+++ b/mhr-api/src/mhr_api/models/mhr_registration.py
@@ -16,7 +16,8 @@
 
 from http import HTTPStatus
 
-from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM, JSONB
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+from sqlalchemy.dialects.postgresql import JSONB
 
 import mhr_api.models.registration_change_utils as change_utils
 import mhr_api.models.registration_json_utils as reg_json_utils
@@ -79,7 +80,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
     pay_invoice_id = db.mapped_column("pay_invoice_id", db.Integer, nullable=True)
     pay_path = db.mapped_column("pay_path", db.String(256), nullable=True)
     user_id = db.mapped_column("user_id", db.String(1000), nullable=True)
-    summary_snapshot = db.mapped_column('summary_snapshot', JSONB)
+    summary_snapshot = db.mapped_column("summary_snapshot", JSONB)
 
     # parent keys
     draft_id = db.mapped_column("draft_id", db.Integer, db.ForeignKey("mhr_drafts.id"), nullable=False, index=True)

--- a/mhr-api/src/mhr_api/models/mhr_registration.py
+++ b/mhr-api/src/mhr_api/models/mhr_registration.py
@@ -16,7 +16,7 @@
 
 from http import HTTPStatus
 
-from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM, JSONB
 
 import mhr_api.models.registration_change_utils as change_utils
 import mhr_api.models.registration_json_utils as reg_json_utils
@@ -79,6 +79,7 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
     pay_invoice_id = db.mapped_column("pay_invoice_id", db.Integer, nullable=True)
     pay_path = db.mapped_column("pay_path", db.String(256), nullable=True)
     user_id = db.mapped_column("user_id", db.String(1000), nullable=True)
+    summary_snapshot = db.mapped_column('summary_snapshot', JSONB)
 
     # parent keys
     draft_id = db.mapped_column("draft_id", db.Integer, db.ForeignKey("mhr_drafts.id"), nullable=False, index=True)
@@ -896,3 +897,13 @@ class MhrRegistration(db.Model):  # pylint: disable=too-many-instance-attributes
         for section in json_data["description"]["sections"]:
             sections.append(MhrSection.create_from_json(section, registration_id))
         return sections
+
+    @classmethod
+    def update_summary_snapshot_by_mhr_number(cls, mhr_number: str):
+        """Update the MHR registration summary snapshot matching the mhr number."""
+        reg_utils.update_summary_snapshot_by_mhr_number(mhr_number)
+
+    @classmethod
+    def update_summary_snapshot_by_reg_id(cls, registration_id: int):
+        """Update the MHR registration summary snapshot matching the registration id."""
+        reg_utils.update_summary_snapshot_by_reg_id(registration_id)

--- a/mhr-api/src/mhr_api/models/queries.py
+++ b/mhr-api/src/mhr_api/models/queries.py
@@ -282,17 +282,17 @@ WHERE arv.mhr_number IN
 )
 REG_ORDER_BY_DATE = " ORDER BY arv.registration_ts DESC"
 REG_ORDER_BY_MHR_NUMBER = " ORDER BY arv.mhr_number"
-REG_ORDER_BY_REG_TYPE = " ORDER BY arv.document_type"
+REG_ORDER_BY_REG_TYPE = " ORDER BY arv.summary_snapshot ->> 'document_type'"
 REG_ORDER_BY_STATUS = " ORDER BY arv.status_type"
-REG_ORDER_BY_SUBMITTING_NAME = " ORDER BY arv.submitting_name"
+REG_ORDER_BY_SUBMITTING_NAME = " ORDER BY arv.summary_snapshot ->> 'submitting_name'"
 REG_ORDER_BY_CLIENT_REF = " ORDER BY arv.client_reference_id"
-REG_ORDER_BY_USERNAME = " ORDER BY arv.registering_name"
-REG_ORDER_BY_OWNER_NAME = " ORDER BY arv.owner_names"
+REG_ORDER_BY_USERNAME = " ORDER BY arv.summary_snapshot ->> 'registering_name'"
+REG_ORDER_BY_OWNER_NAME = " ORDER BY arv.summary_snapshot ->> 'owner_names'"
 REG_ORDER_BY_EXPIRY_DAYS = " ORDER BY arv.mhr_number"
-REG_ORDER_BY_DOCUMENT_ID = " ORDER BY arv.document_id"
-REG_ORDER_BY_MANUFACTURER_NAME = " ORDER BY arv.manufacturer_name"
-REG_ORDER_BY_CIVIC_ADDRESS = " ORDER BY arv.civic_address"
-REG_FILTER_REG_TYPE = " AND arv.document_type = '?'"
+REG_ORDER_BY_DOCUMENT_ID = " ORDER BY arv.summary_snapshot ->> 'document_id'"
+REG_ORDER_BY_MANUFACTURER_NAME = " ORDER BY arv.summary_snapshot ->> 'manufacturer_name'"
+REG_ORDER_BY_CIVIC_ADDRESS = " ORDER BY arv.summary_snapshot ->> 'civic_address'"
+REG_FILTER_REG_TYPE = " AND arv.summary_snapshot ->> 'document_type' = '?'"
 REG_FILTER_REG_TYPE_COLLAPSE = """
  AND arv.mhr_number IN (SELECT DISTINCT r2.mhr_number
                           FROM mhr_registrations r2, mhr_documents d2
@@ -309,12 +309,12 @@ REG_FILTER_STATUS_COLLAPSE = """
                            AND r2.registration_type IN ('MHREG', 'MHREG_CONVERSION')
                            AND r2.status_type = '?')
 """
-REG_FILTER_SUBMITTING_NAME = " AND position('?' in arv.submitting_name) > 0"
+REG_FILTER_SUBMITTING_NAME = " AND position('?' in arv.summary_snapshot ->> 'submitting_name') > 0"
 REG_FILTER_SUBMITTING_NAME_COLLAPSE = """
  AND arv.mhr_number IN (SELECT DISTINCT arv2.mhr_number
-                          FROM mhr_account_reg_vw arv2
+                          FROM mhr_registrations arv2
                          WHERE arv.mhr_number = arv2.mhr_number
-                           AND position('?' in arv2.submitting_name) > 0)
+                           AND position('?' in arv2.summary_snapshot ->> 'submitting_name') > 0)
 """
 REG_FILTER_CLIENT_REF = " AND position('?' in UPPER(arv.client_reference_id)) > 0"
 REG_FILTER_CLIENT_REF_COLLAPSE = """
@@ -323,7 +323,7 @@ REG_FILTER_CLIENT_REF_COLLAPSE = """
                          WHERE arv.mhr_number = r2.mhr_number
                            AND position('?' in UPPER(r2.client_reference_id)) > 0)
 """
-REG_FILTER_USERNAME = " AND position('?' in arv.registering_name) > 0"
+REG_FILTER_USERNAME = " AND position('?' in arv.summary_snapshot ->> 'registering_name') > 0"
 REG_FILTER_USERNAME_COLLAPSE = """
  AND arv.mhr_number IN (SELECT r2.mhr_number
                         FROM mhr_registrations r2, users u
@@ -341,7 +341,7 @@ REG_FILTER_DATE_COLLAPSE = """
                          WHERE arv.mhr_number = r2.mhr_number
                            AND r2.registration_ts BETWEEN :query_start AND :query_end)
 """
-REG_FILTER_DOCUMENT_ID = " AND position('?' in arv.document_id) > 0"
+REG_FILTER_DOCUMENT_ID = " AND position('?' in arv.summary_snapshot ->> 'document_id') > 0"
 REG_FILTER_DOCUMENT_ID_COLLAPSE = """
  AND arv.mhr_number IN (SELECT DISTINCT r2.mhr_number
                           FROM mhr_registrations r2, mhr_documents d2
@@ -349,12 +349,12 @@ REG_FILTER_DOCUMENT_ID_COLLAPSE = """
                            AND r2.id = d2.registration_id
                            AND position('?' in d2.document_id) > 0)
 """
-REG_FILTER_MANUFACTURER_NAME = " AND position('?' in arv.manufacturer_name) > 0"
+REG_FILTER_MANUFACTURER_NAME = " AND position('?' in arv.summary_snapshot ->> 'manufacturer_name') > 0"
 REG_FILTER_MANUFACTURER_NAME_COLLAPSE = """
  AND arv.mhr_number IN (SELECT DISTINCT arv2.mhr_number
-                          FROM mhr_account_reg_vw arv2
+                          FROM mhr_registrations arv2
                          WHERE arv.mhr_number = arv2.mhr_number
-                           AND position('?' in arv2.manufacturer_name) > 0)
+                           AND position('?' in arv2.summary_snapshot ->> 'manufacturer_name') > 0)
 """
 ACCOUNT_SORT_DESCENDING = " DESC"
 ACCOUNT_SORT_ASCENDING = " ASC"

--- a/mhr-api/src/mhr_api/models/queries.py
+++ b/mhr-api/src/mhr_api/models/queries.py
@@ -103,12 +103,15 @@ SET summary_snapshot = to_jsonb(arv)
 FROM mhr_account_reg_vw arv
 """
 UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_MHR_NUMBER = (
-    UPDATE_QUERY_SUMMARY_SNAPSHOT_BASE + """
+    UPDATE_QUERY_SUMMARY_SNAPSHOT_BASE
+    + """
 WHERE arv.mhr_number = :query_value1
 AND r.id = arv.registration_id
-""")
+"""
+)
 UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_REG_ID = (
-    UPDATE_QUERY_SUMMARY_SNAPSHOT_BASE + """
+    UPDATE_QUERY_SUMMARY_SNAPSHOT_BASE
+    + """
 WHERE arv.registration_id = :query_value1
 AND r.id = arv.registration_id
 """

--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -69,6 +69,8 @@ from mhr_api.models.queries import (
     REG_ORDER_BY_SUBMITTING_NAME,
     REG_ORDER_BY_USERNAME,
     UPDATE_BATCH_REG_REPORT,
+    UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_MHR_NUMBER,
+    UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_REG_ID,
 )
 from mhr_api.models.type_tables import (
     MhrDocumentType,
@@ -861,6 +863,32 @@ def find_summary_by_doc_reg_number(account_id: str, doc_reg_number: str, staff: 
         return registrations[0] if registrations else {}
     except Exception as db_exception:  # noqa: B902; return nicer error
         logger.error("find_summary_by_doc_reg_number exception: " + str(db_exception))
+        raise DatabaseException(db_exception) from db_exception
+
+
+def update_summary_snapshot_by_mhr_number(mhr_number: str):
+    """Return the MHR registration summary snapshot matching the mhr number."""
+    try:
+        query = text(UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_MHR_NUMBER)
+        result = db.session.execute(query, {"query_value1": mhr_number})
+        if result:
+            logger.debug(f"Updated mhr registration summary snapshot for mhr_number {mhr_number}.")
+        db.session.commit()
+    except Exception as db_exception:  # noqa: B902; return nicer error
+        logger.error("update_summary_snapshot_by_mhr_number exception: " + str(db_exception))
+        raise DatabaseException(db_exception) from db_exception
+
+
+def update_summary_snapshot_by_reg_id(registration_id: int):
+    """Return the MHR registration summary snapshot matching the registration id."""
+    try:
+        query = text(UPDATE_QUERY_SUMMARY_SNAPSHOT_BY_REG_ID)
+        result = db.session.execute(query, {"query_value1": registration_id})
+        if result:
+            logger.debug(f"Updated mhr registration summary snapshot for reg_id {registration_id}.")
+        db.session.commit()
+    except Exception as db_exception:  # noqa: B902; return nicer error
+        logger.error("update_summary_snapshot_by_registration_id exception: " + str(db_exception))
         raise DatabaseException(db_exception) from db_exception
 
 

--- a/mhr-api/src/mhr_api/resources/registration_utils.py
+++ b/mhr-api/src/mhr_api/resources/registration_utils.py
@@ -190,6 +190,7 @@ def pay_and_save_registration(  # pylint: disable=too-many-arguments,too-many-po
         registration.pay_invoice_id = int(invoice_id)
         registration.pay_path = pay_ref["receipt"]
         registration.save()
+        MhrRegistration.update_summary_snapshot_by_mhr_number(draft.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))
@@ -235,6 +236,7 @@ def pay_and_save_transfer(req: request, current_reg: MhrRegistration, request_js
             current_reg.save_transfer(request_json, registration.id)
         elif MhrRegistration.is_exre_transfer(current_reg, request_json):
             current_reg.save_transfer(request_json, registration.id)
+        MhrRegistration.update_summary_snapshot_by_mhr_number(current_reg.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))
@@ -274,6 +276,7 @@ def pay_and_save_exemption(  # pylint: disable=too-many-arguments,too-many-posit
         registration.pay_path = pay_ref["receipt"]
         registration.save()
         current_reg.save_exemption(registration.id)
+        MhrRegistration.update_summary_snapshot_by_mhr_number(current_reg.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))
@@ -331,6 +334,7 @@ def pay_and_save_permit(  # pylint: disable=too-many-arguments,too-many-position
         registration.save()
         if current_reg.id and current_reg.id > 0 and current_reg.locations:
             change_utils.save_permit(current_reg, request_json, registration.id)
+        MhrRegistration.update_summary_snapshot_by_mhr_number(current_reg.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))
@@ -365,6 +369,7 @@ def pay_and_save_note(  # pylint: disable=too-many-arguments,too-many-positional
         registration.save()
         if request_json.get("cancelDocumentId") and request_json["note"].get("documentType") == MhrDocumentTypes.NCAN:
             save_cancel_note(current_reg, request_json, registration.id)
+        MhrRegistration.update_summary_snapshot_by_mhr_number(current_reg.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))
@@ -425,6 +430,7 @@ def pay_and_save_admin(  # pylint: disable=too-many-arguments,too-many-positiona
             save_admin(current_reg, request_json, registration.id)
         elif request_json.get("documentType") == MhrDocumentTypes.CANCEL_PERMIT and current_reg:
             change_utils.save_permit(current_reg, request_json, registration.id)
+        MhrRegistration.update_summary_snapshot_by_mhr_number(current_reg.mhr_number)
         return registration
     except Exception as db_exception:  # noqa: B902; handle all db related errors.
         logger.error(SAVE_ERROR_MESSAGE.format(account_id, "registration", str(db_exception)))

--- a/mhr-api/src/mhr_api/resources/v1/pay_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/pay_callback.py
@@ -365,6 +365,7 @@ def complete_registration(draft: MhrDraft, base_reg: MhrRegistration, request_js
         msg: str = None
         if new_reg:
             msg = PAY_REG_SUCCESS_MSG.format(reg_id=new_reg.id, mhr_num=new_reg.mhr_number)
+            MhrRegistration.update_summary_snapshot_by_mhr_number(new_reg.mhr_number)
         cc_payment_utils.track_event("10", draft.user_id, HTTPStatus.OK, msg)
         return update_draft(draft)
     except Exception as default_err:  # noqa: B902; return nicer default error

--- a/mhr-api/src/mhr_api/resources/v1/registration_report_callback.py
+++ b/mhr-api/src/mhr_api/resources/v1/registration_report_callback.py
@@ -174,6 +174,7 @@ def get_registration_callback_report(
         )
         if report_info.report_data.get("reviewId"):
             send_review_notification(report_info.report_data, response)
+        MhrRegistration.update_summary_snapshot_by_reg_id(registration_id)
         return {}, HTTPStatus.OK
     except ReportException as report_err:
         return registration_callback_error(

--- a/mhr-api/src/mhr_api/resources/v1/review_registrations.py
+++ b/mhr-api/src/mhr_api/resources/v1/review_registrations.py
@@ -159,6 +159,7 @@ def approve_registration(review_id: int, review_reg: MhrReviewRegistration):
     current_owners = reg_utils.get_active_owners(current_reg)
     update_registration_status(review_reg, current_reg)
     new_reg: MhrRegistration = staff_review_utils.create_change_registration(draft, current_reg, review_reg)
+    MhrRegistration.update_summary_snapshot_by_mhr_number(new_reg.mhr_number)
     queue_transfer_report(review_id, draft, current_reg, new_reg, current_owners)
     update_draft(draft)
 

--- a/mhr-api/test_data/postgres_create_last.sql
+++ b/mhr-api/test_data/postgres_create_last.sql
@@ -1,0 +1,7 @@
+-- Run as the last step
+-- Patch mhr_registrations.summay_snapshot 
+UPDATE mhr_registrations r 
+SET summary_snapshot = to_jsonb(v) 
+FROM mhr_account_reg_vw v 
+WHERE v.registration_id = r.id 
+  AND r.summary_snapshot IS NULL;

--- a/mhr-api/tests/unit/models/test_mhr_registration.py
+++ b/mhr-api/tests/unit/models/test_mhr_registration.py
@@ -1631,8 +1631,20 @@ def test_create_exre_from_json(session, mhr_num, account_id, has_loc, has_desc, 
         assert not reg_json.get('deleteOwnerGroups')
 
 
+def helper_clear_summary_snapshot(mhr_number, account_id):
+    """Clear summary snapshot matching the mhr number for testing purpose."""
+    base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number, account_id)
+    base_reg.summary_snapshot = None
+    base_reg.save()
+
+    for reg in base_reg.change_registrations:
+        reg.summary_snapshot = None
+        reg.save()
+
+
 @pytest.mark.parametrize('mhr_number, account_id', TEST_DATA_SUMMARY_MHR_NUM)
 def test_update_summay_snapshot_by_mhr_number(session, mhr_number, account_id):
+    helper_clear_summary_snapshot(mhr_number, account_id)
     MhrRegistration.update_summary_snapshot_by_mhr_number(mhr_number)
     base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number, account_id)
 
@@ -1643,6 +1655,7 @@ def test_update_summay_snapshot_by_mhr_number(session, mhr_number, account_id):
 
 @pytest.mark.parametrize('reg_id, mhr_number, account_id', TEST_DATA_SUMMRY_REG_ID)
 def test_update_summary_snapshot_by_reg_id(session, reg_id, mhr_number, account_id):
+    helper_clear_summary_snapshot(mhr_number, account_id)
     MhrRegistration.update_summary_snapshot_by_reg_id(reg_id)
     base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number, account_id)
 

--- a/mhr-api/tests/unit/models/test_mhr_registration.py
+++ b/mhr-api/tests/unit/models/test_mhr_registration.py
@@ -456,11 +456,23 @@ TEST_CURRENT_PERMIT_DATA = [
     ('000931', 'PS12345', True)
 ]
 # testdata pattern is ({mhr_num}, {account_id}, {has_loc}, {has_desc}, {has_owners})
-TEST_DATA_EXRE= [
+TEST_DATA_EXRE = [
     ('000928', 'PS12345', True, False, False),
     ('000928', 'PS12345', False, True, False),
     ('000928', 'PS12345', False, False, True),
     ('000928', 'PS12345', True, True, True)
+]
+# testdata pattern is ({mhr_num}, {account_id})
+TEST_DATA_SUMMARY_MHR_NUM = [
+    ('000900', 'PS12345'),
+    ('000909', 'PS12345'),
+    ('000910', 'PS12345'),
+]
+# testdata pattern is ({reg_id}, {mhr_num}, {account_id})
+TEST_DATA_SUMMRY_REG_ID = [
+    (200000001, '000900', 'PS12345'),
+    (200000010, '000909', 'PS12345'),
+    (200000014, '000910', 'PS12345')
 ]
 
 
@@ -1617,3 +1629,29 @@ def test_create_exre_from_json(session, mhr_num, account_id, has_loc, has_desc, 
     else:
         assert not reg_json.get('addOwnerGroups')
         assert not reg_json.get('deleteOwnerGroups')
+
+
+@pytest.mark.parametrize('mhr_number, account_id', TEST_DATA_SUMMARY_MHR_NUM)
+def test_update_summay_snapshot_by_mhr_number(session, mhr_number, account_id):
+    MhrRegistration.update_summary_snapshot_by_mhr_number(mhr_number)
+    base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number, account_id)
+
+    assert base_reg.summary_snapshot
+    for reg in base_reg.change_registrations:
+        assert reg.summary_snapshot
+
+
+@pytest.mark.parametrize('reg_id, mhr_number, account_id', TEST_DATA_SUMMRY_REG_ID)
+def test_update_summary_snapshot_by_reg_id(session, reg_id, mhr_number, account_id):
+    MhrRegistration.update_summary_snapshot_by_reg_id(reg_id)
+    base_reg: MhrRegistration = MhrRegistration.find_all_by_mhr_number(mhr_number, account_id)
+
+    if base_reg.id == reg_id:
+        assert base_reg.summary_snapshot
+    else:
+        assert base_reg.summary_snapshot is None
+    for reg in base_reg.change_registrations:
+        if reg.id == reg_id:
+            assert reg.summary_snapshot
+        else:
+            assert reg.summary_snapshot is None


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31730

*Description of changes:*
- Add new db column `mhr_registrations.summary_snapshot`
- Update query for account registration info to use `mhr_registrations` instead of `mhr_account_reg_vw`
- Update `summary_snapshot` at the end of every registration (Try to cover as many paths as possible: PAD payment, CC payment, report generation, staff review approval)
- Update unit tests
- Add patch script under `src/database/patch` as reference, will use it as part of deployment
- mhr-api version=2.1.4 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
