### PR TITLE
MHR API get qs doc id for QS submitted documents.

### DIFF
--- a/docs/mhr-api-internal.yaml
+++ b/docs/mhr-api-internal.yaml
@@ -722,6 +722,46 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  '/mhr/api/v1/documents/qs-document-ids':
+    parameters:
+      - $ref: '#/components/parameters/accountId'
+    get:
+      tags:
+        - Registration
+      summary: Retrieve a Qualified Supplier document ID for a new staff review registration.
+      description: For MHR registrations that are submitted by qualified suppliers and reviewed by staff, retrieve a document ID to save in DRS before the registration is submitted for review. Intended to only be called once per registration, and only when the registration is submitted by a qualified supplier and will be reviewed by staff.
+      operationId: get-qs-document-id
+      responses:
+        '200':
+          description: OK
+          headers:
+            Access-Control-Allow-Origin:
+              $ref: '#/components/headers/AccessControlAllowOrigin'
+            Access-Control-Allow-Methods:
+              $ref: '#/components/headers/AccessControlAllowMethods'
+            Access-Control-Allow-Headers:
+              $ref: '#/components/headers/AccessControlAllowHeaders'
+            Access-Control-Max-Age:
+              $ref: '#/components/headers/AccessControlMaxAge'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/documentId'
+              examples:
+                /api/v1/documents/qs-document-ids/get:
+                  summary: Request a QS document ID response.
+                  value:
+                    documentId: '10109535'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   '/mhr/api/v1/documents/verify/{documentId}':
     parameters:
       - $ref: '#/components/parameters/accountId'
@@ -3155,13 +3195,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   '/mhr/api/v1/reviews/{reviewId}':
     parameters:
-      - name: reviewId
-        in: path
-        description: 'The identifier of a staff review registration.  If an invalid value is submitted then the response is a [404] status code.'
-        required: true
-        schema:
-          type: string
-        example: '123'
+      - $ref: '#/components/parameters/reviewId'
       - name: Account-Id
         in: header
         description: The account that the user is operating on behalf of.
@@ -5178,6 +5212,13 @@ components:
           csaStandard: 'Z240,'
           rebuiltRemarks: 'REBUILT AS A DOUBLE WIDE, MAKE/MODEL CUSTOM, YEAR 1995'
           otherRemarks: 'BC SAFETY AUTHORITY #339556, PERMIT# EL-721296-2018'
+    documentId:
+      type: object
+      description: The unique identifier of one or more documents that are associated with a single MH registration.
+      properties:
+        documentId:
+          type: string
+          example: '10590422'
     documentSummary:
       title: documentSummary
       type: object

--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.10"
+version = "2.1.11"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -114,6 +114,8 @@ SORT_ASCENDING = "ascending"
 SORT_DESCENDING = "descending"
 DOC_ID_QUALIFIED_CLAUSE = ",  get_mhr_doc_qualified_id() AS doc_id"
 DOC_ID_MANUFACTURER_CLAUSE = ",  get_mhr_doc_manufacturer_id() AS doc_id"
+QUERY_NEXT_QUALIFIED_DOC_ID = "select get_mhr_doc_qualified_id()"
+QUERY_NEXT_MANUFACTURER_DOC_ID = "select get_mhr_doc_manufacturer_id()"
 DOC_ID_GOV_AGENT_CLAUSE = ",  get_mhr_doc_gov_agent_id() AS doc_id"
 DOC_ID_STAFF_CLAUSE = ",  get_mhr_doc_staff_id() AS doc_id"
 BATCH_DOC_NAME_MANUFACTURER_MHREG = "batch-manufacturer-mhreg-report-{time}.pdf"
@@ -440,6 +442,16 @@ def get_change_generated_values(registration, draft, user_group: str = None, sta
     elif staff_doc_id:
         registration.doc_id = staff_doc_id
     return registration
+
+
+def get_qs_document_id(user_group: str) -> str:
+    """Get db generated qualifed supplier document ID based on the user group. Only intended for DRS integration."""
+    query: str = QUERY_NEXT_QUALIFIED_DOC_ID
+    if user_group is not None and user_group == MANUFACTURER_GROUP:
+        query = QUERY_NEXT_MANUFACTURER_DOC_ID
+    result = db.session.execute(text(query))
+    row = result.first()
+    return str(row[0])
 
 
 def get_registration_id() -> int:

--- a/mhr-api/tests/unit/models/test_registration_utils.py
+++ b/mhr-api/tests/unit/models/test_registration_utils.py
@@ -117,6 +117,12 @@ TEST_DATA_MHR_CHECK = [
     ('Invalid exists', '000900', False),
     ('Invalid too high', '999900', False)
 ]
+# testdata pattern is ({description}, {group_id}, {start_digit})
+TEST_DATA_DOC_ID = [
+    ('QS Dealer', DEALERSHIP_GROUP, '1'),
+    ('QS lawyer/notary', QUALIFIED_USER_GROUP, '1'),
+    ('QS manufacturer', MANUFACTURER_GROUP, '8')
+]
 # testdata pattern is ({account_id}, {sort_criteria}, {sort_order}, {mhr_numbers}, {expected_clause})
 TEST_QUERY_ORDER_DATA = [
     ('PS12345', None, None, "'000900'", queries.REG_ORDER_BY_DATE),
@@ -301,6 +307,14 @@ def test_validate_mhr_number(session, desc, mhr_number, valid):
     """Assert that the staff new MH MHR number check works as expected."""
     result: bool = reg_utils.validate_mhr_number(mhr_number)
     assert result == valid
+
+
+@pytest.mark.parametrize('desc, user_group, start_digit', TEST_DATA_DOC_ID)
+def test_qs_doc_id(session, desc, user_group, start_digit):
+    """Assert that the QS get next document id works as expected."""
+    result: str = reg_utils.get_qs_document_id(user_group)
+    assert result
+    assert result.startswith(start_digit)
 
 
 @pytest.mark.parametrize('account_id,sort_criteria,sort_order,mhr_numbers,expected_clause', TEST_QUERY_ORDER_DATA)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32420

*Description of changes:*
- New endpoint GET /mhr/api/v1/documents/qs-document-ids to get an MHR document ID before submitting a QS registration.
- Part of the changes to support MHR qualified supplier submission and maintenance of documents for staff review registrations.
- Enables the creation of a DRS record with a consumerDocumentId that follows the MHR sequence generation and formatting for QS registrations. 

Note: this endpoint should only be called once per registration. A subsequent gateway Doc API change will call this endpoint if a add document request is for a MHR document, submitted by a qualified supplier token, and has no consumerDocumentId parameter.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
