### PR TITLE
32111 - MHR API & UI: Update staff serial number search

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.7"
+version = "2.1.8"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/test_data/postgres_data_files/test0003.sql
+++ b/mhr-api/test_data/postgres_data_files/test0003.sql
@@ -38,7 +38,7 @@ INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_s
 ;
 INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
                                width_feet, width_inches, change_registration_id)
-    VALUES(200000015, 200000007, 'ACTIVE', mhr_serial_compressed_key('998765'), '998765', 60, 10, 14, 11,
+    VALUES(200000015, 200000007, 'ACTIVE', mhr_serial_compressed_key('M998765'), 'M998765', 60, 10, 14, 11,
            200000007)
 ;
 INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 
@@ -109,7 +109,7 @@ INSERT INTO mhr_descriptions(id, status_type, registration_id, csa_number, csa_s
 ;
 INSERT INTO mhr_sections(id, registration_id, status_type, compressed_key, serial_number, length_feet, length_inches,
                                width_feet, width_inches, change_registration_id)
-    VALUES(200000016, 200000008, 'ACTIVE', mhr_serial_compressed_key('9987'), '9987', 60, 10, 14, 11,
+    VALUES(200000016, 200000008, 'ACTIVE', mhr_serial_compressed_key('998765'), '998765', 60, 10, 14, 11,
            200000008)
 ;
 INSERT INTO mhr_documents(id, document_type, registration_id, document_id, document_registration_number, attention_reference, 

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/components/tables/mhr/SearchedResultsMhr.vue
+++ b/ppr-ui/src/components/tables/mhr/SearchedResultsMhr.vue
@@ -459,7 +459,7 @@
     >
       <v-col cols="8">
         <p class="no-results-title ma-0 pt-10">
-          <b>Nil Result</b>
+          <b>No Result</b>
         </p>
         <p class="ma-0 pt-2">
           No registered homes can be found to match the

--- a/ppr-ui/src/components/tables/ppr/SearchedResultsPpr.vue
+++ b/ppr-ui/src/components/tables/ppr/SearchedResultsPpr.vue
@@ -294,7 +294,7 @@
     >
       <v-col>
         <p class="no-results-title pt-10">
-          <b>Nil Result</b>
+          <b>No Result</b>
         </p>
         <p class="pt-2">
           No registered liens or encumbrances have been found on file that match EXACTLY to the

--- a/ppr-ui/tests/unit/SearchedResults.spec.ts
+++ b/ppr-ui/tests/unit/SearchedResults.spec.ts
@@ -44,7 +44,7 @@ describe('Test result table with no results', () => {
     expect(datatable.length).toBe(0)
     const noResultsInfo = wrapper.findAll(noResultsDiv)
     expect(noResultsInfo.length).toBe(1)
-    expect(noResultsInfo.at(0).text()).toContain('Nil Result')
+    expect(noResultsInfo.at(0).text()).toContain('No Result')
     expect(noResultsInfo.at(0).text()).toContain('No registered liens or encumbrances')
     expect(wrapper.findAll(generateResult).length).toBe(1)
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32111

*Description of changes:*
API
- Update staff serial number search algorithm:
  - Perform full serial number match first
  - Fallback to wildcard search only when no full match is found
  - Prioritize serial number exact match (also applies to QS)
- Update unit tests
- mhr-api=2.1.8

UI
- Update search result not found wording from "Nil Result" to "No Result"
- ppr-ui=6.0.5 (potential version conflict with Eve's work)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
