### PR TITLE
33289 Center dashboard inner tables when window resizing

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/ppr-ui/src/pages/Dashboard.vue
+++ b/ppr-ui/src/pages/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container
     id="dashboard"
-    class="py-12 ma-0 px-0"
+    class="py-12 my-0 px-0"
   >
     <!-- Page Overlay -->
     <v-overlay
@@ -21,7 +21,7 @@
     />
     <div
       v-if="appReady"
-      class="container pa-0"
+      class="pa-0"
     >
       <!-- Payment method messaging -->
       <CautionBox


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/33289

*Description of changes:*
Center dashboard layout:

- Replaced ma-0 with my-0 on the main container to preserve horizontal auto-centering.
- Removed the inner container class so content no longer snaps at breakpoint widths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
