### PR TITLE
30894 Use the Keycloak name to determine whether the user is the assignee.

### DIFF
--- a/ppr-ui/package.json
+++ b/ppr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppr-ui",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/ppr-ui/src/components/queue/ReviewDecision.vue
+++ b/ppr-ui/src/components/queue/ReviewDecision.vue
@@ -5,6 +5,7 @@ import { ReviewDecisionTypes, ReviewStatusTypes } from '@/composables';
 import { storeToRefs } from 'pinia';
 import { useAnalystQueueStore } from '@/store/analystQueue';
 import { useStore } from '@/store/store'
+import { getKeycloakName } from '@/utils/auth-helper'
 
 const { reviewDecision, validationErrors, isInReview, queueTransfer, reviewId } = storeToRefs(useAnalystQueueStore())
 const appStore = useStore() as any
@@ -16,28 +17,12 @@ const resetValidationErrors = () => {
 
 const isDeclined = computed(() => reviewDecision.value.statusType === ReviewStatusTypes.DECLINED)
 
-const normalizeName = (name?: string) => {
-  return (name || '')
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-}
-
-const normalizeAssigneeName = (name?: string) => {
-  if (!name || !name.includes(',')) return normalizeName(name)
-
-  const [lastName, firstName] = name.split(',')
-  return normalizeName(`${firstName} ${lastName}`)
-}
-
 const isCurrentUserAssignee = computed(() => {
-  const assignee = normalizeAssigneeName(queueTransfer.value?.assigneeName)
+  const assignee = queueTransfer.value?.assigneeName
   if (!assignee) return false
 
-  const currentUserDisplayName = `${appStore.getUserFirstName} ${appStore.getUserLastName}`
-  const displayName = normalizeName(currentUserDisplayName)
-
-  return assignee === displayName
+  const tokenName = getKeycloakName()
+  return assignee === tokenName
 })
 
 const isDecisionEnabled = computed(() => {

--- a/ppr-ui/src/utils/auth-helper.ts
+++ b/ppr-ui/src/utils/auth-helper.ts
@@ -58,6 +58,12 @@ export function getKeycloakRoles (): Array<string> {
   throw new Error('Error getting Keycloak roles')
 }
 
+/** Gets display name from Keycloak JWT name claim. */
+export function getKeycloakName (): string {
+  const jwt = getJWT()
+  return jwt?.name || ''
+}
+
 export async function getStaffRegisteringParty (isBcOnline: boolean): Promise<PartyIF> {
   let partyCode = sessionStorage.getItem('PPR_STAFF_PARTY_CODE')
   if (isBcOnline) {

--- a/ppr-ui/tests/unit/ReviewDecision.spec.ts
+++ b/ppr-ui/tests/unit/ReviewDecision.spec.ts
@@ -5,6 +5,12 @@ import { useAnalystQueueStore } from '@/store/analystQueue'
 import ReviewDecision from '../../src/components/queue/ReviewDecision.vue'
 import { ReviewStatusTypes } from '@/composables'
 import { createComponent, setupMockStaffUser } from './utils'
+import { vi } from 'vitest'
+import { getKeycloakName } from '@/utils/auth-helper'
+
+vi.mock('@/utils/auth-helper', () => ({
+  getKeycloakName: vi.fn()
+}))
 
 const ASSIGN_ERROR = 'Please assign this filing to yourself to approve or decline.'
 
@@ -25,6 +31,7 @@ describe('ReviewDecision', () => {
       firstname: 'Test',
       lastname: 'User',
     } as any)
+    vi.mocked(getKeycloakName).mockReturnValue('Test User')
     setupMockStaffUser(store)
 
     analystQueueStore.queueTransfer = {
@@ -49,7 +56,7 @@ describe('ReviewDecision', () => {
     expect(wrapper.text()).toContain(ASSIGN_ERROR)
   })
 
-  it('resets the review decision when the assignee changes to the current user (FirstName LastName)', async () => {
+  it('resets the review decision when the assignee changes to the current user token name', async () => {
     analystQueueStore.reviewDecision = {
       statusType: ReviewStatusTypes.DECLINED,
       declinedReasonType: 'NON_COMPLIANCE'
@@ -58,24 +65,6 @@ describe('ReviewDecision', () => {
     analystQueueStore.validationErrors.declineReasonType = 'Please select a reason for declining'
 
     analystQueueStore.queueTransfer.assigneeName = 'Test User'
-    await nextTick()
-
-    expect(analystQueueStore.validationErrors.general).toBe('')
-    expect(analystQueueStore.validationErrors.declineReasonType).toBe('')
-    expect(analystQueueStore.reviewDecision.statusType).toBeUndefined()
-    expect(analystQueueStore.reviewDecision.declinedReasonType).toBeUndefined()
-    expect(wrapper.exists()).toBe(true)
-  })
-
-  it('resets the review decision when the assignee changes to the current user (LastName, FirstName)', async () => {
-    analystQueueStore.reviewDecision = {
-      statusType: ReviewStatusTypes.DECLINED,
-      declinedReasonType: 'NON_COMPLIANCE'
-    } as any
-    analystQueueStore.validationErrors.general = ASSIGN_ERROR
-    analystQueueStore.validationErrors.declineReasonType = 'Please select a reason for declining'
-
-    analystQueueStore.queueTransfer.assigneeName = 'User, Test'
     await nextTick()
 
     expect(analystQueueStore.validationErrors.general).toBe('')


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/30894

*Description of changes:*
Use the Keycloak name to determine whether the user is the assignee.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
