### PR TITLE
31866 MHR-API: Update serial number search algorithm to prioritize exact match

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.4"
+version = "2.1.5"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/search_utils.py
+++ b/mhr-api/src/mhr_api/models/search_utils.py
@@ -148,7 +148,12 @@ SELECT mhr_number, status_type, registration_ts, city, serial_number, year_made,
        manufacturer_name, civic_address
   FROM mhr_search_serial_vw
  WHERE position(:query_value in serial_number) > 0
-  ORDER BY section_id 
+  ORDER BY 
+    CASE
+        WHEN serial_number = :query_value THEN 0
+        ELSE 1
+    END,
+    section_id
 """
 SEARCH_OWNER_BUS_QUERY = """
 SELECT mhr_number, status_type, registration_ts, city, serial_number, year_made, make, model, id,

--- a/mhr-api/test_data/postgres_data_files/test0003.sql
+++ b/mhr-api/test_data/postgres_data_files/test0003.sql
@@ -109,7 +109,7 @@ INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_s
 ;
 INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
                                width_feet, width_inches, change_registration_id)
-    VALUES(200000016, 200000008, 'ACTIVE', mhr_serial_compressed_key('998765'), '998765', 60, 10, 14, 11,
+    VALUES(200000016, 200000008, 'ACTIVE', mhr_serial_compressed_key('9987'), '9987', 60, 10, 14, 11,
            200000008)
 ;
 INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31866

*Description of changes:*
- Update serial number search query with new ordering criteria
- Update test data and unit tests
- mhr-api version=2.1.5

*Overview*

From local run UI and API

<img width="2137" height="1591" alt="image" src="https://github.com/user-attachments/assets/13d18a06-18ed-4723-af3a-9e3f359f5eb3" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
