### PR TITLE
30894 normalize MHR transfer assignee name

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/ppr-ui/src/components/queue/ReviewDecision.vue
+++ b/ppr-ui/src/components/queue/ReviewDecision.vue
@@ -16,18 +16,28 @@ const resetValidationErrors = () => {
 
 const isDeclined = computed(() => reviewDecision.value.statusType === ReviewStatusTypes.DECLINED)
 
-const currentUserDisplayName = computed(() => {
-  return `${appStore.getUserFirstName} ${appStore.getUserLastName}`.trim()
-})
+const normalizeName = (name?: string) => {
+  return (name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+}
+
+const normalizeAssigneeName = (name?: string) => {
+  if (!name || !name.includes(',')) return normalizeName(name)
+
+  const [lastName, firstName] = name.split(',')
+  return normalizeName(`${firstName} ${lastName}`)
+}
 
 const isCurrentUserAssignee = computed(() => {
-  const assignee = queueTransfer.value?.assigneeName?.trim().toLowerCase()
+  const assignee = normalizeAssigneeName(queueTransfer.value?.assigneeName)
   if (!assignee) return false
 
-  const username = appStore.getUserUsername?.trim().toLowerCase()
-  const displayName = currentUserDisplayName.value?.toLowerCase()
+  const currentUserDisplayName = `${appStore.getUserFirstName} ${appStore.getUserLastName}`
+  const displayName = normalizeName(currentUserDisplayName)
 
-  return assignee === username || (!!displayName && assignee === displayName)
+  return assignee === displayName
 })
 
 const isDecisionEnabled = computed(() => {

--- a/ppr-ui/tests/unit/ReviewDecision.spec.ts
+++ b/ppr-ui/tests/unit/ReviewDecision.spec.ts
@@ -6,6 +6,8 @@ import ReviewDecision from '../../src/components/queue/ReviewDecision.vue'
 import { ReviewStatusTypes } from '@/composables'
 import { createComponent, setupMockStaffUser } from './utils'
 
+const ASSIGN_ERROR = 'Please assign this filing to yourself to approve or decline.'
+
 describe('ReviewDecision', () => {
   let pinia
   let store
@@ -22,7 +24,6 @@ describe('ReviewDecision', () => {
     await store.setUserInfo({
       firstname: 'Test',
       lastname: 'User',
-      username: 'user'
     } as any)
     setupMockStaffUser(store)
 
@@ -44,21 +45,19 @@ describe('ReviewDecision', () => {
     await approveButton!.trigger('click')
     await nextTick()
 
-    expect(analystQueueStore.validationErrors.general).toBe(
-      'Please assign this filing to yourself to approve or decline.'
-    )
-    expect(wrapper.text()).toContain('Please assign this filing to yourself to approve or decline.')
+    expect(analystQueueStore.validationErrors.general).toBe(ASSIGN_ERROR)
+    expect(wrapper.text()).toContain(ASSIGN_ERROR)
   })
 
-  it('resets the review decision when the assignee changes to the current user', async () => {
+  it('resets the review decision when the assignee changes to the current user (FirstName LastName)', async () => {
     analystQueueStore.reviewDecision = {
       statusType: ReviewStatusTypes.DECLINED,
       declinedReasonType: 'NON_COMPLIANCE'
     } as any
-    analystQueueStore.validationErrors.general = 'Please assign this filing to yourself to approve or decline.'
+    analystQueueStore.validationErrors.general = ASSIGN_ERROR
     analystQueueStore.validationErrors.declineReasonType = 'Please select a reason for declining'
 
-    analystQueueStore.queueTransfer.assigneeName = 'user'
+    analystQueueStore.queueTransfer.assigneeName = 'Test User'
     await nextTick()
 
     expect(analystQueueStore.validationErrors.general).toBe('')
@@ -67,4 +66,23 @@ describe('ReviewDecision', () => {
     expect(analystQueueStore.reviewDecision.declinedReasonType).toBeUndefined()
     expect(wrapper.exists()).toBe(true)
   })
+
+  it('resets the review decision when the assignee changes to the current user (LastName, FirstName)', async () => {
+    analystQueueStore.reviewDecision = {
+      statusType: ReviewStatusTypes.DECLINED,
+      declinedReasonType: 'NON_COMPLIANCE'
+    } as any
+    analystQueueStore.validationErrors.general = ASSIGN_ERROR
+    analystQueueStore.validationErrors.declineReasonType = 'Please select a reason for declining'
+
+    analystQueueStore.queueTransfer.assigneeName = 'User, Test'
+    await nextTick()
+
+    expect(analystQueueStore.validationErrors.general).toBe('')
+    expect(analystQueueStore.validationErrors.declineReasonType).toBe('')
+    expect(analystQueueStore.reviewDecision.statusType).toBeUndefined()
+    expect(analystQueueStore.reviewDecision.declinedReasonType).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+  })
+
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
The assignee name could be either 'FirstName LastName' or 'LastName, FirstName' in the db. Normalize the assignee name before comparing to the username.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
