### PR TITLE
PPR API fix debtor name search: undo pg8000 change.

### DIFF
--- a/ppr-api/pyproject.toml
+++ b/ppr-api/pyproject.toml
@@ -106,7 +106,7 @@ atomic = true
 profile = "black"
 line_length = 120
 skip_gitignore = true
-skip_glob = ["migrations", "devops", "tests", "src/database/*"]
+skip_glob = ["migrations", "devops", "tests", "src/database/*", "src/ppr_api/config.py"]
 
 [tool.pylint.main]
 fail-under = 10

--- a/ppr-api/pyproject.toml
+++ b/ppr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ppr-api"
-version = "1.3.17"
+version = "1.3.18"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/ppr-api/src/ppr_api/__init__.py
+++ b/ppr-api/src/ppr_api/__init__.py
@@ -45,7 +45,10 @@ def create_app(service_environment=APP_RUNNING_ENVIRONMENT, run_mode=None, **kwa
     app = Flask(__name__)
     app.config.from_object(config[service_environment])
     app.url_map.strict_slashes = False
-    print(f'CreateApp: Using Sidecar:{app.config["CLOUD_SQL_PROXY_SIDECAR"]} DB connection: {app.config["SQLALCHEMY_DATABASE_URI"]}', file=sys.stderr)
+    print(
+        f'CreateApp: Using Sidecar:{app.config["CLOUD_SQL_PROXY_SIDECAR"]} DB connection: {app.config["SQLALCHEMY_DATABASE_URI"]}',  # noqa: E501
+        file=sys.stderr,
+    )
 
     errorhandlers.init_app(app)
 
@@ -64,7 +67,10 @@ def create_app(service_environment=APP_RUNNING_ENVIRONMENT, run_mode=None, **kwa
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     db.init_app(app)
-    print(f'INIT: Using Sidecar:{app.config["CLOUD_SQL_PROXY_SIDECAR"]} DB connection: {app.config["SQLALCHEMY_DATABASE_URI"]}', file=sys.stderr)
+    print(
+        f'INIT: Using Sidecar:{app.config["CLOUD_SQL_PROXY_SIDECAR"]} DB connection: {app.config["SQLALCHEMY_DATABASE_URI"]}',  # noqa: E501
+        file=sys.stderr,
+    )
     Migrate(app, db)
 
     with app.app_context():

--- a/ppr-api/src/ppr_api/__init__.py
+++ b/ppr-api/src/ppr_api/__init__.py
@@ -52,8 +52,9 @@ def create_app(service_environment=APP_RUNNING_ENVIRONMENT, run_mode=None, **kwa
 
     errorhandlers.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME")  \
-      and not app.config.get("CLOUD_SQL_PROXY_SIDECAR"):  # pragma: no cover
+    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME") and not app.config.get(
+        "CLOUD_SQL_PROXY_SIDECAR"
+    ):  # pragma: no cover
         from cloud_sql_connector import DBConfig
 
         db_config = DBConfig(

--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -247,7 +247,7 @@ class UnitTestingConfig(Config):  # pylint: disable=too-few-public-methods
     DB_HOST = os.getenv("DATABASE_TEST_HOST", "")
     DB_PORT = os.getenv("DATABASE_TEST_PORT", "5432")
     # SQLALCHEMY_DATABASE_URI = f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-    SQLALCHEMY_DATABASE_URI = f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
     # JWT OIDC settings
     # JWT_OIDC_TEST_MODE will set jwt_manager to use

--- a/ppr-api/src/ppr_api/config.py
+++ b/ppr-api/src/ppr_api/config.py
@@ -105,15 +105,21 @@ class Config:  # pylint: disable=too-few-public-methods
     CLOUDSQL_INSTANCE_CONNECTION_NAME = os.getenv("CLOUDSQL_INSTANCE_CONNECTION_NAME", "")
     CLOUD_SQL_PROXY_SIDECAR = bool(os.getenv("CLOUD_SQL_PROXY_SIDECAR", None) == "yes")
     DB_IP_TYPE = os.getenv("DATABASE_IP_TYPE", "private").lower()
-    
+
     if CLOUD_SQL_PROXY_SIDECAR:
         SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{DB_USER}@127.0.0.1:{DB_PORT}/{DB_NAME}"
+        print(
+            f"Tracking:SQLALCHEMY_DATABASE_URI: {SQLALCHEMY_DATABASE_URI}, CLOUD_SQL_PROXY_SIDECAR:{CLOUD_SQL_PROXY_SIDECAR}",  # noqa: E501
+            file=sys.stderr,
+        )
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        print(
+            f"Tracking:SQLALCHEMY_DATABASE_URI: {SQLALCHEMY_DATABASE_URI}, CLOUD_SQL_PROXY_SIDECAR:{CLOUD_SQL_PROXY_SIDECAR}",  # noqa: E501
+            file=sys.stderr,
+        )
     elif DB_HOST:
         SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-    
-    print(f"Tracking:SQLALCHEMY_DATABASE_URI: {SQLALCHEMY_DATABASE_URI}, CLOUD_SQL_PROXY_SIDECAR:{CLOUD_SQL_PROXY_SIDECAR}", file=sys.stderr)
 
     # Connection pool settings
     DB_MIN_POOL_SIZE = os.getenv("DATABASE_MIN_POOL_SIZE", "2")

--- a/ppr-api/src/ppr_api/models/search_historical.py
+++ b/ppr-api/src/ppr_api/models/search_historical.py
@@ -154,7 +154,7 @@ WITH q AS (
    AND p.party_type = 'DB'
    AND p.bus_name_base = search_name_base
    AND p.bus_name_key_char1 = search_key_char1
-    AND ((search_key <%% p.business_srch_key AND
+    AND ((search_key <% p.business_srch_key AND
           SIMILARITY(search_key, p.business_srch_key) >= :query_bus_quotient)
           OR p.business_srch_key = search_key
           OR word_length=1 and search_key = split_part(business_name,' ',1)

--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -213,14 +213,8 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         search_value = self.request_json["criteria"]["debtorName"]["business"]
         rows = None
         try:
-            query: str = search_utils.BUSINESS_NAME_QUERY
-            # pg8000 trigram word similarity operator workaround
-            if current_app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME") and not current_app.config.get(
-                "CLOUD_SQL_PROXY_SIDECAR"
-            ):
-                query = query.replace(" <% ", " <%% ")
             result = db.session.execute(
-                text(query),
+                text(search_utils.BUSINESS_NAME_QUERY),
                 {
                     "query_bus_name": search_value.strip().upper(),
                     "query_bus_quotient": current_app.config.get("SIMILARITY_QUOTIENT_BUSINESS_NAME"),

--- a/ppr-api/src/ppr_api/models/search_request.py
+++ b/ppr-api/src/ppr_api/models/search_request.py
@@ -213,8 +213,14 @@ class SearchRequest(db.Model):  # pylint: disable=too-many-instance-attributes
         search_value = self.request_json["criteria"]["debtorName"]["business"]
         rows = None
         try:
+            query: str = search_utils.BUSINESS_NAME_QUERY
+            # pg8000 trigram word similarity operator workaround
+            if current_app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME") and not current_app.config.get(
+                "CLOUD_SQL_PROXY_SIDECAR"
+            ):
+                query = query.replace(" <% ", " <%% ")
             result = db.session.execute(
-                text(search_utils.BUSINESS_NAME_QUERY),
+                text(query),
                 {
                     "query_bus_name": search_value.strip().upper(),
                     "query_bus_quotient": current_app.config.get("SIMILARITY_QUOTIENT_BUSINESS_NAME"),

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -193,7 +193,7 @@ WHERE r.financing_id = fs.id
    AND p.registration_id_end IS NULL
    AND p.party_type = 'DB'
    AND p.bus_name_key_char1 = search_key_char1
-    AND ((search_key <%% p.business_srch_key AND
+    AND ((search_key <% p.business_srch_key AND
           SIMILARITY(search_key, p.business_srch_key) >= :query_bus_quotient)
           OR p.business_srch_key = search_key
           OR word_length=1 and search_key = split_part(business_name,' ',1)

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -193,7 +193,7 @@ WHERE r.financing_id = fs.id
    AND p.registration_id_end IS NULL
    AND p.party_type = 'DB'
    AND p.bus_name_key_char1 = search_key_char1
-    AND ((search_key <% p.business_srch_key AND
+   AND ((search_key::text <% p.business_srch_key::text AND
           SIMILARITY(search_key, p.business_srch_key) >= :query_bus_quotient)
           OR p.business_srch_key = search_key
           OR word_length=1 and search_key = split_part(business_name,' ',1)

--- a/ppr-api/src/ppr_api/models/search_utils.py
+++ b/ppr-api/src/ppr_api/models/search_utils.py
@@ -193,7 +193,7 @@ WHERE r.financing_id = fs.id
    AND p.registration_id_end IS NULL
    AND p.party_type = 'DB'
    AND p.bus_name_key_char1 = search_key_char1
-   AND ((search_key::text <% p.business_srch_key::text AND
+   AND ((search_key <% p.business_srch_key AND
           SIMILARITY(search_key, p.business_srch_key) >= :query_bus_quotient)
           OR p.business_srch_key = search_key
           OR word_length=1 and search_key = split_part(business_name,' ',1)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33944

*Description of changes:*
- Undo recent business debtor name search query change made as part of the db drvier pg8000 update - we have switched back to using the native postgres driver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
