### PR TITLE
fix: Update cd_runner_version to 1.2.1

### DIFF
--- a/.github/workflows/ppr-api-cd.yml
+++ b/.github/workflows/ppr-api-cd.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       target: ${{ inputs.target }}
       app_name: "ppr-api"
-      cd_runner_version: "1.0.8"
+      cd_runner_version: "1.2.1"
       working_directory: "./ppr-api"
       redeploy: ${{ inputs.redeploy }}
     secrets:


### PR DESCRIPTION
Update CD runner to use sidecar from bcgov/entity#33672

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
