### PR TITLE
30747 MHR transfer queue staff review: Ensure status in header is reactive to the assign/un-assign

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/components/queue/QueueWrapper.vue
+++ b/ppr-ui/src/components/queue/QueueWrapper.vue
@@ -2,7 +2,8 @@
 import { h, resolveComponent, ref, computed, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAnalystQueueStore } from '@/store/analystQueue'
-import { queueTableColumns, transformEnumToLabel } from '@/composables/analystQueue'
+import { queueTableColumns } from '@/composables/analystQueue'
+import { enumToLabel } from '@/utils'
 
 const { setMhrInformation } = useStore()
 const { goToRoute } = useNavigation()
@@ -50,7 +51,7 @@ const renderStatusChip = (col) => ({ row }) => {
       class: 'size-full text-md text-center flex justify-center',
       variant: 'subtle',
       color
-    }, () => transformEnumToLabel(status))
+    }, () => enumToLabel(status))
   }
 
 const renderSortableHeader = (columnData) => ({ column }: any) => {

--- a/ppr-ui/src/components/queue/QueueWrapper.vue
+++ b/ppr-ui/src/components/queue/QueueWrapper.vue
@@ -2,8 +2,7 @@
 import { h, resolveComponent, ref, computed, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAnalystQueueStore } from '@/store/analystQueue'
-import { queueTableColumns } from '@/composables/analystQueue'
-import { FilterTypes } from '@/enums'
+import { queueTableColumns, transformEnumToLabel } from '@/composables/analystQueue'
 
 const { setMhrInformation } = useStore()
 const { goToRoute } = useNavigation()
@@ -38,19 +37,20 @@ const filterTable = (columnId, filterValue) => {
 }
 
 const renderStatusChip = (col) => ({ row }) => {
+    const status = row.getValue('statusType') as string
     const color = {
       APPROVED: 'success' as const,
       DECLINED: 'error' as const,
       PAY_CANCELLED: 'neutral' as const,
       NEW: 'warning' as const
-    }[row.getValue('statusType') as string]
+    }[status]
 
     return h(UBadge, {
       as: 'div',
       class: 'size-full text-md text-center flex justify-center',
       variant: 'subtle',
       color
-    }, () => row.getValue('statusType'))
+    }, () => transformEnumToLabel(status))
   }
 
 const renderSortableHeader = (columnData) => ({ column }: any) => {

--- a/ppr-ui/src/composables/analystQueue/resources.ts
+++ b/ppr-ui/src/composables/analystQueue/resources.ts
@@ -1,11 +1,9 @@
 import { FilterTypes } from '@/enums'
 import { ReviewStatusTypes, ReviewRegTypes } from '@/composables/analystQueue/enums'
+import { enumToLabel } from '@/utils'
 
-const transformEnumToLabel = (enumValue: string): string => {
-  return enumValue
-    .split('_')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ')
+export const transformEnumToLabel = (enumValue?: string | null): string => {
+  return enumToLabel(enumValue)
 }
 
 export const queueTableColumns = [

--- a/ppr-ui/src/composables/analystQueue/resources.ts
+++ b/ppr-ui/src/composables/analystQueue/resources.ts
@@ -2,10 +2,6 @@ import { FilterTypes } from '@/enums'
 import { ReviewStatusTypes, ReviewRegTypes } from '@/composables/analystQueue/enums'
 import { enumToLabel } from '@/utils'
 
-export const transformEnumToLabel = (enumValue?: string | null): string => {
-  return enumToLabel(enumValue)
-}
-
 export const queueTableColumns = [
     { id: 'mhrNumber',
       header: 'Registration Number',
@@ -29,7 +25,7 @@ export const queueTableColumns = [
         type: FilterTypes.SELECT,
         placeholder: 'Status',
         options: Object.values(ReviewStatusTypes).map(status => ({
-            label: transformEnumToLabel(status),
+            label: enumToLabel(status),
             value: status
         })),
       },
@@ -47,7 +43,7 @@ export const queueTableColumns = [
         type: FilterTypes.SELECT,
         placeholder: 'Registration Type',
         options: Object.values(ReviewRegTypes).map(status => ({
-            label: transformEnumToLabel(status),
+            label: enumToLabel(status),
             value: status
         })),
       },

--- a/ppr-ui/src/utils/format-helper.ts
+++ b/ppr-ui/src/utils/format-helper.ts
@@ -50,6 +50,14 @@ export function toTitleCase (value: string): string {
 }
 
 /**
+ * Formats enum-like strings (eg, "IN_REVIEW") into a human-friendly label ("In Review").
+ */
+export function enumToLabel (value?: string | null): string {
+  const normalized = String(value || '').replace(/_/g, ' ').trim()
+  return normalized ? multipleWordsToTitleCase(normalized, false) : ''
+}
+
+/**
  * Formats a string of multiple words to title case for display.
  * @param value the string of multiple words to format
  * @param excludeWords whether to exclude certain prepositions and conjunctions


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/30747

*Description of changes:*
1. Display readable transfer-queue status 
2. Keep the tombstone transfer status in sync on the Transfer Details page when it changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
