### PR TITLE
fix: add @tailwindcss/oxide to ppr-ui allowBuilds

### DIFF
--- a/ppr-ui/pnpm-workspace.yaml
+++ b/ppr-ui/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages: []
 allowBuilds:
   '@parcel/watcher': true
+  '@tailwindcss/oxide': true
   esbuild: true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary
`ppr-ui/pnpm-workspace.yaml`'s `allowBuilds` was missing `@tailwindcss/oxide`, present in the lockfile with a native install script. Under pnpm v11, this would be silently blocked (`ERR_PNPM_IGNORED_BUILDS`) once the deploy pipeline actually runs the correct pnpm version (see bcgov/bcregistry-sre#377/#378/#379, which fix the deploy pipeline to actually run 11.9.0 instead of a stale version) -- this repo's own PR-time CI never surfaces it since the shared CI workflow installs with `--ignore-scripts`.

## Test plan
- [ ] Trigger a `dev`-target redeploy once merged and confirm no `ERR_PNPM_IGNORED_BUILDS` in the build log