### PR TITLE
chore: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/ppr-ui-cd.yml
+++ b/.github/workflows/ppr-ui-cd.yml
@@ -35,7 +35,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "assets-ui"
       working_directory: "./ppr-ui"
-      node_version: "22"
+      node_version: 24
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/ppr-ui-ci.yml
+++ b/.github/workflows/ppr-ui-ci.yml
@@ -19,4 +19,4 @@ jobs:
       app_name: "ppr-ui"
       working_directory: "./ppr-ui"
       codecov_flag: "pprui"
-      node_version: "22"
+      node_version: 24

--- a/ppr-ui/devops/cloudbuild-pr.yaml
+++ b/ppr-ui/devops/cloudbuild-pr.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'node:20.5.1'
+  - name: 'node:24'
     env:
       - 'VUE_APP_ADDRESS_COMPLETE_KEY=$_VUE_APP_ADDRESS_COMPLETE_KEY'
       - 'VUE_APP_PPR_LD_CLIENT_ID=$_VUE_APP_PPR_LD_CLIENT_ID'
@@ -25,7 +25,7 @@ steps:
   #
   # Generate the static site
   #
-  - name: node:20.5.1
+  - name: node:24
     dir: "ppr-ui"
     entrypoint: pnpm
     env:

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -2,6 +2,9 @@
   "name": "ppr-ui",
   "version": "6.0.9",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "appName": "Assets UI",
   "connectLayerName": "Core UI",
   "type": "module",


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835

*Description of changes:*
Update engines field in package.json to require Node.js >= 24.
Update GitHub Actions CI/CD workflows to use Node 24.
Align with modern runtime standards and ensure pipeline stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
