### PR TITLE
32721 mhr search cau notes

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.16"
+version = "2.1.17"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/src/mhr_api/models/registration_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_utils.py
@@ -499,7 +499,7 @@ def include_caution_note(notes, document_id: str) -> bool:
             break
         if latest_caution and note.get("documentType", "") not in ("CAUC", "CAUE", "CAU "):
             return False
-    return latest_caution and not model_utils.date_elapsed(latest_caution.get("expiryDate"))
+    return latest_caution and not model_utils.date_elapsed(latest_caution.get("expiryDateTime"))
 
 
 def get_batch_manufacturer_reg_report_data(start_ts: str = None, end_ts: str = None) -> dict:

--- a/mhr-api/src/mhr_api/reports/v2/report_utils.py
+++ b/mhr-api/src/mhr_api/reports/v2/report_utils.py
@@ -635,7 +635,8 @@ def get_reg_signature_version(registration_ts: str) -> str:
         logger.info(f"reg_ts={registration_ts} reg_date={reg_date} version={reg_version}")
         return reg_version
     for version in REG_SIG_VERSIONS:
-        if reg_date >= version.get("start") and reg_date <= version.get("end"):
+        # if reg_date >= version.get("start") and reg_date <= version.get("end"):
+        if version.get("start") <= reg_date <= version.get("end"):
             reg_version = version.get("version")
             break
     logger.debug(f"reg_ts={registration_ts} reg_date={reg_date} version={reg_version}")

--- a/mhr-api/tests/unit/models/test_registration_utils.py
+++ b/mhr-api/tests/unit/models/test_registration_utils.py
@@ -71,6 +71,14 @@ OWNER_IND7 = {'individualName': {'first': 'FIRST','middle': 'M.','last': 'DIFF'}
 OWNER_ORG1 = {'organizationName': 'ORG NAME'}
 OWNER_ORG2 = {'organizationName': 'Org Name'}
 OWNER_ORG3 = {'organizationName': 'ORG NAME DIFF'}
+SEARCH_CAUTION_NOTES = [
+    {
+        "documentId": "12343434",
+        "documentType": "CAUC",
+        "status": "ACTIVE",
+        "expiryDateTime": "2024-04-28T06:59:59+00:00"
+    }
+]
 # testdata pattern is ({same}, {owner1}, {owner2})
 TEST_DATA_OWNER_NAME = [
     ('1', True, OWNER_IND1, OWNER_IND1),
@@ -205,6 +213,36 @@ TEST_DATA_ID_GENERATION = [
     (STAFF_ROLE, False, '1'),
     (STAFF_ROLE, True, '7'),
 ]
+# testdata pattern is ({has_note}, {doc_type}, {expiry_ts})
+TEST_DATA_SEARCH_NOTES_CAUTION = [
+    (True, "CAU", None),
+    (True, "CAUC", None),
+    (True, "CAUE", None),
+    (True, "CAU", "2099-04-28T06:59:59+00:00"),
+    (True, "CAUC", "2099-04-28T06:59:59+00:00"),
+    (True, "CAUE", "2099-04-28T06:59:59+00:00"),
+    (False, "CAU", "2026-04-28T06:59:59+00:00"),
+    (False, "CAUC", "2026-04-28T06:59:59+00:00"),
+    (False, "CAUE", "2026-04-28T06:59:59+00:00"),
+]
+
+
+@pytest.mark.parametrize('has_note,doc_type,expiry_ts', TEST_DATA_SEARCH_NOTES_CAUTION)
+def test_search_notes_caution(session, has_note, doc_type, expiry_ts):
+    """Assert that owner name test is_identical_owner_name works as expected."""
+    search_notes = copy.deepcopy(SEARCH_CAUTION_NOTES)
+    note = search_notes[0]
+    note["documentType"] = doc_type
+    if expiry_ts:
+        note["expiryDateTime"] = expiry_ts
+    else:
+        del note["expiryDateTime"]
+    result = reg_json_utils.update_notes_search_json(search_notes, True)
+    if has_note:
+        assert result
+        assert len(result) == 1
+    else:
+        assert not result
 
 
 @pytest.mark.parametrize('desc,same,owner1,owner2', TEST_DATA_OWNER_NAME)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32721

*Description of changes:*
- Search reports do not included expired caution notes for staff and QS.
- Minor lint fix for report utils. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
