### PR TITLE
32163 Assets UI - Enable ToD Options for Clients

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/components/mhrTransfers/TransferType.vue
+++ b/ppr-ui/src/components/mhrTransfers/TransferType.vue
@@ -302,9 +302,9 @@ export default defineComponent({
             : StaffTransferTypesOrg
           case isRoleQualifiedSupplierLawyersNotaries.value:
             return isMiscTransfersEnabled
-              ? QualifiedSupplierTransferTypes.filter(item =>
+              ? QualifiedSupplierTransferTypes().filter(item =>
               localState.displayGroup[item.group] || item.class === 'transfer-type-list-header')
-              : QualifiedSupplierTransferTypes
+              : QualifiedSupplierTransferTypes()
           default:
             return ClientTransferTypes
         }

--- a/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
+++ b/ppr-ui/src/composables/mhrInformation/useMhrInformation.ts
@@ -379,7 +379,7 @@ export const useMhrInformation = () => {
         case isRoleStaffReg.value:
           return StaffTransferTypes
         case isRoleQualifiedSupplierLawyersNotaries.value:
-          return QualifiedSupplierTransferTypes
+          return QualifiedSupplierTransferTypes()
         default:
           return ClientTransferTypes
       }

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -461,7 +461,7 @@ const transferDueToDeathTypes: Array<TransferTypeSelectIF> = [
     disabled: true,
     divider: false,
     group: 2,
-    transferType: BlankSearchTypes.BLANK1 as any,
+    transferType: BlankSearchTypes.BLANK2 as any,
     textLabel: 'Transfer Due to Death' as any,
     color: 'primary'
   },
@@ -553,5 +553,5 @@ export const QualifiedSupplierTransferTypes = (): Array<TransferTypeSelectIF> =>
   return [
     ...ClientTransferTypes,
     ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : [])
-  ];
-};
+  ]
+}

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -1,6 +1,7 @@
 import type { TransferTypeSelectIF } from '@/interfaces'
 import { ApiTransferTypes, UITransferTypes } from '@/enums/transferTypes'
 import { BlankSearchTypes } from '@/enums'
+import { getFeatureFlag } from '@/utils'
 
 export const StaffTransferTypesOrg: Array<TransferTypeSelectIF> = [
   {
@@ -454,6 +455,77 @@ export const StaffTransferTypes: Array<TransferTypeSelectIF> = [
   }
 ]
 
+const transferDueToDeathTypes: Array<TransferTypeSelectIF> = [
+  {
+    class: 'transfer-type-list-header',
+    disabled: true,
+    divider: false,
+    group: 2,
+    transferType: BlankSearchTypes.BLANK1 as any,
+    textLabel: 'Transfer Due to Death' as any,
+    color: 'primary'
+  },
+  {
+    divider: false,
+    disabled: false,
+    transferType: ApiTransferTypes.SURVIVING_JOINT_TENANT,
+    textLabel: UITransferTypes.SURVIVING_JOINT_TENANT,
+    group: 2,
+    tooltip: {
+      title: 'Supporting Documents Required',
+      bullets: ['Ownership Transfer or Change form',
+        'Original or certified copy of death certificate issued from Canada or the United States.']
+    }
+  },
+  {
+    divider: false,
+    disabled: false,
+    transferType: ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL,
+    textLabel: UITransferTypes.TO_EXECUTOR_PROBATE_WILL,
+    group: 2,
+    tooltip: {
+      title: 'Supporting Documents Required',
+      bullets: ['Ownership Transfer or Change form',
+        'Court certified true copy of the Grant of Probate with the will attached.',
+        'Original or certified copy of death certificate issued from Canada or the United States ' +
+        'for deceased joint tenants, if any, except for the person who last died. ']
+    }
+  },
+  {
+    divider: false,
+    disabled: false,
+    transferType: ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
+    textLabel: UITransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
+    group: 2,
+    tooltip: {
+      title: 'Supporting Documents Required',
+      bullets: ['Ownership Transfer or Change form',
+        'Original signed Affidavit of Executor form',
+        'Certified true copy of will',
+        'Original or certified copy of death certificate issued from Canada or the United States.'
+      ],
+      note: 'Value of the estate must be no more than $25,000, ' +
+        'including the total value of the manufactured home.'
+    }
+  },
+  {
+    divider: false,
+    disabled: false,
+    transferType: ApiTransferTypes.TO_ADMIN_NO_WILL,
+    textLabel: UITransferTypes.TO_ADMIN_NO_WILL,
+    group: 2,
+    tooltip: {
+      title: 'Supporting Documents Required',
+      bullets: ['Ownership Transfer or Change form',
+        'Certified true copy of Grant of Administration issued by the court',
+        'Affidavit of Administration with list of Assets and Liabilities',
+        'Original or certified copy of death certificate issued from Canada or the United States ' +
+          'for deceased joint tenants, if any, except for the person who last died.'
+      ]
+    }
+  }
+]
+
 export const ClientTransferTypes: Array<TransferTypeSelectIF> = [
   {
     class: 'transfer-type-list-header',
@@ -478,45 +550,6 @@ export const ClientTransferTypes: Array<TransferTypeSelectIF> = [
 ]
 
 export const QualifiedSupplierTransferTypes: Array<TransferTypeSelectIF> = [
-  {
-    class: 'transfer-type-list-header',
-    disabled: true,
-    divider: false,
-    group: 1,
-    transferType: BlankSearchTypes.BLANK1 as any,
-    textLabel: 'Transfer' as any,
-    color: 'primary'
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.SALE_OR_GIFT,
-    textLabel: UITransferTypes.SALE_OR_GIFT,
-    group: 1,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form', 'Bill of Sale']
-    }
-  },
-  {
-    class: 'transfer-type-list-header',
-    disabled: true,
-    divider: false,
-    group: 2,
-    transferType: BlankSearchTypes.BLANK2 as any,
-    textLabel: 'Transfer Due to Death' as any,
-    color: 'primary'
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.SURVIVING_JOINT_TENANT,
-    textLabel: UITransferTypes.SURVIVING_JOINT_TENANT,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Original or certified copy of death certificate issued from Canada or the United States.']
-    }
-  }
-]
+  ...ClientTransferTypes,
+  ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : [])
+];

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -549,7 +549,9 @@ export const ClientTransferTypes: Array<TransferTypeSelectIF> = [
   }
 ]
 
-export const QualifiedSupplierTransferTypes: Array<TransferTypeSelectIF> = [
-  ...ClientTransferTypes,
-  ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : [])
-];
+export const QualifiedSupplierTransferTypes = (): Array<TransferTypeSelectIF> => {
+  return [
+    ...ClientTransferTypes,
+    ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : [])
+  ];
+};

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -3,27 +3,8 @@ import { ApiTransferTypes, UITransferTypes } from '@/enums/transferTypes'
 import { BlankSearchTypes } from '@/enums'
 import { getFeatureFlag } from '@/utils'
 
-export const StaffTransferTypesOrg: Array<TransferTypeSelectIF> = [
-  {
-    class: 'transfer-type-list-header',
-    disabled: true,
-    divider: false,
-    group: 1,
-    transferType: BlankSearchTypes.BLANK1 as any,
-    textLabel: 'Transfer' as any,
-    color: 'primary'
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.SALE_OR_GIFT,
-    textLabel: UITransferTypes.SALE_OR_GIFT,
-    group: 1,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form', 'Bill of Sale']
-    }
-  },
+
+const transferDueToDeathTypes: Array<TransferTypeSelectIF> = [
   {
     class: 'transfer-type-list-header',
     disabled: true,
@@ -92,6 +73,30 @@ export const StaffTransferTypesOrg: Array<TransferTypeSelectIF> = [
       ]
     }
   }
+]
+
+export const StaffTransferTypesOrg: Array<TransferTypeSelectIF> = [
+  {
+    class: 'transfer-type-list-header',
+    disabled: true,
+    divider: false,
+    group: 1,
+    transferType: BlankSearchTypes.BLANK1 as any,
+    textLabel: 'Transfer' as any,
+    color: 'primary'
+  },
+  {
+    divider: false,
+    disabled: false,
+    transferType: ApiTransferTypes.SALE_OR_GIFT,
+    textLabel: UITransferTypes.SALE_OR_GIFT,
+    group: 1,
+    tooltip: {
+      title: 'Supporting Documents Required',
+      bullets: ['Ownership Transfer or Change form', 'Bill of Sale']
+    }
+  },
+  ...transferDueToDeathTypes
 ]
 
 export const StaffTransferTypes: Array<TransferTypeSelectIF> = [
@@ -207,74 +212,7 @@ export const StaffTransferTypes: Array<TransferTypeSelectIF> = [
   },
 
   // Transfers Due to Death
-  {
-    class: 'transfer-type-list-header',
-    disabled: true,
-    divider: false,
-    group: 2,
-    transferType: BlankSearchTypes.BLANK2 as any,
-    textLabel: 'Transfers Due to Death' as any,
-    color: 'primary'
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.SURVIVING_JOINT_TENANT,
-    textLabel: UITransferTypes.SURVIVING_JOINT_TENANT,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Original or certified copy of death certificate issued from Canada or the United States.']
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL,
-    textLabel: UITransferTypes.TO_EXECUTOR_PROBATE_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Court certified true copy of the Grant of Probate with the will attached.',
-        'Original or certified copy of death certificate issued from Canada or the United States ' +
-        'for deceased joint tenants, if any, except for the person who last died. ']
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
-    textLabel: UITransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Original signed Affidavit of Executor form',
-        'Certified true copy of will',
-        'Original or certified copy of death certificate issued from Canada or the United States.'
-      ],
-      note: 'Value of the estate must be no more than $25,000, ' +
-        'including the total value of the manufactured home.'
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_ADMIN_NO_WILL,
-    textLabel: UITransferTypes.TO_ADMIN_NO_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Certified true copy of Grant of Administration issued by the court',
-        'Affidavit of Administration with list of Assets and Liabilities',
-        'Original or certified copy of death certificate issued from Canada or the United States ' +
-          'for deceased joint tenants, if any, except for the person who last died.'
-      ]
-    }
-  },
+  ...transferDueToDeathTypes,
 
   // Other Transfers
   {
@@ -450,77 +388,6 @@ export const StaffTransferTypes: Array<TransferTypeSelectIF> = [
         "Ownership Transfer or Change form",
         "Certified true copy of Court Order",
         "Solicitor letter, if required"
-      ]
-    }
-  }
-]
-
-const transferDueToDeathTypes: Array<TransferTypeSelectIF> = [
-  {
-    class: 'transfer-type-list-header',
-    disabled: true,
-    divider: false,
-    group: 2,
-    transferType: BlankSearchTypes.BLANK2 as any,
-    textLabel: 'Transfer Due to Death' as any,
-    color: 'primary'
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.SURVIVING_JOINT_TENANT,
-    textLabel: UITransferTypes.SURVIVING_JOINT_TENANT,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Original or certified copy of death certificate issued from Canada or the United States.']
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_EXECUTOR_PROBATE_WILL,
-    textLabel: UITransferTypes.TO_EXECUTOR_PROBATE_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Court certified true copy of the Grant of Probate with the will attached.',
-        'Original or certified copy of death certificate issued from Canada or the United States ' +
-        'for deceased joint tenants, if any, except for the person who last died. ']
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
-    textLabel: UITransferTypes.TO_EXECUTOR_UNDER_25K_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Original signed Affidavit of Executor form',
-        'Certified true copy of will',
-        'Original or certified copy of death certificate issued from Canada or the United States.'
-      ],
-      note: 'Value of the estate must be no more than $25,000, ' +
-        'including the total value of the manufactured home.'
-    }
-  },
-  {
-    divider: false,
-    disabled: false,
-    transferType: ApiTransferTypes.TO_ADMIN_NO_WILL,
-    textLabel: UITransferTypes.TO_ADMIN_NO_WILL,
-    group: 2,
-    tooltip: {
-      title: 'Supporting Documents Required',
-      bullets: ['Ownership Transfer or Change form',
-        'Certified true copy of Grant of Administration issued by the court',
-        'Affidavit of Administration with list of Assets and Liabilities',
-        'Original or certified copy of death certificate issued from Canada or the United States ' +
-          'for deceased joint tenants, if any, except for the person who last died.'
       ]
     }
   }

--- a/ppr-ui/src/utils/feature-flags.ts
+++ b/ppr-ui/src/utils/feature-flags.ts
@@ -7,6 +7,7 @@ import { initialize } from 'launchdarkly-js-client-sdk'
 export const defaultFlagSet: LDFlagSet = {
   'enable-manage-party-codes': false,
   'enable-analyst-queue': false,
+  'mhr-transfer-enable-tod': false,
   'banner-text': '' // by default, there is no banner text
 }
 /**

--- a/ppr-ui/tests/unit/MhrInformation.spec.ts
+++ b/ppr-ui/tests/unit/MhrInformation.spec.ts
@@ -170,7 +170,7 @@ describe.skip('Mhr Information', async () => {
     await store.setUserProductSubscriptionsCodes([ProductCode.LAWYERS_NOTARIES])
     await nextTick()
 
-    expect(transferTypeComponent.vm.transferTypesSelector).toStrictEqual(QualifiedSupplierTransferTypes)
+    expect(transferTypeComponent.vm.transferTypesSelector).toStrictEqual(QualifiedSupplierTransferTypes())
     // reset staff role
     await store.setAuthRoles([AuthRoles.MHR])
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/32163

*Description of changes:*
- Enable ToD options for clients in the Transfer Type Drop Down
- For the Lawyers and notaries (only - no other qs types)
- This will need to be feature flagged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
