### PR TITLE
MHR API use QS account name for QS registration outputs.

### DIFF
--- a/mhr-api/pyproject.toml
+++ b/mhr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mhr-api"
-version = "2.1.17"
+version = "2.1.18"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/mhr-api/report-templates/template-parts/registration/submittingParty.html
+++ b/mhr-api/report-templates/template-parts/registration/submittingParty.html
@@ -58,6 +58,8 @@
         <span class="section-data pl-1">
             {% if meta_account_id == 'ppr_staff' %}
                 BC REGISTRIES STAFF
+            {% elif meta_account_name is defined and meta_account_name != '' %} 
+                {{ meta_account_name }}
             {% elif affirmByName is defined and affirmByName != '' %} 
                 {{ affirmByName }}
             {% else %}

--- a/mhr-api/src/mhr_api/reports/v2/report.py
+++ b/mhr-api/src/mhr_api/reports/v2/report.py
@@ -26,6 +26,7 @@ from mhr_api.models.type_tables import MhrDocumentTypes, MhrRegistrationTypes, M
 from mhr_api.reports import ppr_report_utils
 from mhr_api.reports.v2 import report_utils
 from mhr_api.reports.v2.report_utils import ReportTypes
+from mhr_api.services.authz import STAFF_ROLE
 from mhr_api.services.gcp_auth.auth_service import GoogleAuthService
 from mhr_api.utils.logging import logger
 
@@ -926,8 +927,9 @@ class Report:  # pylint: disable=too-few-public-methods
         self._report_data["meta_account_id"] = self._account_id
         if self._account_name:
             self._report_data["meta_account_name"] = self._account_name
+        elif self._account_id != STAFF_ROLE:
+            self._report_data["meta_account_name"] = report_utils.get_qs_account_name(self._account_id)
 
-        # Get source ???
         # Appears in the Description section of the PDF Document Properties as Title.
         self._report_data["meta_title"] = ReportMeta.reports[self._report_key]["metaTitle"].upper()
         self._report_data["meta_subtitle"] = ReportMeta.reports[self._report_key]["metaSubtitle"]

--- a/mhr-api/src/mhr_api/reports/v2/report_utils.py
+++ b/mhr-api/src/mhr_api/reports/v2/report_utils.py
@@ -18,6 +18,7 @@ import PyPDF2
 from flask import current_app
 from jinja2 import Template
 
+from mhr_api.models import MhrManufacturer, MhrQualifiedSupplier
 from mhr_api.models.type_tables import MhrDocumentTypes
 from mhr_api.utils.base import BaseEnum
 from mhr_api.utils.logging import logger
@@ -641,3 +642,12 @@ def get_reg_signature_version(registration_ts: str) -> str:
             break
     logger.debug(f"reg_ts={registration_ts} reg_date={reg_date} version={reg_version}")
     return reg_version
+
+
+def get_qs_account_name(account_id: str) -> str:
+    """Get the qualified supplier account name from the registration account id."""
+    supplier: MhrQualifiedSupplier = MhrQualifiedSupplier.find_by_account_id(account_id)
+    if supplier:
+        return supplier.business_name
+    manufacturer: MhrManufacturer = MhrManufacturer.find_by_account_id(account_id)
+    return manufacturer.manufacturer_name if manufacturer else ""

--- a/mhr-api/tests/unit/reports/v2/test_report_utils.py
+++ b/mhr-api/tests/unit/reports/v2/test_report_utils.py
@@ -35,13 +35,24 @@ TEST_REG_VERSION_DATA = [
     ('2012-06-01T20:11:53+00:00', '2'),
     ('2012-05-31T20:11:53+00:00', '1'),
 ]
-
+# test data pattern is ({account_id}, {account_name})
+TEST_QS_ACCOUNT_NAME_DATA = [
+    ("PS12345", "TEST NOTARY PUBLIC"),
+    ("JUNK", ""),
+]
 
 @pytest.mark.parametrize('reg_ts,version', TEST_REG_VERSION_DATA)
 def test_reg_sig_version(session, reg_ts, version):
     """Assert that deriving a registrar's signature from a regisration timestamp works as expected."""
     test_version = report_utils.get_reg_signature_version(reg_ts)
     assert test_version == version
+
+
+@pytest.mark.parametrize('account_id,account_name', TEST_QS_ACCOUNT_NAME_DATA)
+def test_qs_account_name(session, account_id, account_name):
+    """Assert that obtaining a verification report account name from a regisration account id works as expected."""
+    test_name = report_utils.get_qs_account_name(account_id)
+    assert test_name == account_name
 
 
 def test_get_header_data(session):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34340

*Description of changes:*
For new registrations submitted by qualified suppliers, user the QS service agreement account name from auth as the affirm by name in all registration reports.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
