### PR TITLE
32591 enable Transfer to Surviving Joint Tenant without new FF

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "private": true,
   "appName": "Assets UI",
   "connectLayerName": "Core UI",

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -416,9 +416,11 @@ export const ClientTransferTypes: Array<TransferTypeSelectIF> = [
   }
 ]
 
+const toDTypesForLawyersAndQSNotary: Array<TransferTypeSelectIF> = transferDueToDeathTypes.slice(0, 2);
+
 export const QualifiedSupplierTransferTypes = (): Array<TransferTypeSelectIF> => {
   return [
     ...ClientTransferTypes,
-    ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : [])
+    ...(getFeatureFlag('mhr-transfer-enable-tod') ? transferDueToDeathTypes : toDTypesForLawyersAndQSNotary)
   ]
 }

--- a/ppr-ui/src/resources/transferTypes.ts
+++ b/ppr-ui/src/resources/transferTypes.ts
@@ -416,7 +416,13 @@ export const ClientTransferTypes: Array<TransferTypeSelectIF> = [
   }
 ]
 
-const toDTypesForLawyersAndQSNotary: Array<TransferTypeSelectIF> = transferDueToDeathTypes.slice(0, 2);
+const toDTypesForLawyersAndQSNotary: Array<TransferTypeSelectIF> = (() => {
+  const header = transferDueToDeathTypes[0]
+  const survivingJointTenant = transferDueToDeathTypes.find(
+    type => type.transferType === ApiTransferTypes.SURVIVING_JOINT_TENANT
+  )
+  return survivingJointTenant ? [header, survivingJointTenant] : [header]
+})()
 
 export const QualifiedSupplierTransferTypes = (): Array<TransferTypeSelectIF> => {
   return [


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/32591

*Description of changes:*
enable Transfer to Surviving Joint Tenant without new FF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
