### PR TITLE
32292-2 Fix error uploading rejection report to DRS

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.12"
+version = "2.1.13"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/resources/v1/review_registrations.py
+++ b/mhr-api/src/mhr_api/resources/v1/review_registrations.py
@@ -380,10 +380,13 @@ def upload_rejection_report(report: bytes, document_id: str, filing_date: str, r
         drs_url = current_app.config.get("DOC_SERVICE_URL")
         url = f"{drs_url}/documents/MHR/CORR"
         token = SBCPaymentClient.get_sa_token()
+        apikey: str = current_app.config.get("DOC_SERVICE_KEY")
+        account_id = current_app.config.get("DOC_SERVICE_ACCOUNT_ID")
         headers = {
+            "x-apikey": apikey,
             "Authorization": "Bearer " + token,
             "Content-Type": "application/pdf",
-            "Account-Id": "system",
+            "Account-Id": account_id,
         }
         params = {"consumerDocumentId": document_id, "consumerFilingDate": filing_date}
         res = requests.post(url=url, headers=headers, data=report, params=params, timeout=20)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32292

*Description of changes:*
- Fix error uploading rejection report to DRS - missing API key
- mhr-api=2.1.13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
