### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/.github/workflows/ppr-ui-ci.yml
+++ b/.github/workflows/ppr-ui-ci.yml
@@ -20,3 +20,4 @@ jobs:
       working_directory: "./ppr-ui"
       codecov_flag: "pprui"
       node_version: 24
+      pnpm_version: 11.9.0

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,38 @@
+name: Test pnpm v11 upgrade
+on:
+  push:
+    branches: [feat/upgrade-pnpm-v11]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-pnpm-v11.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ppr-ui
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: ppr-ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Report pnpm version
+        run: pnpm --version

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -107,8 +107,5 @@
     "vue-router-mock": "^1.0.0",
     "vue-test-utils-helpers": "git+https://github.com/bcgov/vue-test-utils-helpers.git"
   },
-  "pnpm": {
-    "overrides": {}
-  },
   "packageManager": "pnpm@11.9.0"
 }

--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -109,5 +109,6 @@
   },
   "pnpm": {
     "overrides": {}
-  }
+  },
+  "packageManager": "pnpm@11.9.0"
 }

--- a/ppr-ui/pnpm-workspace.yaml
+++ b/ppr-ui/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages: []
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
Sets `packageManager` to `pnpm@11.9.0` in `ppr-ui/package.json` as part of the pnpm v11 upgrade (ticket #33875).

The Cloud Build CI trigger has already been updated to use `pnpm@11.9.0`.