### PR TITLE
32024 Support other transfer due to death types to use CC payment

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.5"
+version = "2.1.6"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32024

_This PR includes only partial updates for the remaining ToD work, as further adjustments may be needed based on the design._

*Description of changes:*
- Update payment callback to support more transfer due to death types for QS
    - transfer to executor - grant of probate with will
    - transfer to administrator - grant of administration
    - transfer to executor - estate under 25000 with will
- mhr-api=2.1.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
