### PR TITLE
32292 MHR API - Include rejection report in email notification

### DIFF
--- a/mhr-api/migrations/versions/0006_add_summary_snapshot_into_mhr_registrations.py
+++ b/mhr-api/migrations/versions/0006_add_summary_snapshot_into_mhr_registrations.py
@@ -1,4 +1,4 @@
-"""0006_add_meta_into_mhr_registrations
+"""0006_add_summary_snapshot_into_mhr_registrations
 
 Revision ID: aed708d88460
 Revises: 793f7c153047

--- a/mhr-api/migrations/versions/0007_add_drs_id_into_mhr_review_registrations.py
+++ b/mhr-api/migrations/versions/0007_add_drs_id_into_mhr_review_registrations.py
@@ -1,0 +1,23 @@
+"""0007_add_drs_id_into_mhr_review_registrations
+
+Revision ID: 639ae66d100b
+Revises: aed708d88460
+Create Date: 2026-02-11 14:40:10.515903
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '639ae66d100b'
+down_revision = 'aed708d88460'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('mhr_review_registrations', sa.Column('drs_id', sa.String(length=20), nullable=True),)
+
+
+def downgrade():
+    op.drop_column('mhr_review_registrations', 'drs_id')

--- a/mhr-api/migrations/versions/0007_add_drs_rejection_id_into_mhr_review_registrations.py
+++ b/mhr-api/migrations/versions/0007_add_drs_rejection_id_into_mhr_review_registrations.py
@@ -1,4 +1,4 @@
-"""0007_add_drs_id_into_mhr_review_registrations
+"""0007_add_drs_rejection_id_into_mhr_review_registrations
 
 Revision ID: 639ae66d100b
 Revises: aed708d88460
@@ -16,8 +16,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('mhr_review_registrations', sa.Column('drs_id', sa.String(length=20), nullable=True),)
+    op.add_column('mhr_review_registrations', sa.Column('drs_rejection_id', sa.String(length=20), nullable=True),)
 
 
 def downgrade():
-    op.drop_column('mhr_review_registrations', 'drs_id')
+    op.drop_column('mhr_review_registrations', 'drs_rejection_id')

--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.8"
+version = "2.1.9"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/mhr_review_registration.py
+++ b/mhr-api/src/mhr_api/models/mhr_review_registration.py
@@ -58,6 +58,7 @@ class MhrReviewRegistration(db.Model):
     user_id = db.mapped_column("user_id", db.String(1000), nullable=True)
     document_id = db.mapped_column("document_id", db.String(20), nullable=True)
     priority = db.mapped_column("priority", db.Boolean, nullable=False, index=True)
+    drs_id = db.mapped_column("drs_id", db.String(20), nullable=True)
 
     # parent keys
     registration_type = db.mapped_column(

--- a/mhr-api/src/mhr_api/models/mhr_review_registration.py
+++ b/mhr-api/src/mhr_api/models/mhr_review_registration.py
@@ -58,7 +58,7 @@ class MhrReviewRegistration(db.Model):
     user_id = db.mapped_column("user_id", db.String(1000), nullable=True)
     document_id = db.mapped_column("document_id", db.String(20), nullable=True)
     priority = db.mapped_column("priority", db.Boolean, nullable=False, index=True)
-    drs_id = db.mapped_column("drs_id", db.String(20), nullable=True)
+    drs_rejection_id = db.mapped_column("drs_rejection_id", db.String(20), nullable=True)
 
     # parent keys
     registration_type = db.mapped_column(

--- a/mhr-api/src/mhr_api/resources/v1/review_registrations.py
+++ b/mhr-api/src/mhr_api/resources/v1/review_registrations.py
@@ -358,7 +358,7 @@ def get_rejection_report_link(review_reg: MhrReviewRegistration, declined_data: 
             logger.error(f"Error generating rejection report for reviewId={review_reg.id}, status code={status_code}")
             return None
         res = upload_rejection_report(raw_data, review_reg.document_id, filing_date, review_reg.id)
-        review_reg.drs_id = res.get("documentServiceId")
+        review_reg.drs_rejection_id = res.get("documentServiceId")
         review_reg.save()
         return res.get("documentURL")
     except Exception as err:

--- a/mhr-api/src/mhr_api/services/notify/__init__.py
+++ b/mhr-api/src/mhr_api/services/notify/__init__.py
@@ -74,7 +74,7 @@ class Notify:
                 )
         return res.status_code
 
-    def send_review_declined(self, reg_data: dict, reason: str, report_link: str) -> HTTPStatus:
+    def send_review_declined(self, reg_data: dict, reason: str, rejection_url: str) -> HTTPStatus:
         """Send a Staff review declined email to the registering party email address."""
         mhr_number: str = reg_data.get("mhrNumber")
         if not self.notify_review_config or not self.notify_review_config.get("bodyDecline"):
@@ -100,7 +100,7 @@ class Notify:
         subject: str = str(self.notify_review_config.get("subjectDecline")).format(mhr_number=mhr_number)
         invoice_id: str = reg_data["payment"].get("invoiceId")
         body: str = str(self.notify_review_config.get("bodyDecline")).format(
-            reg_type=doc_desc, mhr_number=mhr_number, reason=reason, invoice_id=invoice_id
+            reg_type=doc_desc, mhr_number=mhr_number, reason=reason, invoice_id=invoice_id, rejection_url=rejection_url
         )
         body = body.replace("$", "\n")
         payload = copy.deepcopy(EMAIL_DATA_TEMPLATE)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32292

*Description of changes:*
- Generate rejection report
- Call DRS API to store the report
- Update data model to add new field `mhr_review_registrations.drs_id`
- Include document link in email
- Update unit tests
- mhr-api = 2.1.9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
