### PR TITLE
MHR API extend transport permit do not change home status.

### DIFF
--- a/mhr-api/src/mhr_api/models/registration_change_utils.py
+++ b/mhr-api/src/mhr_api/models/registration_change_utils.py
@@ -18,7 +18,13 @@
 from mhr_api.models import MhrLocation
 from mhr_api.models import utils as model_utils
 from mhr_api.models.db import db
-from mhr_api.models.type_tables import MhrDocumentTypes, MhrNoteStatusTypes, MhrRegistrationStatusTypes, MhrStatusTypes
+from mhr_api.models.type_tables import (
+    MhrDocumentTypes,
+    MhrNoteStatusTypes,
+    MhrRegistrationStatusTypes,
+    MhrRegistrationTypes,
+    MhrStatusTypes,
+)
 from mhr_api.utils.logging import logger
 
 
@@ -94,8 +100,10 @@ def save_permit(registration, json_data, new_reg_id):
         logger.info("Amend Transport Permit new location in BC, updating EXEMPT status to ACTIVE.")
     elif (
         json_data
+        and not json_data.get("extension")  # Skip for extensions: location does not change.
         and json_data["newLocation"]["address"]["region"] != model_utils.PROVINCE_BC
         and json_data.get("documentType", "") != MhrDocumentTypes.CANCEL_PERMIT
+        and json_data.get("registrationType", "") != MhrRegistrationTypes.PERMIT_EXTENSION
     ):
         registration.status_type = MhrRegistrationStatusTypes.EXEMPT
         logger.info("Transport Permit new location out of province, updating status to EXEMPT.")

--- a/mhr-api/tests/unit/api/test_permits.py
+++ b/mhr-api/tests/unit/api/test_permits.py
@@ -141,7 +141,8 @@ TEST_AMEND_DATA = [
 # testdata pattern is ({description}, {mhr_num}, {roles}, {status}, {account}, {ownland})
 TEST_EXTEND_DATA = [
     ('Valid staff', '000931', STAFF_ROLES, HTTPStatus.CREATED, 'PS12345', True),
-    ('Valid non-staff ', '000931', QUALIFIED_USER_ROLES, HTTPStatus.CREATED, 'PS12345', False)
+    ('Valid non-staff ', '000931', QUALIFIED_USER_ROLES, HTTPStatus.CREATED, 'PS12345', False),
+    ('Valid non-BC request location', '000931', STAFF_ROLES, HTTPStatus.CREATED, 'PS12345', True),
 ]
 
 
@@ -272,6 +273,8 @@ def test_extend(session, client, jwt, desc, mhr_num, roles, status, account, own
     json_data['mhrNumber'] = mhr_num
     json_data['newLocation'] = LOCATION_OTHER
     json_data['extension'] = True
+    if desc == "Valid non-BC request location":
+        json_data["newLocation"]["address"]["region"] = "AB"
     if account:
         headers = create_header_account(jwt, roles, 'UT-TEST', account)
     else:
@@ -307,6 +310,7 @@ def test_extend(session, client, jwt, desc, mhr_num, roles, status, account, own
         registration.current_view = True
         reg_json = registration.new_registration_json
         assert 'ownLand' in reg_json
+        assert reg_json.get("status") == "ACTIVE"
 
 
 def get_valid_tax_cert_dt() -> str:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33192

*Description of changes:*
- Bug fix for extend transport permit setting the home status to EXEMPT when the submitted location address is outside of BC. Do not change the home status for extend transport permit registrations where the home location does not change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
