### PR TITLE
33807 To allow the highlight for the new MHR registration in the list to fade out.

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/ppr-ui/src/components/common/RegistrationsWrapper.vue
+++ b/ppr-ui/src/components/common/RegistrationsWrapper.vue
@@ -502,11 +502,9 @@ export default defineComponent({
           addedReg: regNum,
           addedRegParent: parentRegNum,
           addedRegSummary: addReg,
-          prevDraft: '',
-          isScrollTo: true
+          prevDraft: ''
         }
         setRegTableNewItem(newRegItem)
-        await fetchMhRegistrations(getRegTableMhSortOptions.value)
       }
       localState.loading = false
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/33807

*Description of changes:*
Remove the redundant fetch of the new MHR registration:
- Allow the highlight for the new MHR registration in the list to fade out naturally.
- Preserve the highlight on the newly added MHR registration until it fades out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
