### PR TITLE
MHR API QS permit location data validation.

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "mhr_api", from = "src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.14"
+python = ">=3.12,<3.13"
 flask = "^3.0.3"
 flask-sqlalchemy = "^3.1.1"
 Flask-Cors = "^4.0.1"

--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.14"
+version = "2.1.15"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "mhr_api", from = "src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.13"
+python = ">=3.12,<3.14"
 flask = "^3.0.3"
 flask-sqlalchemy = "^3.1.1"
 Flask-Cors = "^4.0.1"

--- a/mhr-api/src/mhr_api/utils/registration_validator.py
+++ b/mhr-api/src/mhr_api/utils/registration_validator.py
@@ -444,12 +444,10 @@ def validate_permit_location_address(json_data: dict, current_location: dict) ->
     addr_2 = current_location.get("address")
     # logger.debug(addr_1)
     # logger.debug(addr_2)
-    if addr_2.get("street"):
-        addr_2["street"] = str(addr_2.get("street")).upper().strip()
     if addr_2.get("city"):
         addr_2["city"] = str(addr_2.get("city")).upper().strip()
     if (
-        addr_1.get("street", "") != addr_2.get("street", "")
+        not validator_utils.validate_manufacturer_street(addr_1.get("street", ""), addr_2.get("street", ""))
         or addr_1.get("city", "") != addr_2.get("city", "")
         or addr_1.get("region", "") != addr_2.get("region", "")
         or addr_1.get("country", "") != addr_2.get("country", "")

--- a/mhr-api/src/mhr_api/utils/validator_utils.py
+++ b/mhr-api/src/mhr_api/utils/validator_utils.py
@@ -120,6 +120,102 @@ PPR_RESTRICTED_REG_TYPES = {
     MhrRegistrationTypes.TRANS: PPR_REG_TYPE_TRANSFER,
     MhrRegistrationTypes.PERMIT: PPR_REG_TYPE_PERMIT,
 }
+MANUFACTURER_STREET_ABBREVIATIONS = [
+    "RD",
+    "ROAD",
+    "ST",
+    "STREET",
+    "AVE",
+    "AVENUE",
+    "DR",
+    "DRIVE",
+    "BLVD",
+    "BOULEVARD",
+    "HWY",
+    "HIGHWAY",
+    "LN",
+    "LANE",
+    "CRT",
+    "COURT",
+    "PL",
+    "PLACE",
+    "SQ",
+    "SQUARE",
+    "CIR",
+    "CIRCLE",
+    "CRES",
+    "CRESCENT",
+    "PKWY",
+    "PARKWAY",
+    "TER",
+    "TERRACE",
+    "TRL",
+    "TRAIL",
+    "N",
+    "NORTH",
+    "NE",
+    "NORTHEAST",
+    "NW",
+    "NORTHWEST",
+    "E",
+    "EAST",
+    "S",
+    "SOUTH",
+    "SE",
+    "SOUTHEAST",
+    "SW",
+    "SOUTHWEST",
+    "W",
+    "WEST",
+]
+MANUFACTURER_STREET_ABBREVIATIONS_MAPPING = {
+    "RD": "ROAD",
+    "ROAD": "RD",
+    "ST": "STREET",
+    "STREET": "ST",
+    "AVE": "AVENUE",
+    "AVENUE": "AVE",
+    "DR": "DRIVE",
+    "DRIVE": "DR",
+    "BLVD": "BOULEVARD",
+    "BOULEVARD": "BLVD",
+    "HWY": "HIGHWAY",
+    "HIGHWAY": "HWY",
+    "LN": "LANE",
+    "LANE": "LN",
+    "CRT": "COURT",
+    "COURT": "CRT",
+    "PL": "PLACE",
+    "PLACE": "PL",
+    "SQ": "SQUARE",
+    "SQUARE": "SQ",
+    "CIR": "CIRCLE",
+    "CIRCLE": "CIR",
+    "CRES": "CRESCENT",
+    "CRESCENT": "CRES",
+    "PKWY": "PARKWAY",
+    "PARKWAY": "PKWY",
+    "TER": "TERRACE",
+    "TERRACE": "TER",
+    "TRL": "TRAIL",
+    "TRAIL": "TRL",
+    "N": "NORTH",
+    "NORTH": "N",
+    "NE": "NORTHEAST",
+    "NORTHEAST": "NE",
+    "NW": "NORTHWEST",
+    "NORTHWEST": "NW",
+    "E": "EAST",
+    "EAST": "E",
+    "S": "SOUTH",
+    "SOUTH": "S",
+    "SE": "SOUTHEAST",
+    "SOUTHEAST": "SE",
+    "SW": "SOUTHWEST",
+    "SOUTHWEST": "SW",
+    "W": "WEST",
+    "WEST": "W",
+}
 
 
 def validate_doc_id(json_data, check_exists: bool = True):
@@ -714,3 +810,47 @@ def validate_cancel_permit(registration: MhrRegistration) -> str:
     if not has_active_permit(registration):
         error_msg += CANCEL_PERMIT_INVALID
     return error_msg
+
+
+def validate_manufacturer_street(street_1: str, street_2: str) -> bool:
+    """
+    Manufacturer/dealer current home location address must match QS agreement address, allowing for some
+    common discrepancies from abreviations.
+    """
+    if street_1 == street_2:
+        return True
+    test_1: str = street_1.upper().strip().replace(".", "")
+    test_2: str = street_2.upper().strip().replace(".", "")
+    test_1 = test_1.replace(",", "")
+    test_2 = test_2.replace(",", "")
+    suffix_1: str = test_1.split(" ")[-1]
+    suffix_2: str = test_2.split(" ")[-1]
+    for suffix in MANUFACTURER_STREET_ABBREVIATIONS:
+        if suffix == suffix_1:
+            test_1 = " ".join(test_1.split(" ")[:-1])
+            if MANUFACTURER_STREET_ABBREVIATIONS_MAPPING[suffix] == suffix_2:
+                test_2 = " ".join(test_2.split(" ")[:-1])
+                break
+        if suffix == suffix_2:
+            test_2 = " ".join(test_2.split(" ")[:-1])
+            if MANUFACTURER_STREET_ABBREVIATIONS_MAPPING[suffix] == suffix_1:
+                test_1 = " ".join(test_1.split(" ")[:-1])
+                break
+    if test_1 == test_2:
+        return True
+    # Allow form and direction abbreviation comibations in any order, so check twice.
+    suffix_1 = test_1.split(" ")[-1]
+    suffix_2 = test_2.split(" ")[-1]
+    for suffix in MANUFACTURER_STREET_ABBREVIATIONS:
+        if suffix == suffix_1:
+            test_1 = " ".join(test_1.split(" ")[:-1])
+            if MANUFACTURER_STREET_ABBREVIATIONS_MAPPING[suffix] == suffix_2:
+                test_2 = " ".join(test_2.split(" ")[:-1])
+                break
+        if suffix == suffix_2:
+            test_2 = " ".join(test_2.split(" ")[:-1])
+            if MANUFACTURER_STREET_ABBREVIATIONS_MAPPING[suffix] == suffix_1:
+                test_1 = " ".join(test_1.split(" ")[:-1])
+                break
+    logger.debug(f"test1={test_1} test_2={test_2}")
+    return test_1 == test_2

--- a/mhr-api/tests/unit/utils/test_validator_utils.py
+++ b/mhr-api/tests/unit/utils/test_validator_utils.py
@@ -47,6 +47,35 @@ TEST_DESCRIPTION_DATA2 = [
     ('Invalid year missing', None, 'CHAMPION', 'DELUXE 5000', 0, False, validator_utils.DESCRIPTION_YEAR_REQUIRED),
     ('Invalid no make or model', 2020, None, None, 0, True, validator_utils.DESCRIPTION_MAKE_MODEL_REQUIRED)
 ]
+# testdata pattern is ({identical}, {street1}, {street2})
+TEST_MANUFACTURER_STREET_DATA = [
+    (True, "", ""),
+    (True, "1234 TEST ROAD", "1234 TEST ROAD"),
+    (True, "1234 TEST RD", "1234 TEST RD"),
+    (True, "1234 TEST RD", "1234 TEST RD."),
+    (True, "1234 TEST RD", "1234 TEST ROAD"),
+    (True, "1234 TEST RD.", "1234 TEST ROAD"),
+    (True, "1234 TEST", "1234 TEST ROAD"),
+    (True, "1234 TEST", "1234 TEST RD"),
+    (False, "1234 TEST RDS", "1234 TEST RD"),
+    (True, "1234 TEST ST", "1234 TEST ST."),
+    (True, "1234 TEST ST", "1234 TEST STREET"),
+    (True, "1234 TEST ST.", "1234 TEST STREET"),
+    (True, "1234 TEST", "1234 TEST STREET"),
+    (True, "1234 TEST", "1234 TEST ST"),
+    (False, "1234 TEST STR", "1234 TEST STREET"),
+    (True, "1234 TEST RD SW", "1234 TEST ROAD SOUTHWEST"),
+    (True, "1234 TEST ST N", "1234 TEST NORTH STREET"),
+    (False, "1234 TEST ST EN", "1234 TEST NORTH STREET"),
+    (False, "1234 TEST RD SWE", "1234 TEST ROAD SOUTHWEST"),
+]
+
+
+@pytest.mark.parametrize('identical,street_1,street_2', TEST_MANUFACTURER_STREET_DATA)
+def test_validate_manufacturer_street(session, identical, street_1, street_2):
+    """Assert that manufacturer location address street validation works as expected."""
+    result = validator_utils.validate_manufacturer_street(street_1, street_2)
+    assert result == identical
 
 
 @pytest.mark.parametrize('desc,rebuilt,other,csa_num,eng_date,staff,message_content', TEST_DESCRIPTION_DATA)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33624

*Description of changes:*
- Update MHR API QS transport permit data validation to allow minor discrepancies from abbreviations when verifying that the QS terms of use location address matches the current home address.
- Refer to 33624 for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
